### PR TITLE
Add dashboard filters and search triage views

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ claudectl                   # Interactive TUI dashboard
 claudectl --watch           # Stream status changes (no TUI)
 claudectl --list            # Print session table and exit
 claudectl --json            # Machine-readable output for scripting
+claudectl --filter-status needs-input --search api
+claudectl --watch --focus attention
 ```
 
 ### Control spend
@@ -181,6 +183,7 @@ claudectl --demo --record demo.gif  # One-command GIF for your README
 - Detail panel (`Enter`) with full session metadata
 - Grouped view (`g`) by project with aggregate stats
 - Sort by status, context, cost, burn rate, or elapsed (`s`)
+- Live triage filters: status cycle (`f`), focus cycle (`v`), text search (`/`), clear (`z`)
 - Conflict detection when 2+ sessions share the same git worktree (`!!`)
 - Permission wait time — shows how long sessions have been waiting, longest first
 
@@ -218,6 +221,10 @@ Multi-signal inference from CPU usage, JSONL events, and timestamps:
 | `n` | Launch new Claude session (`tmux`, Kitty, WezTerm) |
 | `g` | Toggle grouped view by project |
 | `s` | Cycle sort column |
+| `f` | Cycle status filter |
+| `v` | Cycle focus filter (`attention`, budget, context, telemetry, conflicts) |
+| `/` | Search project/model/session text |
+| `z` | Clear all active filters |
 | `c` | Send /compact to session (when idle) |
 | `R` | Record session highlight reel (toggle) |
 | `r` | Force refresh |

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,6 +13,114 @@ use crate::theme::Theme;
 
 pub const SORT_COLUMNS: &[&str] = &["Status", "Context", "Cost", "$/hr", "Elapsed"];
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusFilter {
+    All,
+    NeedsInput,
+    Processing,
+    WaitingInput,
+    Unknown,
+    Idle,
+    Finished,
+}
+
+impl StatusFilter {
+    pub fn next(self) -> Self {
+        match self {
+            Self::All => Self::NeedsInput,
+            Self::NeedsInput => Self::Processing,
+            Self::Processing => Self::WaitingInput,
+            Self::WaitingInput => Self::Unknown,
+            Self::Unknown => Self::Idle,
+            Self::Idle => Self::Finished,
+            Self::Finished => Self::All,
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "all" => Some(Self::All),
+            "needsinput" | "needs-input" => Some(Self::NeedsInput),
+            "processing" => Some(Self::Processing),
+            "waiting" | "waitinginput" | "waiting-input" => Some(Self::WaitingInput),
+            "unknown" => Some(Self::Unknown),
+            "idle" => Some(Self::Idle),
+            "finished" => Some(Self::Finished),
+            _ => None,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::All => "All",
+            Self::NeedsInput => "Needs Input",
+            Self::Processing => "Processing",
+            Self::WaitingInput => "Waiting",
+            Self::Unknown => "Unknown",
+            Self::Idle => "Idle",
+            Self::Finished => "Finished",
+        }
+    }
+
+    fn matches(self, status: SessionStatus) -> bool {
+        match self {
+            Self::All => true,
+            Self::NeedsInput => status == SessionStatus::NeedsInput,
+            Self::Processing => status == SessionStatus::Processing,
+            Self::WaitingInput => status == SessionStatus::WaitingInput,
+            Self::Unknown => status == SessionStatus::Unknown,
+            Self::Idle => status == SessionStatus::Idle,
+            Self::Finished => status == SessionStatus::Finished,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FocusFilter {
+    All,
+    Attention,
+    OverBudget,
+    HighContext,
+    UnknownTelemetry,
+    Conflict,
+}
+
+impl FocusFilter {
+    pub fn next(self) -> Self {
+        match self {
+            Self::All => Self::Attention,
+            Self::Attention => Self::OverBudget,
+            Self::OverBudget => Self::HighContext,
+            Self::HighContext => Self::UnknownTelemetry,
+            Self::UnknownTelemetry => Self::Conflict,
+            Self::Conflict => Self::All,
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "all" => Some(Self::All),
+            "attention" => Some(Self::Attention),
+            "overbudget" | "over-budget" => Some(Self::OverBudget),
+            "highcontext" | "high-context" => Some(Self::HighContext),
+            "unknowntelemetry" | "unknown-telemetry" => Some(Self::UnknownTelemetry),
+            "conflict" | "conflicts" => Some(Self::Conflict),
+            _ => None,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::All => "All",
+            Self::Attention => "Attention",
+            Self::OverBudget => "Over Budget",
+            Self::HighContext => "High Context",
+            Self::UnknownTelemetry => "Unknown Telemetry",
+            Self::Conflict => "Conflict",
+        }
+    }
+}
+
 pub struct App {
     pub sessions: Vec<ClaudeSession>,
     pub table_state: TableState,
@@ -37,6 +145,11 @@ pub struct App {
     pub webhook_filter: Option<Vec<String>>, // Only fire on these status names
     pub launch_mode: bool,                   // Capturing directory path for new session
     pub launch_buffer: String,
+    pub search_mode: bool,
+    pub search_buffer: String,
+    pub search_query: String,
+    pub status_filter: StatusFilter,
+    pub focus_filter: FocusFilter,
     pub budget_usd: Option<f64>,     // Per-session budget
     pub kill_on_budget: bool,        // Auto-kill when budget exceeded
     pub budget_warned: HashSet<u32>, // PIDs that have been warned at 80%
@@ -132,6 +245,11 @@ impl App {
             webhook_filter: None,
             launch_mode: false,
             launch_buffer: String::new(),
+            search_mode: false,
+            search_buffer: String::new(),
+            search_query: String::new(),
+            status_filter: StatusFilter::All,
+            focus_filter: FocusFilter::All,
             budget_usd: None,
             kill_on_budget: false,
             budget_warned: HashSet::new(),
@@ -154,7 +272,7 @@ impl App {
             session_recordings: HashMap::new(),
         };
         app.refresh();
-        if !app.sessions.is_empty() {
+        if app.visible_session_count() > 0 {
             app.table_state.select(Some(0));
         }
         app
@@ -497,16 +615,7 @@ impl App {
         self.prev_statuses = sessions.iter().map(|s| (s.pid, s.status)).collect();
 
         self.sessions = sessions;
-
-        // Fix selection bounds
-        let len = self.sessions.len();
-        if len == 0 {
-            self.table_state.select(None);
-        } else if let Some(sel) = self.table_state.selected() {
-            if sel >= len {
-                self.table_state.select(Some(len - 1));
-            }
-        }
+        self.normalize_selection();
 
         // Record debug timings
         if self.debug {
@@ -596,18 +705,7 @@ impl App {
         }
 
         self.sessions = sessions;
-
-        // Fix selection bounds
-        let len = self.sessions.len();
-        if len == 0 {
-            self.table_state.select(None);
-        } else if self.table_state.selected().is_none() {
-            self.table_state.select(Some(0));
-        } else if let Some(sel) = self.table_state.selected() {
-            if sel >= len {
-                self.table_state.select(Some(len - 1));
-            }
-        }
+        self.normalize_selection();
     }
 
     pub fn tick(&mut self) {
@@ -807,11 +905,12 @@ impl App {
     }
 
     pub fn next(&mut self) {
-        if self.sessions.is_empty() {
+        let len = self.visible_session_count();
+        if len == 0 {
             return;
         }
         let i = match self.table_state.selected() {
-            Some(i) if i >= self.sessions.len() - 1 => 0,
+            Some(i) if i >= len - 1 => 0,
             Some(i) => i + 1,
             None => 0,
         };
@@ -819,11 +918,12 @@ impl App {
     }
 
     pub fn previous(&mut self) {
-        if self.sessions.is_empty() {
+        let len = self.visible_session_count();
+        if len == 0 {
             return;
         }
         let i = match self.table_state.selected() {
-            Some(0) => self.sessions.len() - 1,
+            Some(0) => len - 1,
             Some(i) => i - 1,
             None => 0,
         };
@@ -831,9 +931,10 @@ impl App {
     }
 
     pub fn selected_session(&self) -> Option<&ClaudeSession> {
-        self.table_state
-            .selected()
-            .and_then(|i| self.sessions.get(i))
+        let visible = self.visible_session_indices();
+        let selected = self.table_state.selected()?;
+        let session_idx = *visible.get(selected)?;
+        self.sessions.get(session_idx)
     }
 
     pub fn handle_kill(&mut self) {
@@ -882,6 +983,11 @@ impl App {
             return true;
         }
 
+        if self.search_mode {
+            self.handle_search_key(key);
+            return true;
+        }
+
         // Input mode: capture text for sending to a session
         if self.input_mode {
             self.handle_input_key(key);
@@ -922,6 +1028,33 @@ impl App {
             }
             KeyCode::Char(c) => {
                 self.input_buffer.push(c);
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_search_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Enter => {
+                self.search_query = self.search_buffer.trim().to_string();
+                self.search_mode = false;
+                self.normalize_selection();
+                if self.search_query.is_empty() {
+                    self.status_msg = "Search cleared".into();
+                } else {
+                    self.status_msg = format!("Search: {}", self.search_query);
+                }
+            }
+            KeyCode::Esc => {
+                self.search_mode = false;
+                self.search_buffer.clear();
+                self.status_msg = "Search cancelled".into();
+            }
+            KeyCode::Backspace => {
+                self.search_buffer.pop();
+            }
+            KeyCode::Char(c) => {
+                self.search_buffer.push(c);
             }
             _ => {}
         }
@@ -983,6 +1116,26 @@ impl App {
                 self.cancel_pending_kill();
                 self.cancel_pending_auto_approve();
                 self.cycle_sort();
+            }
+            (KeyCode::Char('f'), _) => {
+                self.cancel_pending_kill();
+                self.cancel_pending_auto_approve();
+                self.cycle_status_filter();
+            }
+            (KeyCode::Char('v'), _) => {
+                self.cancel_pending_kill();
+                self.cancel_pending_auto_approve();
+                self.cycle_focus_filter();
+            }
+            (KeyCode::Char('z'), _) => {
+                self.cancel_pending_kill();
+                self.cancel_pending_auto_approve();
+                self.clear_filters();
+            }
+            (KeyCode::Char('/'), _) => {
+                self.cancel_pending_kill();
+                self.cancel_pending_auto_approve();
+                self.enter_search_mode();
             }
             (KeyCode::Char('a'), _) => {
                 self.cancel_pending_kill();
@@ -1062,6 +1215,141 @@ impl App {
             }
             _ => {}
         }
+    }
+
+    fn enter_search_mode(&mut self) {
+        self.search_mode = true;
+        self.search_buffer = self.search_query.clone();
+    }
+
+    pub fn clear_filters(&mut self) {
+        self.status_filter = StatusFilter::All;
+        self.focus_filter = FocusFilter::All;
+        self.search_query.clear();
+        self.search_buffer.clear();
+        self.search_mode = false;
+        self.normalize_selection();
+        self.status_msg = "Filters cleared".into();
+    }
+
+    pub fn cycle_status_filter(&mut self) {
+        self.status_filter = self.status_filter.next();
+        self.normalize_selection();
+        self.status_msg = format!("Status filter: {}", self.status_filter.label());
+    }
+
+    pub fn cycle_focus_filter(&mut self) {
+        self.focus_filter = self.focus_filter.next();
+        self.normalize_selection();
+        self.status_msg = format!("Focus filter: {}", self.focus_filter.label());
+    }
+
+    pub fn has_active_filters(&self) -> bool {
+        self.status_filter != StatusFilter::All
+            || self.focus_filter != FocusFilter::All
+            || !self.search_query.trim().is_empty()
+    }
+
+    pub fn filter_summary(&self) -> String {
+        let mut parts = Vec::new();
+        if self.status_filter != StatusFilter::All {
+            parts.push(format!("status={}", self.status_filter.label()));
+        }
+        if self.focus_filter != FocusFilter::All {
+            parts.push(format!("focus={}", self.focus_filter.label()));
+        }
+        if !self.search_query.trim().is_empty() {
+            parts.push(format!("search=\"{}\"", self.search_query));
+        }
+        if parts.is_empty() {
+            "filters: none".to_string()
+        } else {
+            format!("filters: {}", parts.join(" | "))
+        }
+    }
+
+    pub fn visible_session_indices(&self) -> Vec<usize> {
+        self.sessions
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, session)| self.matches_filters(session).then_some(idx))
+            .collect()
+    }
+
+    pub fn visible_sessions(&self) -> Vec<&ClaudeSession> {
+        self.visible_session_indices()
+            .into_iter()
+            .filter_map(|idx| self.sessions.get(idx))
+            .collect()
+    }
+
+    pub fn visible_session_count(&self) -> usize {
+        self.visible_session_indices().len()
+    }
+
+    fn normalize_selection(&mut self) {
+        let len = self.visible_session_count();
+        if len == 0 {
+            self.table_state.select(None);
+        } else if self.table_state.selected().is_none() {
+            self.table_state.select(Some(0));
+        } else if let Some(sel) = self.table_state.selected() {
+            if sel >= len {
+                self.table_state.select(Some(len - 1));
+            }
+        }
+    }
+
+    fn matches_filters(&self, session: &ClaudeSession) -> bool {
+        self.status_filter.matches(session.status)
+            && self.matches_focus_filter(session)
+            && self.matches_search_query(session)
+    }
+
+    fn matches_focus_filter(&self, session: &ClaudeSession) -> bool {
+        let over_budget = self
+            .budget_usd
+            .map(|budget| session.has_usage_metrics() && session.cost_usd >= budget)
+            .unwrap_or(false);
+        let high_context = session.has_usage_metrics()
+            && session.context_percent() >= self.context_warn_threshold as f64;
+        let unknown_telemetry = !session.has_usage_metrics();
+        let conflict = self.conflict_pids.contains(&session.pid);
+
+        match self.focus_filter {
+            FocusFilter::All => true,
+            FocusFilter::Attention => {
+                session.status == SessionStatus::NeedsInput
+                    || over_budget
+                    || high_context
+                    || unknown_telemetry
+                    || conflict
+            }
+            FocusFilter::OverBudget => over_budget,
+            FocusFilter::HighContext => high_context,
+            FocusFilter::UnknownTelemetry => unknown_telemetry,
+            FocusFilter::Conflict => conflict,
+        }
+    }
+
+    fn matches_search_query(&self, session: &ClaudeSession) -> bool {
+        let query = self.search_query.trim();
+        if query.is_empty() {
+            return true;
+        }
+
+        let query = query.to_ascii_lowercase();
+        let fields = [
+            session.display_name().to_string(),
+            session.project_name.clone(),
+            session.model.clone(),
+            session.cwd.clone(),
+            session.session_id.clone(),
+        ];
+
+        fields
+            .iter()
+            .any(|field| field.to_ascii_lowercase().contains(&query))
     }
 
     fn handle_approve(&mut self) {
@@ -1179,7 +1467,7 @@ pub struct ProjectGroup {
 impl App {
     pub fn project_groups(&self) -> Vec<ProjectGroup> {
         let mut groups: HashMap<String, Vec<&ClaudeSession>> = HashMap::new();
-        for s in &self.sessions {
+        for s in self.visible_sessions() {
             groups.entry(s.project_name.clone()).or_default().push(s);
         }
 
@@ -1218,6 +1506,128 @@ impl App {
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{RawSession, TelemetryStatus};
+
+    fn make_session(
+        pid: u32,
+        project: &str,
+        model: &str,
+        status: SessionStatus,
+        cost_usd: f64,
+        context_pct: f64,
+        telemetry_available: bool,
+    ) -> ClaudeSession {
+        let raw = RawSession {
+            pid,
+            session_id: format!("session-{pid}"),
+            cwd: format!("/tmp/{project}"),
+            started_at: 0,
+        };
+        let mut session = ClaudeSession::from_raw(raw);
+        session.project_name = project.to_string();
+        session.model = model.to_string();
+        session.status = status;
+        session.cost_usd = cost_usd;
+        session.context_max = 100;
+        session.context_tokens = context_pct as u64;
+        session.telemetry_status = if telemetry_available {
+            TelemetryStatus::Available
+        } else {
+            TelemetryStatus::MissingTranscript
+        };
+        session.usage_metrics_available = telemetry_available;
+        session
+    }
+
+    fn make_test_app() -> App {
+        let mut app = App::new();
+        app.sessions = vec![
+            make_session(
+                11,
+                "blocked-api",
+                "sonnet-4.6",
+                SessionStatus::NeedsInput,
+                2.0,
+                40.0,
+                true,
+            ),
+            make_session(
+                12,
+                "hot-cost",
+                "opus-4.6",
+                SessionStatus::Processing,
+                7.5,
+                30.0,
+                true,
+            ),
+            make_session(
+                13,
+                "high-context",
+                "haiku",
+                SessionStatus::WaitingInput,
+                1.0,
+                90.0,
+                true,
+            ),
+            make_session(
+                14,
+                "unknown-metrics",
+                "",
+                SessionStatus::Unknown,
+                0.0,
+                0.0,
+                false,
+            ),
+        ];
+        app.budget_usd = Some(5.0);
+        app.context_warn_threshold = 75;
+        app.conflict_pids.insert(13);
+        app.normalize_selection();
+        app
+    }
+
+    #[test]
+    fn status_filter_returns_only_matching_sessions() {
+        let mut app = make_test_app();
+        app.status_filter = StatusFilter::NeedsInput;
+        let visible: Vec<u32> = app.visible_sessions().iter().map(|s| s.pid).collect();
+        assert_eq!(visible, vec![11]);
+    }
+
+    #[test]
+    fn focus_filter_attention_matches_high_signal_sessions() {
+        let mut app = make_test_app();
+        app.focus_filter = FocusFilter::Attention;
+        let visible: Vec<u32> = app.visible_sessions().iter().map(|s| s.pid).collect();
+        assert_eq!(visible, vec![11, 12, 13, 14]);
+    }
+
+    #[test]
+    fn search_query_matches_project_and_model() {
+        let mut app = make_test_app();
+        app.search_query = "sonnet".into();
+        let visible: Vec<u32> = app.visible_sessions().iter().map(|s| s.pid).collect();
+        assert_eq!(visible, vec![11]);
+
+        app.search_query = "unknown-metrics".into();
+        let visible: Vec<u32> = app.visible_sessions().iter().map(|s| s.pid).collect();
+        assert_eq!(visible, vec![14]);
+    }
+
+    #[test]
+    fn normalize_selection_clamps_to_filtered_session_count() {
+        let mut app = make_test_app();
+        app.table_state.select(Some(3));
+        app.status_filter = StatusFilter::NeedsInput;
+        app.normalize_selection();
+        assert_eq!(app.table_state.selected(), Some(0));
+        assert_eq!(app.selected_session().map(|s| s.pid), Some(11));
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1509,128 +1509,6 @@ impl App {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::session::{RawSession, TelemetryStatus};
-
-    fn make_session(
-        pid: u32,
-        project: &str,
-        model: &str,
-        status: SessionStatus,
-        cost_usd: f64,
-        context_pct: f64,
-        telemetry_available: bool,
-    ) -> ClaudeSession {
-        let raw = RawSession {
-            pid,
-            session_id: format!("session-{pid}"),
-            cwd: format!("/tmp/{project}"),
-            started_at: 0,
-        };
-        let mut session = ClaudeSession::from_raw(raw);
-        session.project_name = project.to_string();
-        session.model = model.to_string();
-        session.status = status;
-        session.cost_usd = cost_usd;
-        session.context_max = 100;
-        session.context_tokens = context_pct as u64;
-        session.telemetry_status = if telemetry_available {
-            TelemetryStatus::Available
-        } else {
-            TelemetryStatus::MissingTranscript
-        };
-        session.usage_metrics_available = telemetry_available;
-        session
-    }
-
-    fn make_test_app() -> App {
-        let mut app = App::new();
-        app.sessions = vec![
-            make_session(
-                11,
-                "blocked-api",
-                "sonnet-4.6",
-                SessionStatus::NeedsInput,
-                2.0,
-                40.0,
-                true,
-            ),
-            make_session(
-                12,
-                "hot-cost",
-                "opus-4.6",
-                SessionStatus::Processing,
-                7.5,
-                30.0,
-                true,
-            ),
-            make_session(
-                13,
-                "high-context",
-                "haiku",
-                SessionStatus::WaitingInput,
-                1.0,
-                90.0,
-                true,
-            ),
-            make_session(
-                14,
-                "unknown-metrics",
-                "",
-                SessionStatus::Unknown,
-                0.0,
-                0.0,
-                false,
-            ),
-        ];
-        app.budget_usd = Some(5.0);
-        app.context_warn_threshold = 75;
-        app.conflict_pids.insert(13);
-        app.normalize_selection();
-        app
-    }
-
-    #[test]
-    fn status_filter_returns_only_matching_sessions() {
-        let mut app = make_test_app();
-        app.status_filter = StatusFilter::NeedsInput;
-        let visible: Vec<u32> = app.visible_sessions().iter().map(|s| s.pid).collect();
-        assert_eq!(visible, vec![11]);
-    }
-
-    #[test]
-    fn focus_filter_attention_matches_high_signal_sessions() {
-        let mut app = make_test_app();
-        app.focus_filter = FocusFilter::Attention;
-        let visible: Vec<u32> = app.visible_sessions().iter().map(|s| s.pid).collect();
-        assert_eq!(visible, vec![11, 12, 13, 14]);
-    }
-
-    #[test]
-    fn search_query_matches_project_and_model() {
-        let mut app = make_test_app();
-        app.search_query = "sonnet".into();
-        let visible: Vec<u32> = app.visible_sessions().iter().map(|s| s.pid).collect();
-        assert_eq!(visible, vec![11]);
-
-        app.search_query = "unknown-metrics".into();
-        let visible: Vec<u32> = app.visible_sessions().iter().map(|s| s.pid).collect();
-        assert_eq!(visible, vec![14]);
-    }
-
-    #[test]
-    fn normalize_selection_clamps_to_filtered_session_count() {
-        let mut app = make_test_app();
-        app.table_state.select(Some(3));
-        app.status_filter = StatusFilter::NeedsInput;
-        app.normalize_selection();
-        assert_eq!(app.table_state.selected(), Some(0));
-        assert_eq!(app.selected_session().map(|s| s.pid), Some(11));
-    }
-}
-
 fn fire_webhook(url: &str, session: &ClaudeSession, old_status: String) {
     let payload = serde_json::json!({
         "event": "status_change",
@@ -1785,4 +1663,126 @@ fn create_aggregate_session(total_cost: f64, limit: f64, period: &str) -> Claude
     s.cost_usd = total_cost;
     s.model = format!("limit=${limit:.2}");
     s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{RawSession, TelemetryStatus};
+
+    fn make_session(
+        pid: u32,
+        project: &str,
+        model: &str,
+        status: SessionStatus,
+        cost_usd: f64,
+        context_pct: f64,
+        telemetry_available: bool,
+    ) -> ClaudeSession {
+        let raw = RawSession {
+            pid,
+            session_id: format!("session-{pid}"),
+            cwd: format!("/tmp/{project}"),
+            started_at: 0,
+        };
+        let mut session = ClaudeSession::from_raw(raw);
+        session.project_name = project.to_string();
+        session.model = model.to_string();
+        session.status = status;
+        session.cost_usd = cost_usd;
+        session.context_max = 100;
+        session.context_tokens = context_pct as u64;
+        session.telemetry_status = if telemetry_available {
+            TelemetryStatus::Available
+        } else {
+            TelemetryStatus::MissingTranscript
+        };
+        session.usage_metrics_available = telemetry_available;
+        session
+    }
+
+    fn make_test_app() -> App {
+        let mut app = App::new();
+        app.sessions = vec![
+            make_session(
+                11,
+                "blocked-api",
+                "sonnet-4.6",
+                SessionStatus::NeedsInput,
+                2.0,
+                40.0,
+                true,
+            ),
+            make_session(
+                12,
+                "hot-cost",
+                "opus-4.6",
+                SessionStatus::Processing,
+                7.5,
+                30.0,
+                true,
+            ),
+            make_session(
+                13,
+                "high-context",
+                "haiku",
+                SessionStatus::WaitingInput,
+                1.0,
+                90.0,
+                true,
+            ),
+            make_session(
+                14,
+                "unknown-metrics",
+                "",
+                SessionStatus::Unknown,
+                0.0,
+                0.0,
+                false,
+            ),
+        ];
+        app.budget_usd = Some(5.0);
+        app.context_warn_threshold = 75;
+        app.conflict_pids.insert(13);
+        app.normalize_selection();
+        app
+    }
+
+    #[test]
+    fn status_filter_returns_only_matching_sessions() {
+        let mut app = make_test_app();
+        app.status_filter = StatusFilter::NeedsInput;
+        let visible: Vec<u32> = app.visible_sessions().iter().map(|s| s.pid).collect();
+        assert_eq!(visible, vec![11]);
+    }
+
+    #[test]
+    fn focus_filter_attention_matches_high_signal_sessions() {
+        let mut app = make_test_app();
+        app.focus_filter = FocusFilter::Attention;
+        let visible: Vec<u32> = app.visible_sessions().iter().map(|s| s.pid).collect();
+        assert_eq!(visible, vec![11, 12, 13, 14]);
+    }
+
+    #[test]
+    fn search_query_matches_project_and_model() {
+        let mut app = make_test_app();
+        app.search_query = "sonnet".into();
+        let visible: Vec<u32> = app.visible_sessions().iter().map(|s| s.pid).collect();
+        assert_eq!(visible, vec![11]);
+
+        app.search_query = "unknown-metrics".into();
+        let visible: Vec<u32> = app.visible_sessions().iter().map(|s| s.pid).collect();
+        assert_eq!(visible, vec![14]);
+    }
+
+    #[test]
+    fn normalize_selection_clamps_to_filtered_session_count() {
+        let mut app = make_test_app();
+        app.table_state.select(Some(3));
+        app.status_filter = StatusFilter::NeedsInput;
+        app.normalize_selection();
+        assert_eq!(app.table_state.selected(), Some(0));
+        assert_eq!(app.selected_session().map(|s| s.pid), Some(11));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,13 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 
 use app::{App, FocusFilter, StatusFilter};
 
+#[derive(Clone)]
+struct ViewFilters {
+    status_filter: StatusFilter,
+    focus_filter: FocusFilter,
+    search: String,
+}
+
 #[derive(Parser)]
 #[command(
     name = "claudectl",
@@ -225,9 +232,11 @@ fn main() -> io::Result<()> {
     }
 
     models::set_overrides(cfg.model_overrides.clone());
-    let status_filter = parse_status_filter(cli.filter_status.as_deref())?;
-    let focus_filter = parse_focus_filter(cli.focus.as_deref())?;
-    let search_query = cli.search.clone().unwrap_or_default();
+    let filters = ViewFilters {
+        status_filter: parse_status_filter(cli.filter_status.as_deref())?,
+        focus_filter: parse_focus_filter(cli.focus.as_deref())?,
+        search: cli.search.clone().unwrap_or_default(),
+    };
 
     // Load event hooks from config
     let hook_registry = config::load_hooks();
@@ -270,11 +279,11 @@ fn main() -> io::Result<()> {
     }
 
     if cli.json && !cli.watch {
-        return print_json(cli.demo, status_filter, focus_filter, &search_query);
+        return print_json(cli.demo, &filters);
     }
 
     if cli.list {
-        return print_list(cli.demo, status_filter, focus_filter, &search_query);
+        return print_list(cli.demo, &filters);
     }
 
     if cli.watch {
@@ -282,9 +291,7 @@ fn main() -> io::Result<()> {
             Duration::from_millis(cfg.interval),
             cli.json,
             &cli.format,
-            status_filter,
-            focus_filter,
-            &search_query,
+            &filters,
         );
     }
 
@@ -312,9 +319,7 @@ fn main() -> io::Result<()> {
             app_theme,
             hook_registry,
             cli.demo,
-            status_filter,
-            focus_filter,
-            &search_query,
+            &filters,
         );
 
         disable_raw_mode()?;
@@ -347,9 +352,7 @@ fn main() -> io::Result<()> {
             app_theme,
             hook_registry,
             cli.demo,
-            status_filter,
-            focus_filter,
-            &search_query,
+            &filters,
         );
 
         disable_raw_mode()?;
@@ -426,15 +429,10 @@ fn parse_focus_filter(value: Option<&str>) -> io::Result<FocusFilter> {
     }
 }
 
-fn apply_filters(
-    app: &mut App,
-    status_filter: StatusFilter,
-    focus_filter: FocusFilter,
-    search_query: &str,
-) {
-    app.status_filter = status_filter;
-    app.focus_filter = focus_filter;
-    app.search_query = search_query.trim().to_string();
+fn apply_filters(app: &mut App, filters: &ViewFilters) {
+    app.status_filter = filters.status_filter;
+    app.focus_filter = filters.focus_filter;
+    app.search_query = filters.search.trim().to_string();
     app.search_buffer.clear();
     app.search_mode = false;
     let len = app.visible_session_count();
@@ -724,12 +722,7 @@ fn format_count(n: u64) -> String {
     }
 }
 
-fn make_app(
-    demo: bool,
-    status_filter: StatusFilter,
-    focus_filter: FocusFilter,
-    search: &str,
-) -> App {
+fn make_app(demo: bool, filters: &ViewFilters) -> App {
     let mut app = if demo {
         let mut app = App::new();
         app.demo_mode = true;
@@ -738,17 +731,12 @@ fn make_app(
     } else {
         App::new()
     };
-    apply_filters(&mut app, status_filter, focus_filter, search);
+    apply_filters(&mut app, filters);
     app
 }
 
-fn print_json(
-    demo: bool,
-    status_filter: StatusFilter,
-    focus_filter: FocusFilter,
-    search: &str,
-) -> io::Result<()> {
-    let app = make_app(demo, status_filter, focus_filter, search);
+fn print_json(demo: bool, filters: &ViewFilters) -> io::Result<()> {
+    let app = make_app(demo, filters);
     let values: Vec<serde_json::Value> = app
         .visible_sessions()
         .iter()
@@ -759,13 +747,8 @@ fn print_json(
     Ok(())
 }
 
-fn print_list(
-    demo: bool,
-    status_filter: StatusFilter,
-    focus_filter: FocusFilter,
-    search: &str,
-) -> io::Result<()> {
-    let app = make_app(demo, status_filter, focus_filter, search);
+fn print_list(demo: bool, filters: &ViewFilters) -> io::Result<()> {
+    let app = make_app(demo, filters);
     let visible_sessions = app.visible_sessions();
 
     if visible_sessions.is_empty() {
@@ -821,15 +804,13 @@ fn run_watch(
     tick_rate: Duration,
     json_mode: bool,
     format_str: &str,
-    status_filter: StatusFilter,
-    focus_filter: FocusFilter,
-    search: &str,
+    filters: &ViewFilters,
 ) -> io::Result<()> {
     use crate::session::SessionStatus;
     use std::collections::HashMap;
 
     let mut app = App::new();
-    apply_filters(&mut app, status_filter, focus_filter, search);
+    apply_filters(&mut app, filters);
     let mut prev_statuses: HashMap<u32, SessionStatus> =
         app.sessions.iter().map(|s| (s.pid, s.status)).collect();
 
@@ -913,9 +894,7 @@ fn run_tui<W: io::Write>(
     app_theme: theme::Theme,
     hook_registry: hooks::HookRegistry,
     demo_mode: bool,
-    status_filter: StatusFilter,
-    focus_filter: FocusFilter,
-    search: &str,
+    filters: &ViewFilters,
 ) -> io::Result<()> {
     let mut app = App::new();
     app.notify = cfg.notify;
@@ -931,7 +910,7 @@ fn run_tui<W: io::Write>(
     app.weekly_limit = cfg.weekly_limit;
     app.context_warn_threshold = cfg.context_warn_threshold;
     app.demo_mode = demo_mode;
-    apply_filters(&mut app, status_filter, focus_filter, search);
+    apply_filters(&mut app, filters);
 
     if demo_mode {
         app.daily_limit = Some(50.0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ use crossterm::{
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
 
-use app::App;
+use app::{App, FocusFilter, StatusFilter};
 
 #[derive(Parser)]
 #[command(
@@ -70,6 +70,18 @@ struct Cli {
         default_value = "{pid} {project}: {status} (${cost}, ctx {context}%)"
     )]
     format: String,
+
+    /// Filter sessions by status for TUI and non-TUI views
+    #[arg(long)]
+    filter_status: Option<String>,
+
+    /// Focus on a high-signal subset (`attention`, `over-budget`, `high-context`, `unknown-telemetry`, `conflict`)
+    #[arg(long)]
+    focus: Option<String>,
+
+    /// Search project/model/session text for TUI and non-TUI views
+    #[arg(long)]
+    search: Option<String>,
 
     /// Enable debug mode: show timing metrics in the footer
     #[arg(long)]
@@ -213,6 +225,9 @@ fn main() -> io::Result<()> {
     }
 
     models::set_overrides(cfg.model_overrides.clone());
+    let status_filter = parse_status_filter(cli.filter_status.as_deref())?;
+    let focus_filter = parse_focus_filter(cli.focus.as_deref())?;
+    let search_query = cli.search.clone().unwrap_or_default();
 
     // Load event hooks from config
     let hook_registry = config::load_hooks();
@@ -255,15 +270,22 @@ fn main() -> io::Result<()> {
     }
 
     if cli.json && !cli.watch {
-        return print_json(cli.demo);
+        return print_json(cli.demo, status_filter, focus_filter, &search_query);
     }
 
     if cli.list {
-        return print_list(cli.demo);
+        return print_list(cli.demo, status_filter, focus_filter, &search_query);
     }
 
     if cli.watch {
-        return run_watch(Duration::from_millis(cfg.interval), cli.json, &cli.format);
+        return run_watch(
+            Duration::from_millis(cfg.interval),
+            cli.json,
+            &cli.format,
+            status_filter,
+            focus_filter,
+            &search_query,
+        );
     }
 
     let tick_rate = Duration::from_millis(cfg.interval);
@@ -290,6 +312,9 @@ fn main() -> io::Result<()> {
             app_theme,
             hook_registry,
             cli.demo,
+            status_filter,
+            focus_filter,
+            &search_query,
         );
 
         disable_raw_mode()?;
@@ -322,6 +347,9 @@ fn main() -> io::Result<()> {
             app_theme,
             hook_registry,
             cli.demo,
+            status_filter,
+            focus_filter,
+            &search_query,
         );
 
         disable_raw_mode()?;
@@ -368,6 +396,57 @@ fn parse_duration_str(s: &str) -> Duration {
         }
     }
     Duration::from_secs(24 * 3600) // default 24h
+}
+
+fn parse_status_filter(value: Option<&str>) -> io::Result<StatusFilter> {
+    match value {
+        Some(raw) => StatusFilter::parse(raw).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "Invalid --filter-status value: {raw}. Expected one of: all, needs-input, processing, waiting, unknown, idle, finished"
+                ),
+            )
+        }),
+        None => Ok(StatusFilter::All),
+    }
+}
+
+fn parse_focus_filter(value: Option<&str>) -> io::Result<FocusFilter> {
+    match value {
+        Some(raw) => FocusFilter::parse(raw).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "Invalid --focus value: {raw}. Expected one of: all, attention, over-budget, high-context, unknown-telemetry, conflict"
+                ),
+            )
+        }),
+        None => Ok(FocusFilter::All),
+    }
+}
+
+fn apply_filters(
+    app: &mut App,
+    status_filter: StatusFilter,
+    focus_filter: FocusFilter,
+    search_query: &str,
+) {
+    app.status_filter = status_filter;
+    app.focus_filter = focus_filter;
+    app.search_query = search_query.trim().to_string();
+    app.search_buffer.clear();
+    app.search_mode = false;
+    let len = app.visible_session_count();
+    if len == 0 {
+        app.table_state.select(None);
+    } else if app.table_state.selected().is_none() {
+        app.table_state.select(Some(0));
+    } else if let Some(sel) = app.table_state.selected() {
+        if sel >= len {
+            app.table_state.select(Some(len - 1));
+        }
+    }
 }
 
 fn run_clean(older_than: Option<&str>, finished_only: bool, dry_run: bool) -> io::Result<()> {
@@ -645,30 +724,59 @@ fn format_count(n: u64) -> String {
     }
 }
 
-fn make_app(demo: bool) -> App {
-    if demo {
+fn make_app(
+    demo: bool,
+    status_filter: StatusFilter,
+    focus_filter: FocusFilter,
+    search: &str,
+) -> App {
+    let mut app = if demo {
         let mut app = App::new();
         app.demo_mode = true;
         app.sessions = demo::generate_sessions(10);
         app
     } else {
         App::new()
-    }
+    };
+    apply_filters(&mut app, status_filter, focus_filter, search);
+    app
 }
 
-fn print_json(demo: bool) -> io::Result<()> {
-    let app = make_app(demo);
-    let values: Vec<serde_json::Value> = app.sessions.iter().map(|s| s.to_json_value()).collect();
+fn print_json(
+    demo: bool,
+    status_filter: StatusFilter,
+    focus_filter: FocusFilter,
+    search: &str,
+) -> io::Result<()> {
+    let app = make_app(demo, status_filter, focus_filter, search);
+    let values: Vec<serde_json::Value> = app
+        .visible_sessions()
+        .iter()
+        .map(|s| s.to_json_value())
+        .collect();
     let json = serde_json::to_string_pretty(&values).unwrap_or_else(|_| "[]".to_string());
     println!("{json}");
     Ok(())
 }
 
-fn print_list(demo: bool) -> io::Result<()> {
-    let app = make_app(demo);
+fn print_list(
+    demo: bool,
+    status_filter: StatusFilter,
+    focus_filter: FocusFilter,
+    search: &str,
+) -> io::Result<()> {
+    let app = make_app(demo, status_filter, focus_filter, search);
+    let visible_sessions = app.visible_sessions();
 
-    if app.sessions.is_empty() {
-        println!("No active Claude sessions.");
+    if visible_sessions.is_empty() {
+        if app.has_active_filters() {
+            println!("No sessions match the current filters.");
+        } else {
+            println!("No active Claude sessions.");
+        }
+        if app.has_active_filters() {
+            println!("  ({})", app.filter_summary());
+        }
         return Ok(());
     }
 
@@ -678,7 +786,7 @@ fn print_list(demo: bool) -> io::Result<()> {
     );
     println!("{}", "-".repeat(105));
 
-    for s in &app.sessions {
+    for s in visible_sessions {
         let status_text = if s.status == session::SessionStatus::Unknown {
             s.telemetry_status.short_label().to_string()
         } else {
@@ -699,23 +807,34 @@ fn print_list(demo: bool) -> io::Result<()> {
         );
     }
 
-    let total_cost: f64 = app.sessions.iter().map(|s| s.cost_usd).sum();
+    let total_cost: f64 = app.visible_sessions().iter().map(|s| s.cost_usd).sum();
     println!("{}", "-".repeat(105));
     println!("Total cost: ${total_cost:.2}");
+    if app.has_active_filters() {
+        println!("{}", app.filter_summary());
+    }
 
     Ok(())
 }
 
-fn run_watch(tick_rate: Duration, json_mode: bool, format_str: &str) -> io::Result<()> {
+fn run_watch(
+    tick_rate: Duration,
+    json_mode: bool,
+    format_str: &str,
+    status_filter: StatusFilter,
+    focus_filter: FocusFilter,
+    search: &str,
+) -> io::Result<()> {
     use crate::session::SessionStatus;
     use std::collections::HashMap;
 
     let mut app = App::new();
+    apply_filters(&mut app, status_filter, focus_filter, search);
     let mut prev_statuses: HashMap<u32, SessionStatus> =
         app.sessions.iter().map(|s| (s.pid, s.status)).collect();
 
     // Print initial state for all sessions
-    for s in &app.sessions {
+    for s in app.visible_sessions() {
         if json_mode {
             let obj = serde_json::json!({
                 "event": "initial",
@@ -736,12 +855,14 @@ fn run_watch(tick_rate: Duration, json_mode: bool, format_str: &str) -> io::Resu
     loop {
         std::thread::sleep(tick_rate);
         app.tick();
+        let visible_pids: std::collections::HashSet<u32> =
+            app.visible_sessions().iter().map(|s| s.pid).collect();
 
         for s in &app.sessions {
             let prev = prev_statuses.get(&s.pid).copied();
             let changed = prev.is_none_or(|p| p != s.status);
 
-            if !changed {
+            if !changed || !visible_pids.contains(&s.pid) {
                 continue;
             }
 
@@ -792,6 +913,9 @@ fn run_tui<W: io::Write>(
     app_theme: theme::Theme,
     hook_registry: hooks::HookRegistry,
     demo_mode: bool,
+    status_filter: StatusFilter,
+    focus_filter: FocusFilter,
+    search: &str,
 ) -> io::Result<()> {
     let mut app = App::new();
     app.notify = cfg.notify;
@@ -807,6 +931,7 @@ fn run_tui<W: io::Write>(
     app.weekly_limit = cfg.weekly_limit;
     app.context_warn_threshold = cfg.context_warn_threshold;
     app.demo_mode = demo_mode;
+    apply_filters(&mut app, status_filter, focus_filter, search);
 
     if demo_mode {
         app.daily_limit = Some(50.0);

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -53,6 +53,22 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
             Span::raw("  Cycle sort column"),
         ]),
         Line::from(vec![
+            Span::styled("  f              ", Style::default().fg(t.highlight_key)),
+            Span::raw("  Cycle status filter"),
+        ]),
+        Line::from(vec![
+            Span::styled("  v              ", Style::default().fg(t.highlight_key)),
+            Span::raw("  Cycle focus filter"),
+        ]),
+        Line::from(vec![
+            Span::styled("  /              ", Style::default().fg(t.highlight_key)),
+            Span::raw("  Search project/model/session text"),
+        ]),
+        Line::from(vec![
+            Span::styled("  z              ", Style::default().fg(t.highlight_key)),
+            Span::raw("  Clear all active filters"),
+        ]),
+        Line::from(vec![
             Span::styled("  a              ", Style::default().fg(t.highlight_key)),
             Span::raw("  Toggle auto-approve (double-tap)"),
         ]),
@@ -135,6 +151,10 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
         Line::from(vec![
             Span::styled("  (Xm Xs) ", Style::default().fg(t.highlight_key)),
             Span::raw("after Needs Input = wait time"),
+        ]),
+        Line::from(vec![
+            Span::styled("  filters ", Style::default().fg(t.highlight_key)),
+            Span::raw("in footer/status bar = active triage filters"),
         ]),
         Line::from(""),
         Line::from(Span::styled(

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -10,7 +10,19 @@ use crate::app::App;
 
 pub fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
     let t = &app.theme;
-    if app.launch_mode {
+    if app.search_mode {
+        let msg = Paragraph::new(Line::from(vec![
+            Span::styled(
+                " / ",
+                Style::default()
+                    .fg(t.highlight_key)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(&*app.search_buffer, Style::default().fg(t.text_primary)),
+            Span::styled("_", Style::default().fg(t.text_muted)),
+        ]));
+        frame.render_widget(msg, area);
+    } else if app.launch_mode {
         let msg = Paragraph::new(Line::from(vec![
             Span::styled(
                 " new> ",
@@ -41,6 +53,12 @@ pub fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
         let msg = Paragraph::new(Span::styled(
             format!(" {}", app.status_msg),
             Style::default().fg(color),
+        ));
+        frame.render_widget(msg, area);
+    } else if app.has_active_filters() {
+        let msg = Paragraph::new(Span::styled(
+            format!(" {}", app.filter_summary()),
+            Style::default().fg(t.header),
         ));
         frame.render_widget(msg, area);
     } else if !app.session_recordings.is_empty() {

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -15,7 +15,12 @@ use super::status_bar::render_status_bar;
 
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let t = &app.theme;
-    let has_status = !app.status_msg.is_empty() || app.input_mode || app.launch_mode;
+    let visible_sessions = app.visible_sessions();
+    let has_status = !app.status_msg.is_empty()
+        || app.input_mode
+        || app.launch_mode
+        || app.search_mode
+        || app.has_active_filters();
     let show_detail = app.detail_panel && app.selected_session().is_some();
 
     let mut constraints = Vec::new();
@@ -87,6 +92,43 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         return;
     }
 
+    if visible_sessions.is_empty() {
+        let empty_lines = vec![
+            Line::from(""),
+            Line::from(""),
+            Line::from(Span::styled(
+                "No sessions match the current filters.",
+                Style::default()
+                    .fg(t.text_muted)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Line::from(""),
+            Line::from(format!("  {}", app.filter_summary())),
+            Line::from(""),
+            Line::from("  Press z to clear filters, or / to edit the search query."),
+        ];
+
+        let block = Block::default()
+            .title(" claudectl ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(t.border));
+
+        let empty_widget = Paragraph::new(empty_lines)
+            .block(block)
+            .alignment(Alignment::Center);
+
+        frame.render_widget(empty_widget, chunks[0]);
+
+        if has_status && chunks.len() > 1 {
+            render_status_bar(frame, chunks[1], app);
+        }
+
+        if app.show_help {
+            render_help_overlay(frame, area, app);
+        }
+        return;
+    }
+
     // Build header with sort indicator
     let header_names = [
         "PID", "Project", "Status", "Context", "Cost", "$/hr", "Elapsed", "CPU%", "MEM", "In/Out",
@@ -115,9 +157,12 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     let header = Row::new(header_cells).height(1);
 
+    let selected_pid = app.selected_session().map(|s| s.pid);
+    let mut selected_row_idx = app.table_state.selected();
     let rows: Vec<Row> = if app.grouped_view {
         let groups = app.project_groups();
         let mut rows = Vec::new();
+        let mut row_idx = 0usize;
         for group in &groups {
             // Group header row
             let cost_str = if group.total_cost < 1.0 {
@@ -142,15 +187,28 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                 cells.push(Cell::from(""));
             }
             rows.push(Row::new(cells));
+            row_idx += 1;
 
             // Session rows under this group
-            for s in app.sessions.iter().filter(|s| s.project_name == group.name) {
+            for s in visible_sessions
+                .iter()
+                .copied()
+                .filter(|s| s.project_name == group.name)
+            {
+                if Some(s.pid) == selected_pid {
+                    selected_row_idx = Some(row_idx);
+                }
                 rows.push(session_row(s, app));
+                row_idx += 1;
             }
         }
         rows
     } else {
-        app.sessions.iter().map(|s| session_row(s, app)).collect()
+        visible_sessions
+            .iter()
+            .copied()
+            .map(|s| session_row(s, app))
+            .collect()
     };
 
     let widths = [
@@ -167,9 +225,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         Constraint::Length(16), // Activity sparkline
     ];
 
-    let count = app.sessions.len();
-    let active = app
-        .sessions
+    let count = visible_sessions.len();
+    let total_sessions = app.sessions.len();
+    let active = visible_sessions
         .iter()
         .filter(|s| {
             matches!(
@@ -178,14 +236,12 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
             )
         })
         .count();
-    let total_cost: f64 = app.sessions.iter().map(|s| s.cost_usd).sum();
-    let total_tokens: u64 = app
-        .sessions
+    let total_cost: f64 = visible_sessions.iter().map(|s| s.cost_usd).sum();
+    let total_tokens: u64 = visible_sessions
         .iter()
         .map(|s| s.total_input_tokens + s.total_output_tokens)
         .sum();
-    let missing_usage = app
-        .sessions
+    let missing_usage = visible_sessions
         .iter()
         .filter(|s| !s.has_usage_metrics())
         .count();
@@ -208,7 +264,11 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     let mut footer_spans = vec![
         Span::styled(
-            format!(" {count} sessions ({active} active) "),
+            if app.has_active_filters() {
+                format!(" {count}/{total_sessions} shown ({active} active) ")
+            } else {
+                format!(" {count} sessions ({active} active) ")
+            },
             Style::default().fg(t.footer),
         ),
         Span::styled(format!("{cost_str} "), Style::default().fg(t.cost)),
@@ -222,6 +282,13 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         ),
     ];
 
+    if app.has_active_filters() {
+        footer_spans.push(Span::styled(
+            format!(" {} ", app.filter_summary()),
+            Style::default().fg(t.header),
+        ));
+    }
+
     if app.debug {
         footer_spans.push(Span::styled(
             format!("  {}", app.debug_timings.format()),
@@ -231,11 +298,11 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         // Contextual hints based on selected session state
         let hint = match app.selected_session().map(|s| s.status) {
             Some(SessionStatus::NeedsInput) => {
-                "  y:approve i:type c:compact R:record Tab:go d:kill ?:help".to_string()
+                "  y:approve i:type c:compact R:record Tab:go f/v:filter /:search z:clear d:kill ?:help".to_string()
             }
             _ => {
                 format!(
-                    "  q:quit j/k:nav Tab:go y:approve i:input c:compact R:record d:kill s:sort({sort_name}) ?:help"
+                    "  q:quit j/k:nav Tab:go y:approve i:input c:compact R:record f/v:filter /:search z:clear d:kill s:sort({sort_name}) ?:help"
                 )
             }
         };
@@ -325,7 +392,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         )
         .highlight_symbol("\u{25b6} "); // ▶
 
-    frame.render_stateful_widget(table, chunks[0], &mut app.table_state.clone());
+    let mut render_state = app.table_state.clone();
+    render_state.select(selected_row_idx);
+    frame.render_stateful_widget(table, chunks[0], &mut render_state);
 
     // Detail panel
     let mut next_chunk = 1;


### PR DESCRIPTION
## Summary
- add composable triage filters for status, focus, and text search in the TUI
- apply the same filters to `--list`, `--json`, and `--watch`
- expose the new controls in the README, footer/status bar, and help overlay

## What changed
- added status filters for `Needs Input`, `Processing`, `Waiting`, `Unknown`, `Idle`, and `Finished`
- added focus filters for `attention`, `over-budget`, `high-context`, `unknown-telemetry`, and `conflict`
- added `/` search across project, model, cwd, and session id
- added `z` to clear active filters
- made grouped rendering and selection work against the filtered session set
- added unit coverage for core filter behavior and selection clamping

## Validation
- `cargo test`
- `cargo run -- --demo --list --filter-status needs-input`
- `cargo run -- --demo --json --focus attention --search api`

Closes #69.
