### PR TITLE
Add TUI launch wizard parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Multi-signal inference from CPU usage, JSONL events, and timestamps:
 | `i` | Input mode (type text to session) |
 | `d`/`x` | Kill session (double-tap to confirm) |
 | `a` | Toggle auto-approve (double-tap to confirm) |
-| `n` | Launch new Claude session (`tmux`, Kitty, WezTerm) |
+| `n` | Launch wizard for cwd, prompt, and resume (`tmux`, Kitty, WezTerm) |
 | `g` | Toggle grouped view by project |
 | `s` | Cycle sort column |
 | `f` | Cycle status filter |

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,6 +5,7 @@ use ratatui::widgets::TableState;
 
 use crate::discovery;
 use crate::hooks::{HookEvent, HookRegistry};
+use crate::launch::{self, LaunchRequest};
 use crate::monitor;
 use crate::process;
 use crate::session::{ClaudeSession, SessionStatus};
@@ -121,6 +122,129 @@ impl FocusFilter {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LaunchField {
+    Cwd,
+    Prompt,
+    Resume,
+}
+
+impl LaunchField {
+    fn next(self) -> Self {
+        match self {
+            Self::Cwd => Self::Prompt,
+            Self::Prompt => Self::Resume,
+            Self::Resume => Self::Resume,
+        }
+    }
+
+    fn prev(self) -> Self {
+        match self {
+            Self::Cwd => Self::Cwd,
+            Self::Prompt => Self::Cwd,
+            Self::Resume => Self::Prompt,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Cwd => "cwd",
+            Self::Prompt => "prompt",
+            Self::Resume => "resume",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchForm {
+    pub field: LaunchField,
+    pub cwd: String,
+    pub prompt: String,
+    pub resume: String,
+}
+
+impl Default for LaunchForm {
+    fn default() -> Self {
+        Self {
+            field: LaunchField::Cwd,
+            cwd: ".".into(),
+            prompt: String::new(),
+            resume: String::new(),
+        }
+    }
+}
+
+impl LaunchForm {
+    pub fn active_buffer(&self) -> &str {
+        match self.field {
+            LaunchField::Cwd => &self.cwd,
+            LaunchField::Prompt => &self.prompt,
+            LaunchField::Resume => &self.resume,
+        }
+    }
+
+    fn active_buffer_mut(&mut self) -> &mut String {
+        match self.field {
+            LaunchField::Cwd => &mut self.cwd,
+            LaunchField::Prompt => &mut self.prompt,
+            LaunchField::Resume => &mut self.resume,
+        }
+    }
+
+    fn advance(&mut self) {
+        self.field = self.field.next();
+    }
+
+    fn retreat(&mut self) {
+        self.field = self.field.prev();
+    }
+
+    fn is_last_field(&self) -> bool {
+        self.field == LaunchField::Resume
+    }
+
+    pub fn status_hint(&self) -> String {
+        format!(
+            "New session [{}] Enter next, Tab move, Ctrl+Enter launch, Esc cancel",
+            self.field.label()
+        )
+    }
+
+    fn request(&self) -> Result<LaunchRequest, String> {
+        launch::prepare(
+            &self.cwd,
+            Some(self.prompt.as_str()),
+            Some(self.resume.as_str()),
+        )
+    }
+
+    pub fn summary(&self) -> String {
+        let cwd = compact_value(&self.cwd, ".");
+        let prompt = if self.prompt.trim().is_empty() {
+            "skip".to_string()
+        } else {
+            "set".to_string()
+        };
+        let resume = compact_value(&self.resume, "skip");
+        format!("cwd={cwd} | prompt={prompt} | resume={resume}")
+    }
+}
+
+fn compact_value(value: &str, empty_label: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return empty_label.to_string();
+    }
+
+    const MAX_LEN: usize = 24;
+    if trimmed.chars().count() <= MAX_LEN {
+        trimmed.to_string()
+    } else {
+        let prefix: String = trimmed.chars().take(MAX_LEN - 1).collect();
+        format!("{prefix}…")
+    }
+}
+
 pub struct App {
     pub sessions: Vec<ClaudeSession>,
     pub table_state: TableState,
@@ -143,8 +267,8 @@ pub struct App {
     pub detail_panel: bool, // Show expanded detail for selected session
     pub webhook_url: Option<String>,
     pub webhook_filter: Option<Vec<String>>, // Only fire on these status names
-    pub launch_mode: bool,                   // Capturing directory path for new session
-    pub launch_buffer: String,
+    pub launch_mode: bool,                   // Capturing launch wizard fields
+    pub launch_form: LaunchForm,
     pub search_mode: bool,
     pub search_buffer: String,
     pub search_query: String,
@@ -244,7 +368,7 @@ impl App {
             webhook_url: None,
             webhook_filter: None,
             launch_mode: false,
-            launch_buffer: String::new(),
+            launch_form: LaunchForm::default(),
             search_mode: false,
             search_buffer: String::new(),
             search_query: String::new(),
@@ -1144,10 +1268,7 @@ impl App {
             (KeyCode::Char('n'), _) => {
                 self.cancel_pending_kill();
                 self.cancel_pending_auto_approve();
-                self.launch_mode = true;
-                self.launch_buffer.clear();
-                self.status_msg =
-                    "New session — enter directory path (Enter to launch, Esc to cancel): ".into();
+                self.enter_launch_mode();
             }
             (KeyCode::Char('g'), _) => {
                 self.cancel_pending_kill();
@@ -1178,42 +1299,69 @@ impl App {
 
     fn handle_launch_key(&mut self, key: KeyEvent) {
         match key.code {
+            KeyCode::Enter if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.submit_launch_form();
+            }
             KeyCode::Enter => {
-                let dir = if self.launch_buffer.is_empty() {
-                    ".".to_string()
+                if self.launch_form.is_last_field() {
+                    self.submit_launch_form();
                 } else {
-                    self.launch_buffer.clone()
-                };
-
-                let cwd_path = std::path::Path::new(&dir)
-                    .canonicalize()
-                    .unwrap_or_else(|_| std::path::PathBuf::from(&dir));
-
-                match terminals::launch_session(cwd_path.to_string_lossy().as_ref(), None, None) {
-                    Ok(target) => {
-                        self.status_msg =
-                            format!("Launched session in {target} at {}", cwd_path.display());
-                    }
-                    Err(e) => {
-                        self.status_msg = format!("Launch failed: {e}");
-                    }
+                    self.launch_form.advance();
+                    self.status_msg = self.launch_form.status_hint();
                 }
-
-                self.launch_mode = false;
-                self.launch_buffer.clear();
+            }
+            KeyCode::Tab | KeyCode::Down => {
+                self.launch_form.advance();
+                self.status_msg = self.launch_form.status_hint();
+            }
+            KeyCode::BackTab | KeyCode::Up => {
+                self.launch_form.retreat();
+                self.status_msg = self.launch_form.status_hint();
             }
             KeyCode::Esc => {
                 self.launch_mode = false;
-                self.launch_buffer.clear();
+                self.launch_form = LaunchForm::default();
                 self.status_msg = "Launch cancelled".into();
             }
             KeyCode::Backspace => {
-                self.launch_buffer.pop();
+                self.launch_form.active_buffer_mut().pop();
             }
             KeyCode::Char(c) => {
-                self.launch_buffer.push(c);
+                self.launch_form.active_buffer_mut().push(c);
             }
             _ => {}
+        }
+    }
+
+    fn enter_launch_mode(&mut self) {
+        self.launch_mode = true;
+        self.launch_form = LaunchForm::default();
+        self.status_msg = self.launch_form.status_hint();
+    }
+
+    fn submit_launch_form(&mut self) {
+        let request = match self.launch_form.request() {
+            Ok(request) => request,
+            Err(err) => {
+                self.launch_form.field = LaunchField::Cwd;
+                self.status_msg = format!("Launch failed: {err}");
+                return;
+            }
+        };
+
+        match launch::launch(&request) {
+            Ok(target) => {
+                self.launch_mode = false;
+                self.launch_form = LaunchForm::default();
+                self.status_msg = format!(
+                    "Launched session in {target} at {}{}",
+                    request.cwd_path.display(),
+                    request.option_summary()
+                );
+            }
+            Err(err) => {
+                self.status_msg = format!("Launch failed: {err}");
+            }
         }
     }
 
@@ -1784,5 +1932,49 @@ mod tests {
         app.normalize_selection();
         assert_eq!(app.table_state.selected(), Some(0));
         assert_eq!(app.selected_session().map(|s| s.pid), Some(11));
+    }
+
+    #[test]
+    fn launch_wizard_starts_with_cli_defaults() {
+        let mut app = App::new();
+        app.enter_launch_mode();
+
+        assert!(app.launch_mode);
+        assert_eq!(app.launch_form.field, LaunchField::Cwd);
+        assert_eq!(app.launch_form.cwd, ".");
+        assert!(app.launch_form.prompt.is_empty());
+        assert!(app.launch_form.resume.is_empty());
+    }
+
+    #[test]
+    fn launch_wizard_moves_between_fields() {
+        let mut app = App::new();
+        app.enter_launch_mode();
+
+        app.handle_launch_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(app.launch_form.field, LaunchField::Prompt);
+
+        app.handle_launch_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        assert_eq!(app.launch_form.field, LaunchField::Resume);
+
+        app.handle_launch_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
+        assert_eq!(app.launch_form.field, LaunchField::Prompt);
+    }
+
+    #[test]
+    fn invalid_launch_keeps_wizard_open_and_reports_error() {
+        let mut app = App::new();
+        app.enter_launch_mode();
+        app.launch_form.cwd = "/tmp/claudectl-this-path-should-not-exist".into();
+        app.launch_form.field = LaunchField::Resume;
+
+        app.submit_launch_form();
+
+        assert!(app.launch_mode);
+        assert_eq!(app.launch_form.field, LaunchField::Cwd);
+        assert!(
+            app.status_msg
+                .starts_with("Launch failed: Directory not found:")
+        );
     }
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1,0 +1,113 @@
+use std::path::{Path, PathBuf};
+
+use crate::terminals;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchRequest {
+    pub cwd_path: PathBuf,
+    pub prompt: Option<String>,
+    pub resume: Option<String>,
+}
+
+impl LaunchRequest {
+    pub fn option_summary(&self) -> String {
+        let mut parts = Vec::new();
+        if let Some(resume) = &self.resume {
+            parts.push(format!("resume {resume}"));
+        }
+        if self.prompt.is_some() {
+            parts.push("prompt set".to_string());
+        }
+
+        if parts.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", parts.join(", "))
+        }
+    }
+}
+
+pub fn prepare(
+    cwd: &str,
+    prompt: Option<&str>,
+    resume: Option<&str>,
+) -> Result<LaunchRequest, String> {
+    let raw_cwd = if cwd.trim().is_empty() {
+        "."
+    } else {
+        cwd.trim()
+    };
+    let cwd_path = Path::new(raw_cwd)
+        .canonicalize()
+        .map_err(|_| format!("Directory not found: {raw_cwd}"))?;
+
+    if !cwd_path.is_dir() {
+        return Err(format!(
+            "Launch path is not a directory: {}",
+            cwd_path.display()
+        ));
+    }
+
+    let prompt = prompt
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned);
+    let resume = resume
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+
+    Ok(LaunchRequest {
+        cwd_path,
+        prompt,
+        resume,
+    })
+}
+
+pub fn launch(request: &LaunchRequest) -> Result<String, String> {
+    terminals::launch_session(
+        request.cwd_path.to_string_lossy().as_ref(),
+        request.prompt.as_deref(),
+        request.resume.as_deref(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prepare_normalizes_optional_fields() {
+        let temp = tempfile::tempdir().unwrap();
+        let request = prepare(
+            temp.path().to_string_lossy().as_ref(),
+            Some("ship it"),
+            Some("  session-123  "),
+        )
+        .unwrap();
+
+        assert_eq!(request.cwd_path, temp.path().canonicalize().unwrap());
+        assert_eq!(request.prompt.as_deref(), Some("ship it"));
+        assert_eq!(request.resume.as_deref(), Some("session-123"));
+    }
+
+    #[test]
+    fn prepare_rejects_missing_directory() {
+        let missing = "/tmp/claudectl-this-path-should-not-exist";
+        let err = prepare(missing, None, None).unwrap_err();
+        assert_eq!(err, format!("Directory not found: {missing}"));
+    }
+
+    #[test]
+    fn prepare_treats_blank_prompt_and_resume_as_none() {
+        let temp = tempfile::tempdir().unwrap();
+        let request = prepare(
+            temp.path().to_string_lossy().as_ref(),
+            Some("   "),
+            Some(""),
+        )
+        .unwrap();
+
+        assert_eq!(request.prompt, None);
+        assert_eq!(request.resume, None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod demo;
 pub mod discovery;
 pub mod history;
 pub mod hooks;
+pub mod launch;
 pub mod logger;
 pub mod models;
 pub mod monitor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod demo;
 mod discovery;
 mod history;
 mod hooks;
+mod launch;
 mod logger;
 mod models;
 mod monitor;
@@ -372,16 +373,15 @@ fn main() -> io::Result<()> {
 }
 
 fn launch_session(cwd: &str, prompt: Option<&str>, resume: Option<&str>) -> io::Result<()> {
-    let cwd_path = std::path::Path::new(cwd)
-        .canonicalize()
-        .unwrap_or_else(|_| std::path::PathBuf::from(cwd));
+    let request = launch::prepare(cwd, prompt, resume).map_err(io::Error::other)?;
 
-    match terminals::launch_session(cwd_path.to_string_lossy().as_ref(), prompt, resume) {
+    match launch::launch(&request) {
         Ok(target) => {
             println!(
-                "Launched Claude session in {} at {}",
+                "Launched Claude session in {} at {}{}",
                 target,
-                cwd_path.display()
+                request.cwd_path.display(),
+                request.option_summary()
             );
             Ok(())
         }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -74,7 +74,15 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
         ]),
         Line::from(vec![
             Span::styled("  n              ", Style::default().fg(t.highlight_key)),
-            Span::raw("  Launch new Claude session (tmux/Kitty/WezTerm)"),
+            Span::raw("  Launch wizard for cwd, prompt, and resume (tmux/Kitty/WezTerm)"),
+        ]),
+        Line::from(vec![
+            Span::styled("  Enter/Tab      ", Style::default().fg(t.highlight_key)),
+            Span::raw("  In launch wizard: next field / move fields"),
+        ]),
+        Line::from(vec![
+            Span::styled("  Ctrl+Enter     ", Style::default().fg(t.highlight_key)),
+            Span::raw("  In launch wizard: launch immediately"),
         ]),
         Line::from(vec![
             Span::styled("  c              ", Style::default().fg(t.highlight_key)),

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -25,11 +25,22 @@ pub fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
     } else if app.launch_mode {
         let msg = Paragraph::new(Line::from(vec![
             Span::styled(
-                " new> ",
+                format!(" new[{}]> ", app.launch_form.field.label()),
                 Style::default().fg(t.success).add_modifier(Modifier::BOLD),
             ),
-            Span::styled(&*app.launch_buffer, Style::default().fg(t.text_primary)),
+            Span::styled(
+                app.launch_form.active_buffer(),
+                Style::default().fg(t.text_primary),
+            ),
             Span::styled("_", Style::default().fg(t.text_muted)),
+            Span::styled(
+                format!("  {}", app.launch_form.summary()),
+                Style::default().fg(t.text_muted),
+            ),
+            Span::styled(
+                "  Enter next  Ctrl+Enter launch",
+                Style::default().fg(t.text_muted),
+            ),
         ]));
         frame.render_widget(msg, area);
     } else if app.input_mode {

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -43,7 +43,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     // Empty state: show onboarding message when no sessions found
     if app.sessions.is_empty() {
         let launch_hint = if crate::terminals::can_launch_session() {
-            "  Press n to launch a new session, or start claude in another terminal."
+            "  Press n for the launch wizard, or start claude in another terminal."
         } else {
             "  Start claude in tmux, Kitty, WezTerm, or another terminal."
         };


### PR DESCRIPTION
## Summary
- add a multi-step TUI launch wizard for cwd, prompt, and resume instead of the old single-path input
- share launch preparation and validation between the CLI and TUI so both paths reject invalid directories before dispatch
- improve TUI launch feedback, status-bar guidance, and docs/help text for the new flow

## Testing
- 
- 
running 41 tests
test config::tests::test_parse_bool ... ok
test config::tests::test_config_layering ... ok
test config::tests::test_unquote ... ok
test config::tests::test_parse_string_array ... ok
test history::tests::test_is_leap ... ok
test history::tests::test_format_duration ... ok
test history::tests::test_parse_duration ... ok
test history::tests::test_parse_timestamp_epoch ... ok
test config::tests::test_parse_config_file ... ok
test history::tests::test_truncate ... ok
test hooks::tests::test_expand_template ... ok
test hooks::tests::test_expand_all_vars ... ok
test hooks::tests::test_expand_context_pct ... ok
test hooks::tests::test_hook_event_from_section ... ok
test hooks::tests::test_registry_add_and_fire ... ok
test launch::tests::prepare_rejects_missing_directory ... ok
test logger::tests::test_days_to_date_epoch ... ok
test logger::tests::test_days_to_date_known ... ok
test launch::tests::prepare_normalizes_optional_fields ... ok
test logger::tests::test_log_without_init ... ok
test models::tests::resolve_builtin_profile ... ok
test models::tests::resolve_fallback_profile ... ok
test models::tests::resolve_override_profile ... ok
test launch::tests::prepare_treats_blank_prompt_and_resume_as_none ... ok
test orchestrator::tests::test_dependency_validation ... ok
test orchestrator::tests::test_load_tasks_json ... ok
test orchestrator::tests::test_sanitize_task_name ... ok
test terminals::tests::help_summary_lists_kitty_actions ... ok
test terminals::tests::help_summary_marks_unknown_terminal_monitor_only ... ok
test logger::tests::test_init_and_log ... ok
test terminals::tests::doctor_report_for_unknown_terminal_marks_actions_unsupported ... ok
test transcript::tests::parse_legacy_fixture_line ... ok
test transcript::tests::parse_waiting_for_task_progress ... ok
test transcript::tests::parse_real_fixture_line ... ok
test app::tests::invalid_launch_keeps_wizard_open_and_reports_error ... ok
test app::tests::launch_wizard_moves_between_fields ... ok
test app::tests::normalize_selection_clamps_to_filtered_session_count ... ok
test app::tests::status_filter_returns_only_matching_sessions ... ok
test app::tests::focus_filter_attention_matches_high_signal_sessions ... ok
test app::tests::launch_wizard_starts_with_cli_defaults ... ok
test app::tests::search_query_matches_project_and_model ... ok

test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.42s


running 41 tests
test config::tests::test_parse_bool ... ok
test config::tests::test_config_layering ... ok
test config::tests::test_unquote ... ok
test config::tests::test_parse_string_array ... ok
test history::tests::test_is_leap ... ok
test history::tests::test_format_duration ... ok
test config::tests::test_parse_config_file ... ok
test history::tests::test_parse_duration ... ok
test history::tests::test_parse_timestamp_epoch ... ok
test hooks::tests::test_expand_context_pct ... ok
test hooks::tests::test_expand_all_vars ... ok
test history::tests::test_truncate ... ok
test hooks::tests::test_hook_event_from_section ... ok
test hooks::tests::test_expand_template ... ok
test hooks::tests::test_registry_add_and_fire ... ok
test launch::tests::prepare_normalizes_optional_fields ... ok
test launch::tests::prepare_rejects_missing_directory ... ok
test logger::tests::test_days_to_date_known ... ok
test launch::tests::prepare_treats_blank_prompt_and_resume_as_none ... ok
test logger::tests::test_days_to_date_epoch ... ok
test logger::tests::test_log_without_init ... ok
test logger::tests::test_init_and_log ... ok
test models::tests::resolve_builtin_profile ... ok
test models::tests::resolve_fallback_profile ... ok
test models::tests::resolve_override_profile ... ok
test orchestrator::tests::test_dependency_validation ... ok
test orchestrator::tests::test_sanitize_task_name ... ok
test orchestrator::tests::test_load_tasks_json ... ok
test terminals::tests::doctor_report_for_unknown_terminal_marks_actions_unsupported ... ok
test terminals::tests::help_summary_lists_kitty_actions ... ok
test terminals::tests::help_summary_marks_unknown_terminal_monitor_only ... ok
test transcript::tests::parse_legacy_fixture_line ... ok
test transcript::tests::parse_waiting_for_task_progress ... ok
test transcript::tests::parse_real_fixture_line ... ok
test app::tests::focus_filter_attention_matches_high_signal_sessions ... ok
test app::tests::search_query_matches_project_and_model ... ok
test app::tests::launch_wizard_starts_with_cli_defaults ... ok
test app::tests::invalid_launch_keeps_wizard_open_and_reports_error ... ok
test app::tests::status_filter_returns_only_matching_sessions ... ok
test app::tests::normalize_selection_clamps_to_filtered_session_count ... ok
test app::tests::launch_wizard_moves_between_fields ... ok

test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.11s


running 52 tests
test context_percent_calculation ... ok
test context_percent_zero_max ... ok
test context_percent_zero_tokens ... ok
test cost_haiku_tokens ... ok
test burn_rate_formatting ... ok
test context_max_haiku ... ok
test context_bar_formatting ... ok
test cost_opus_tokens ... ok
test cost_sonnet_tokens ... ok
test cost_unknown_model_defaults_to_opus ... ok
test cost_zero_tokens ... ok
test json_export_format ... ok
test context_max_sonnet ... ok
test context_max_opus ... ok
test context_max_unknown ... ok
test jsonl_no_path ... ok
test jsonl_missing_file ... ok
test jsonl_corrupted_lines_skipped ... ok
test jsonl_parse_multiple_entries ... ok
test mem_formatting ... ok
test jsonl_waiting_for_task_detection ... ok
test jsonl_parse_token_usage ... ok
test jsonl_empty_file ... ok
test jsonl_incremental_reads ... ok
test recorder_cast_file_creation ... ok
test shorten_model_haiku ... ok
test shorten_model_opus_46 ... ok
test shorten_model_opus_generic ... ok
test shorten_model_sonnet_46 ... ok
test shorten_model_sonnet_generic ... ok
test session_recorder_empty_jsonl ... ok
test shorten_model_unknown ... ok
test sparkline_empty ... ok
test sparkline_ring_buffer_limit ... ok
test status_cpu_threshold_boundary ... ok
test status_end_turn_11min_idle ... ok
test status_end_turn_exactly_10min_still_waiting ... ok
test status_end_turn_old_idle ... ok
test sparkline_records_and_renders ... ok
test session_recorder_produces_highlight_reel ... ok
test status_end_turn_recent_waiting_input ... ok
test status_high_cpu_always_processing ... ok
test status_high_cpu_overrides_end_turn ... ok
test status_high_cpu_overrides_waiting_for_task ... ok
test status_no_signals_idle ... ok
test status_no_telemetry_unknown ... ok
test status_tool_use_high_cpu_processing ... ok
test status_tool_use_low_cpu_old_needs_input ... ok
test status_tool_use_low_cpu_recent_processing ... ok
test status_user_message_low_cpu_still_processing ... ok
test status_user_message_pending_processing ... ok
test status_waiting_for_task_needs_input ... ok

test result: ok. 52 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 8 tests
test test_cwd_to_project_name ... ok
test test_format_cost ... ok
test test_format_elapsed ... ok
test test_format_tokens ... ok
test test_session_display_name_prefers_session_name ... ok
test test_session_from_raw ... ok
test test_session_status_display ... ok
test test_session_status_sort_order ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
- 

Closes #71