### PR TITLE
[codex] Complete #67 subagent rollup UX and prepare 0.16.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  verify:
+    name: Verify tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure Cargo version matches tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)
+          test "$TAG" = "$VERSION"
+
   build:
     name: Build (${{ matrix.target }})
+    needs: verify
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -70,9 +82,27 @@ jobs:
             claudectl-*.tar.gz
             claudectl-*.tar.gz.sha256
 
+  publish-crate:
+    name: Publish crate
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked --token "$CARGO_REGISTRY_TOKEN"
+
   release:
     name: Release
-    needs: build
+    needs:
+      - build
+      - publish-crate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -89,3 +119,48 @@ jobs:
           files: |
             artifacts/claudectl-*.tar.gz
             artifacts/claudectl-*.tar.gz.sha256
+
+  update-homebrew:
+    name: Update Homebrew tap
+    needs:
+      - build
+      - release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: claudectl
+
+      - uses: actions/checkout@v4
+        with:
+          repository: mercurialsolo/homebrew-tap
+          path: homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Render formula
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          cd claudectl
+          ./scripts/render-homebrew-formula.sh \
+            "$VERSION" \
+            "$(awk '{print $1}' ../artifacts/claudectl-${TAG}-aarch64-apple-darwin.tar.gz.sha256)" \
+            "$(awk '{print $1}' ../artifacts/claudectl-${TAG}-x86_64-apple-darwin.tar.gz.sha256)" \
+            "$(awk '{print $1}' ../artifacts/claudectl-${TAG}-x86_64-unknown-linux-musl.tar.gz.sha256)" \
+            "$(awk '{print $1}' ../artifacts/claudectl-${TAG}-aarch64-unknown-linux-musl.tar.gz.sha256)" \
+            > ../homebrew-tap/Formula/claudectl.rb
+
+      - name: Commit formula update
+        run: |
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/claudectl.rb
+          git diff --cached --quiet && exit 0
+          git commit -m "claudectl ${GITHUB_REF#refs/tags/v}"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.16.0] - 2026-04-14
+
+### Added
+- GNOME Terminal support on Linux for `--new` and the `n` launch wizard, with doctor output that makes the current control limitations explicit
+- GNOME Terminal launch support for Ubuntu's default terminal, verified under Docker/X11
+- Homebrew release automation for both macOS and Linux artifacts, updating `mercurialsolo/homebrew-tap` on tagged releases
+
+### Fixed
+- Parent sessions now keep subagent token and cost rollups even when transient task files disappear from `/tmp`
+- Session detail and JSON output now distinguish active subagents from total rolled-up subagent usage
+- The main dashboard now expands parent sessions into child subagent rows, with a completed-subagent aggregate plus live active subagents underneath
+- Release automation now publishes to crates.io instead of stopping at GitHub release assets
+
 ## [0.15.5] - 2026-04-14
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.15.5"
+version = "0.16.0"
 edition = "2024"
 description = "TUI for monitoring and managing Claude Code CLI agents"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Mission control for Claude Code.**
 
-Monitor multiple Claude Code sessions in one terminal dashboard. Catch blocked agents, control token burn, approve actions, and orchestrate work across tmux, iTerm2, Ghostty, Warp, and more.
+Monitor multiple Claude Code sessions in one terminal dashboard. Catch blocked agents, control token burn, approve actions, and orchestrate work across GNOME Terminal, tmux, iTerm2, Ghostty, Warp, and more.
 
 [![CI](https://github.com/mercurialsolo/claudectl/actions/workflows/ci.yml/badge.svg)](https://github.com/mercurialsolo/claudectl/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/claudectl)](https://crates.io/crates/claudectl)
@@ -17,7 +17,7 @@ Monitor multiple Claude Code sessions in one terminal dashboard. Catch blocked a
 ## Install
 
 ```bash
-brew install mercurialsolo/tap/claudectl     # Homebrew (macOS)
+brew install mercurialsolo/tap/claudectl     # Homebrew (macOS / Linux)
 cargo install claudectl                       # Cargo (any platform)
 ```
 
@@ -186,6 +186,7 @@ claudectl --demo --record demo.gif  # One-command GIF for your README
 
 ### Dashboard
 - Live table: PID, project, status, context %, cost, $/hr burn rate, elapsed, CPU%, memory, tokens, sparkline
+- Parent sessions expand into subagent rows so you can see completed-subagent totals and currently active subagents separately
 - Detail panel (`Enter`) with full session metadata
 - Grouped view (`g`) by project with aggregate stats
 - Sort by status, context, cost, burn rate, or elapsed (`s`)
@@ -224,7 +225,7 @@ Multi-signal inference from CPU usage, JSONL events, and timestamps:
 | `i` | Input mode (type text to session) |
 | `d`/`x` | Kill session (double-tap to confirm) |
 | `a` | Toggle auto-approve (double-tap to confirm) |
-| `n` | Launch wizard for cwd, prompt, and resume (`tmux`, Kitty, WezTerm) |
+| `n` | Launch wizard for cwd, prompt, and resume (GNOME Terminal, `tmux`, Kitty, WezTerm) |
 | `g` | Toggle grouped view by project |
 | `s` | Cycle sort column |
 | `f` | Cycle status filter |
@@ -243,6 +244,7 @@ Use `claudectl --doctor` to check the current terminal's launch/switch/input sup
 
 | Terminal | Tab Switch | Approve/Input | Method |
 |----------|-----------|---------------|--------|
+| **GNOME Terminal** | - | - | Visible launch via `gnome-terminal --window` |
 | **Ghostty** | Background | Background | Native AppleScript API |
 | **Kitty** | Background | Background | `kitty @` remote control |
 | **tmux** | Background | Background | `tmux send-keys` |
@@ -251,7 +253,7 @@ Use `claudectl --doctor` to check the current terminal's launch/switch/input sup
 | **iTerm2** | Focus switch | Focus switch | AppleScript + System Events |
 | **Terminal.app** | Focus switch | Focus switch | AppleScript + System Events |
 
-**Notes:** Ghostty has the best support — no config needed. Kitty requires `allow_remote_control yes` in config. Warp, iTerm2, and Terminal.app require macOS Automation/Accessibility permission. tmux is auto-detected. Run `claudectl --doctor` from the same terminal you use for Claude to verify the current setup.
+**Notes:** GNOME Terminal launch works on Linux and is verified under Docker/X11, but remote focus/input automation is intentionally not exposed yet. Ghostty has the best support on macOS with no extra config. Kitty requires `allow_remote_control yes` in config. Warp, iTerm2, and Terminal.app require macOS Automation/Accessibility permission. tmux is auto-detected. Run `claudectl --doctor` from the same terminal you use for Claude to verify the current setup.
 
 ### Themes
 - Dark, light, and monochrome (`--theme`)
@@ -360,6 +362,7 @@ Status inference combines multiple signals: `waiting_for_task` events, CPU usage
 
 **Tab switching doesn't work**
 - Run `claudectl --doctor` first to see the detected terminal, missing prerequisites, and supported actions
+- GNOME Terminal: launch support is available; use tmux or Kitty if you need remote switching or input automation
 - Ghostty: should work out of the box
 - Kitty: add `allow_remote_control yes` to `~/.config/kitty/kitty.conf`
 - Warp/iTerm2/Terminal.app: grant Automation/Accessibility permission in System Settings > Privacy & Security

--- a/scripts/render-homebrew-formula.sh
+++ b/scripts/render-homebrew-formula.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -eu
+
+VERSION="${1:?version is required}"
+MACOS_ARM_SHA="${2:?macOS arm64 sha is required}"
+MACOS_INTEL_SHA="${3:?macOS x86_64 sha is required}"
+LINUX_INTEL_SHA="${4:?Linux x86_64 sha is required}"
+LINUX_ARM_SHA="${5:?Linux arm64 sha is required}"
+
+TAG="v${VERSION}"
+BASE_URL="https://github.com/mercurialsolo/claudectl/releases/download/${TAG}"
+
+cat <<EOF
+class Claudectl < Formula
+  desc "TUI for monitoring and managing Claude Code CLI sessions"
+  homepage "https://github.com/mercurialsolo/claudectl"
+  version "${VERSION}"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "${BASE_URL}/claudectl-${TAG}-aarch64-apple-darwin.tar.gz"
+      sha256 "${MACOS_ARM_SHA}"
+    end
+
+    on_intel do
+      url "${BASE_URL}/claudectl-${TAG}-x86_64-apple-darwin.tar.gz"
+      sha256 "${MACOS_INTEL_SHA}"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "${BASE_URL}/claudectl-${TAG}-aarch64-unknown-linux-musl.tar.gz"
+      sha256 "${LINUX_ARM_SHA}"
+    end
+
+    on_intel do
+      url "${BASE_URL}/claudectl-${TAG}-x86_64-unknown-linux-musl.tar.gz"
+      sha256 "${LINUX_INTEL_SHA}"
+    end
+  end
+
+  def install
+    bin.install "claudectl"
+  end
+
+  test do
+    assert_match "claudectl", shell_output("#{bin}/claudectl --version 2>&1", 0)
+  end
+end
+EOF

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -132,6 +132,10 @@ pub fn scan_subagents(sessions: &mut [ClaudeSession]) {
     let tmp_base = PathBuf::from(format!("/tmp/claude-{uid}"));
 
     if !tmp_base.exists() {
+        for session in sessions.iter_mut() {
+            session.active_subagent_count = 0;
+            session.active_subagent_jsonl_paths.clear();
+        }
         return;
     }
 
@@ -140,18 +144,33 @@ pub fn scan_subagents(sessions: &mut [ClaudeSession]) {
         let tasks_dir = tmp_base.join(&slug).join(&session.session_id).join("tasks");
 
         if !tasks_dir.exists() {
+            session.active_subagent_count = 0;
+            session.active_subagent_jsonl_paths.clear();
             continue;
         }
 
-        let count = match fs::read_dir(&tasks_dir) {
-            Ok(entries) => entries
-                .flatten()
-                .filter(|e| e.path().extension().and_then(|ext| ext.to_str()) == Some("jsonl"))
-                .count(),
-            Err(_) => 0,
-        };
+        let mut jsonls = Vec::new();
+        collect_subagent_jsonls(&tasks_dir, &mut jsonls);
+        jsonls.sort();
+        session.active_subagent_count = jsonls.len();
+        session.active_subagent_jsonl_paths = jsonls;
+    }
+}
 
-        session.subagent_count = count;
+fn collect_subagent_jsonls(dir: &PathBuf, jsonls: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_subagent_jsonls(&path, jsonls);
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
+            jsonls.push(path);
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -714,7 +714,7 @@ fn print_summary(since: &str) -> io::Result<()> {
         }
 
         if s.subagent_count > 0 {
-            println!("  Subagents: {}", s.subagent_count);
+            println!("  Subagents: {}", s.format_subagent_summary());
         }
 
         println!();

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -4,153 +4,227 @@ use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use serde_json::Value;
 
 use crate::models;
-use crate::session::{ClaudeSession, SessionStatus, TelemetryStatus};
+use crate::session::{ClaudeSession, SessionStatus, SubagentRollup, TelemetryStatus};
 use crate::transcript::{TranscriptBlock, TranscriptEvent, TranscriptRole, parse_line};
+
+#[derive(Default)]
+struct UsageRollup {
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_tokens: u64,
+    cache_write_tokens: u64,
+    cost_usd: f64,
+    usage_metrics_available: bool,
+    cost_estimate_unverified: bool,
+}
+
+impl UsageRollup {
+    fn total_input_tokens(&self) -> u64 {
+        self.input_tokens + self.cache_read_tokens + self.cache_write_tokens
+    }
+}
 
 /// Read new JSONL entries since last offset, accumulate token stats.
 pub fn update_tokens(session: &mut ClaudeSession) {
-    let Some(ref path) = session.jsonl_path else {
-        session.telemetry_status = TelemetryStatus::MissingTranscript;
-        return;
-    };
-
-    let mut file = match File::open(path) {
-        Ok(f) => f,
-        Err(_) => {
-            session.telemetry_status = TelemetryStatus::UnreadableTranscript;
-            return;
-        }
-    };
-
-    let file_len = file.metadata().map(|m| m.len()).unwrap_or(0);
-
-    if file_len == 0 {
-        session.telemetry_status = TelemetryStatus::Pending;
-        return;
-    }
-
-    if session.jsonl_offset > file_len {
-        session.jsonl_offset = 0;
-    }
-
-    if session.jsonl_offset > 0 && session.jsonl_offset >= file_len {
-        return;
-    }
-
-    if session.jsonl_offset > 0 && file.seek(SeekFrom::Start(session.jsonl_offset)).is_err() {
-        return;
-    }
-
-    let reader = BufReader::new(&file);
     let mut last_type = String::new();
     let mut last_stop_reason = String::new();
     let mut is_waiting_for_task = false;
     let mut saw_non_empty_line = false;
     let mut recognized_events = 0usize;
+    let mut saw_parent_usage = false;
+    let jsonl_path = session.jsonl_path.clone();
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => break,
-        };
+    match jsonl_path.as_ref() {
+        Some(path) => {
+            let mut file = match File::open(path) {
+                Ok(f) => f,
+                Err(_) => {
+                    session.telemetry_status = TelemetryStatus::UnreadableTranscript;
+                    finalize_usage(
+                        session,
+                        &last_type,
+                        &last_stop_reason,
+                        is_waiting_for_task,
+                        false,
+                    );
+                    return;
+                }
+            };
 
-        if line.trim().is_empty() {
-            continue;
-        }
-        saw_non_empty_line = true;
+            let file_len = file.metadata().map(|m| m.len()).unwrap_or(0);
 
-        let Some(event) = parse_line(&line) else {
-            continue;
-        };
-        recognized_events += 1;
+            if file_len == 0 {
+                session.telemetry_status = TelemetryStatus::Pending;
+            } else {
+                if session.jsonl_offset > file_len {
+                    session.jsonl_offset = 0;
+                    session.own_input_tokens = 0;
+                    session.own_output_tokens = 0;
+                    session.own_cache_read_tokens = 0;
+                    session.own_cache_write_tokens = 0;
+                }
 
-        match event {
-            TranscriptEvent::WaitingForTask => {
-                is_waiting_for_task = true;
-            }
-            TranscriptEvent::Message(message) => {
-                is_waiting_for_task = false;
-                last_type = match message.role {
-                    TranscriptRole::Assistant => "assistant".to_string(),
-                    TranscriptRole::User => "user".to_string(),
-                };
+                if session.jsonl_offset < file_len {
+                    if session.jsonl_offset > 0
+                        && file.seek(SeekFrom::Start(session.jsonl_offset)).is_err()
+                    {
+                        finalize_usage(
+                            session,
+                            &last_type,
+                            &last_stop_reason,
+                            is_waiting_for_task,
+                            false,
+                        );
+                        return;
+                    }
 
-                if let Some(reason) = message.stop_reason {
-                    last_stop_reason = reason;
+                    let reader = BufReader::new(&file);
+
+                    for line in reader.lines() {
+                        let line = match line {
+                            Ok(l) => l,
+                            Err(_) => break,
+                        };
+
+                        if line.trim().is_empty() {
+                            continue;
+                        }
+                        saw_non_empty_line = true;
+
+                        let Some(event) = parse_line(&line) else {
+                            continue;
+                        };
+                        recognized_events += 1;
+
+                        match event {
+                            TranscriptEvent::WaitingForTask => {
+                                is_waiting_for_task = true;
+                            }
+                            TranscriptEvent::Message(message) => {
+                                is_waiting_for_task = false;
+                                last_type = match message.role {
+                                    TranscriptRole::Assistant => "assistant".to_string(),
+                                    TranscriptRole::User => "user".to_string(),
+                                };
+
+                                if let Some(reason) = message.stop_reason {
+                                    last_stop_reason = reason;
+                                } else {
+                                    last_stop_reason.clear();
+                                }
+
+                                if let Some(usage) = message.usage {
+                                    let input = usage.input_tokens;
+                                    let cache_read = usage.cache_read_input_tokens;
+                                    let cache_create = usage.cache_creation_input_tokens;
+                                    let output = usage.output_tokens;
+
+                                    session.own_input_tokens += input + cache_read + cache_create;
+                                    session.own_output_tokens += output;
+                                    session.own_cache_read_tokens += cache_read;
+                                    session.own_cache_write_tokens += cache_create;
+                                    saw_parent_usage = true;
+
+                                    // Track context window: the input_tokens of the LAST API call
+                                    // represents the current prompt/context size
+                                    let context_size = input + cache_read + cache_create;
+                                    if context_size > 0 {
+                                        session.context_tokens = context_size;
+                                    }
+                                }
+
+                                if let Some(model) = message.model {
+                                    session.model = shorten_model(&model);
+                                }
+
+                                for block in message.content {
+                                    if let TranscriptBlock::ToolUse { name, input } = block {
+                                        record_tool_usage(&name, &input, session);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if recognized_events > 0 || session.telemetry_status.is_available() {
+                    session.telemetry_status = TelemetryStatus::Available;
+                } else if saw_non_empty_line {
+                    session.telemetry_status = TelemetryStatus::UnsupportedTranscript;
                 } else {
-                    last_stop_reason.clear();
+                    session.telemetry_status = TelemetryStatus::Pending;
                 }
 
-                if let Some(usage) = message.usage {
-                    let input = usage.input_tokens;
-                    let cache_read = usage.cache_read_input_tokens;
-                    let cache_create = usage.cache_creation_input_tokens;
-                    let output = usage.output_tokens;
+                session.jsonl_offset = file_len;
+            }
 
-                    session.total_input_tokens += input + cache_read + cache_create;
-                    session.total_output_tokens += output;
-                    session.cache_read_tokens += cache_read;
-                    session.cache_write_tokens += cache_create;
-                    session.usage_metrics_available = true;
-
-                    // Track context window: the input_tokens of the LAST API call
-                    // represents the current prompt/context size
-                    let context_size = input + cache_read + cache_create;
-                    if context_size > 0 {
-                        session.context_tokens = context_size;
-                    }
-                }
-
-                if let Some(model) = message.model {
-                    session.model = shorten_model(&model);
-                }
-
-                for block in message.content {
-                    if let TranscriptBlock::ToolUse { name, input } = block {
-                        record_tool_usage(&name, &input, session);
-                    }
+            if let Ok(meta) = std::fs::metadata(path) {
+                if let Ok(modified) = meta.modified() {
+                    let mtime_ms = modified
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_millis() as u64;
+                    session.last_message_ts = mtime_ms;
                 }
             }
         }
-    }
-
-    if recognized_events > 0 || session.telemetry_status.is_available() {
-        session.telemetry_status = TelemetryStatus::Available;
-    } else if saw_non_empty_line {
-        session.telemetry_status = TelemetryStatus::UnsupportedTranscript;
-    } else {
-        session.telemetry_status = TelemetryStatus::Pending;
-    }
-
-    session.jsonl_offset = file_len;
-
-    // Use the JSONL file's mtime as "last activity" — reliable, no timestamp parsing needed
-    if let Some(ref path) = session.jsonl_path {
-        if let Ok(meta) = std::fs::metadata(path) {
-            if let Ok(modified) = meta.modified() {
-                let mtime_ms = modified
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_millis() as u64;
-                session.last_message_ts = mtime_ms;
-            }
+        None => {
+            session.telemetry_status = TelemetryStatus::MissingTranscript;
         }
     }
 
+    finalize_usage(
+        session,
+        &last_type,
+        &last_stop_reason,
+        is_waiting_for_task,
+        saw_parent_usage,
+    );
+}
+
+fn finalize_usage(
+    session: &mut ClaudeSession,
+    last_type: &str,
+    last_stop_reason: &str,
+    is_waiting_for_task: bool,
+    saw_parent_usage: bool,
+) {
     let resolved_profile = models::resolve(&session.model);
     session.context_max = resolved_profile.profile.context_max;
-    session.cost_estimate_unverified =
-        resolved_profile.source == models::ModelProfileSource::Fallback;
     session.model_profile_source = resolved_profile.source.label().to_string();
 
-    // Compute cost estimate based on model pricing
-    session.cost_usd = if session.usage_metrics_available {
-        estimate_cost(session)
-    } else {
-        0.0
-    };
+    let subagent_rollup = refresh_subagent_rollups(session);
+    session.subagent_input_tokens = subagent_rollup.total_input_tokens();
+    session.subagent_output_tokens = subagent_rollup.output_tokens;
+    session.subagent_cache_read_tokens = subagent_rollup.cache_read_tokens;
+    session.subagent_cache_write_tokens = subagent_rollup.cache_write_tokens;
+    session.subagent_count = session.subagent_rollups.len();
 
-    infer_status(session, &last_type, &last_stop_reason, is_waiting_for_task);
+    session.total_input_tokens = session.own_input_tokens + session.subagent_input_tokens;
+    session.total_output_tokens = session.own_output_tokens + session.subagent_output_tokens;
+    session.cache_read_tokens = session.own_cache_read_tokens + session.subagent_cache_read_tokens;
+    session.cache_write_tokens =
+        session.own_cache_write_tokens + session.subagent_cache_write_tokens;
+
+    let own_usage_metrics_available = saw_parent_usage
+        || session.own_input_tokens > 0
+        || session.own_output_tokens > 0
+        || session.own_cache_read_tokens > 0
+        || session.own_cache_write_tokens > 0;
+    let (own_cost, own_cost_unverified) = estimate_cost_components(
+        &session.model,
+        session.own_input_tokens,
+        session.own_output_tokens,
+        session.own_cache_read_tokens,
+        session.own_cache_write_tokens,
+    );
+    session.cost_usd = own_cost + subagent_rollup.cost_usd;
+    session.usage_metrics_available =
+        own_usage_metrics_available || subagent_rollup.usage_metrics_available;
+    session.cost_estimate_unverified = (own_usage_metrics_available && own_cost_unverified)
+        || subagent_rollup.cost_estimate_unverified;
+
+    infer_status(session, last_type, last_stop_reason, is_waiting_for_task);
 }
 
 pub fn infer_status(
@@ -228,19 +302,16 @@ pub fn infer_status(
 }
 
 /// Estimate USD cost based on token usage and model.
+#[allow(dead_code)]
 pub fn estimate_cost(session: &ClaudeSession) -> f64 {
-    // Plain input tokens = total_input - cache_read - cache_write
-    let plain_input = session
-        .total_input_tokens
-        .saturating_sub(session.cache_read_tokens)
-        .saturating_sub(session.cache_write_tokens);
-
-    let profile = models::resolve(&session.model).profile;
-
-    (plain_input as f64 / 1_000_000.0) * profile.input_per_m
-        + (session.total_output_tokens as f64 / 1_000_000.0) * profile.output_per_m
-        + (session.cache_read_tokens as f64 / 1_000_000.0) * profile.cache_read_per_m
-        + (session.cache_write_tokens as f64 / 1_000_000.0) * profile.cache_write_per_m
+    estimate_cost_components(
+        &session.model,
+        session.total_input_tokens,
+        session.total_output_tokens,
+        session.cache_read_tokens,
+        session.cache_write_tokens,
+    )
+    .0
 }
 
 /// Max context window tokens by model.
@@ -269,4 +340,121 @@ fn record_tool_usage(tool_name: &str, input: &Value, session: &mut ClaudeSession
 
 pub fn shorten_model(model: &str) -> String {
     models::shorten_model(model)
+}
+
+fn refresh_subagent_rollups(session: &mut ClaudeSession) -> UsageRollup {
+    for path in session.active_subagent_jsonl_paths.clone() {
+        let rollup = session.subagent_rollups.entry(path.clone()).or_default();
+        update_subagent_rollup(&path, rollup, &session.model);
+    }
+
+    let mut totals = UsageRollup::default();
+    for rollup in session.subagent_rollups.values() {
+        totals.input_tokens += rollup.input_tokens;
+        totals.output_tokens += rollup.output_tokens;
+        totals.cache_read_tokens += rollup.cache_read_tokens;
+        totals.cache_write_tokens += rollup.cache_write_tokens;
+        totals.cost_usd += rollup.cost_usd;
+        totals.usage_metrics_available |= rollup.usage_metrics_available;
+        totals.cost_estimate_unverified |= rollup.cost_estimate_unverified;
+    }
+    totals
+}
+
+fn update_subagent_rollup(
+    path: &std::path::Path,
+    rollup: &mut SubagentRollup,
+    default_model: &str,
+) {
+    let mut file = match File::open(path) {
+        Ok(file) => file,
+        Err(_) => return,
+    };
+
+    let file_len = file.metadata().map(|meta| meta.len()).unwrap_or(0);
+    if rollup.jsonl_offset > file_len {
+        *rollup = SubagentRollup::default();
+    }
+
+    if rollup.jsonl_offset >= file_len {
+        rollup.jsonl_offset = file_len;
+        return;
+    }
+
+    if rollup.jsonl_offset > 0 && file.seek(SeekFrom::Start(rollup.jsonl_offset)).is_err() {
+        return;
+    }
+
+    let mut current_model = if rollup.model.is_empty() {
+        default_model.to_string()
+    } else {
+        rollup.model.clone()
+    };
+
+    let reader = BufReader::new(&file);
+    for line in reader.lines() {
+        let Ok(line) = line else {
+            break;
+        };
+        let Some(TranscriptEvent::Message(message)) = parse_line(&line) else {
+            continue;
+        };
+
+        if let Some(model) = message.model {
+            current_model = shorten_model(&model);
+            rollup.model = current_model.clone();
+        }
+
+        let Some(usage) = message.usage else {
+            continue;
+        };
+
+        rollup.input_tokens += usage.input_tokens;
+        rollup.output_tokens += usage.output_tokens;
+        rollup.cache_read_tokens += usage.cache_read_input_tokens;
+        rollup.cache_write_tokens += usage.cache_creation_input_tokens;
+        rollup.usage_metrics_available = true;
+
+        let input_with_cache =
+            usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens;
+        let model_for_cost = if current_model.is_empty() {
+            default_model
+        } else {
+            current_model.as_str()
+        };
+        let (delta_cost, unverified) = estimate_cost_components(
+            model_for_cost,
+            input_with_cache,
+            usage.output_tokens,
+            usage.cache_read_input_tokens,
+            usage.cache_creation_input_tokens,
+        );
+        rollup.cost_usd += delta_cost;
+        rollup.cost_estimate_unverified |= unverified;
+    }
+
+    rollup.jsonl_offset = file_len;
+}
+
+fn estimate_cost_components(
+    model: &str,
+    total_input_tokens: u64,
+    total_output_tokens: u64,
+    cache_read_tokens: u64,
+    cache_write_tokens: u64,
+) -> (f64, bool) {
+    let plain_input = total_input_tokens
+        .saturating_sub(cache_read_tokens)
+        .saturating_sub(cache_write_tokens);
+    let resolved = models::resolve(model);
+
+    let cost = (plain_input as f64 / 1_000_000.0) * resolved.profile.input_per_m
+        + (total_output_tokens as f64 / 1_000_000.0) * resolved.profile.output_per_m
+        + (cache_read_tokens as f64 / 1_000_000.0) * resolved.profile.cache_read_per_m
+        + (cache_write_tokens as f64 / 1_000_000.0) * resolved.profile.cache_write_per_m;
+
+    (
+        cost,
+        resolved.source == models::ModelProfileSource::Fallback,
+    )
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde::Deserialize;
@@ -100,6 +100,14 @@ pub struct ClaudeSession {
     pub cpu_percent: f32,
     pub cpu_history: Vec<f32>, // Last N CPU readings for smoothing
     pub mem_mb: f64,
+    pub own_input_tokens: u64,
+    pub own_output_tokens: u64,
+    pub own_cache_read_tokens: u64,
+    pub own_cache_write_tokens: u64,
+    pub subagent_input_tokens: u64,
+    pub subagent_output_tokens: u64,
+    pub subagent_cache_read_tokens: u64,
+    pub subagent_cache_write_tokens: u64,
     pub total_input_tokens: u64,
     pub total_output_tokens: u64,
     pub model: String,
@@ -116,6 +124,9 @@ pub struct ClaudeSession {
     pub prev_cost_usd: f64,
     pub burn_rate_per_hr: f64,
     pub subagent_count: usize,
+    pub active_subagent_count: usize,
+    pub active_subagent_jsonl_paths: Vec<PathBuf>,
+    pub subagent_rollups: HashMap<PathBuf, SubagentRollup>,
     pub activity_history: Vec<u8>, // Ring buffer of status levels (0-7) for sparkline, one per tick
     pub files_modified: HashMap<String, u32>, // file path -> edit count
     pub tool_usage: HashMap<String, ToolStats>, // tool name -> call count & tokens
@@ -130,6 +141,102 @@ pub struct ClaudeSession {
 #[derive(Debug, Clone, Default)]
 pub struct ToolStats {
     pub calls: u32,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SubagentRollup {
+    pub jsonl_offset: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_write_tokens: u64,
+    pub cost_usd: f64,
+    pub model: String,
+    pub cost_estimate_unverified: bool,
+    pub usage_metrics_available: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubagentState {
+    Active,
+    Completed,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubagentBreakdown {
+    pub label: String,
+    pub state: SubagentState,
+    pub count: usize,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_write_tokens: u64,
+    pub cost_usd: f64,
+    pub usage_metrics_available: bool,
+    pub cost_estimate_unverified: bool,
+}
+
+impl SubagentBreakdown {
+    pub fn total_input_tokens(&self) -> u64 {
+        self.input_tokens + self.cache_read_tokens + self.cache_write_tokens
+    }
+
+    pub fn state_label(&self) -> String {
+        match self.state {
+            SubagentState::Active => "Active".to_string(),
+            SubagentState::Completed if self.count > 1 => format!("Completed ({})", self.count),
+            SubagentState::Completed => "Completed".to_string(),
+        }
+    }
+
+    pub fn display_label(&self) -> String {
+        if self.state == SubagentState::Completed && self.label == "completed" && self.count > 1 {
+            format!("completed ({})", self.count)
+        } else {
+            self.label.clone()
+        }
+    }
+
+    pub fn format_tokens(&self) -> String {
+        if !self.usage_metrics_available {
+            return "n/a".to_string();
+        }
+        let total = self.total_input_tokens() + self.output_tokens;
+        if total == 0 {
+            return "-".to_string();
+        }
+        format_count(self.total_input_tokens()) + "/" + &format_count(self.output_tokens)
+    }
+
+    pub fn format_cost(&self) -> String {
+        if !self.usage_metrics_available {
+            return "n/a".to_string();
+        }
+        if self.cost_usd < 0.01 {
+            return "-".to_string();
+        }
+        if self.cost_usd < 1.0 {
+            format!(
+                "${:.2}{}",
+                self.cost_usd,
+                if self.cost_estimate_unverified {
+                    "?"
+                } else {
+                    ""
+                }
+            )
+        } else {
+            format!(
+                "${:.1}{}",
+                self.cost_usd,
+                if self.cost_estimate_unverified {
+                    "?"
+                } else {
+                    ""
+                }
+            )
+        }
+    }
 }
 
 impl ClaudeSession {
@@ -155,6 +262,14 @@ impl ClaudeSession {
             cpu_percent: 0.0,
             cpu_history: Vec::new(),
             mem_mb: 0.0,
+            own_input_tokens: 0,
+            own_output_tokens: 0,
+            own_cache_read_tokens: 0,
+            own_cache_write_tokens: 0,
+            subagent_input_tokens: 0,
+            subagent_output_tokens: 0,
+            subagent_cache_read_tokens: 0,
+            subagent_cache_write_tokens: 0,
             total_input_tokens: 0,
             total_output_tokens: 0,
             model: String::new(),
@@ -171,6 +286,9 @@ impl ClaudeSession {
             prev_cost_usd: 0.0,
             burn_rate_per_hr: 0.0,
             subagent_count: 0,
+            active_subagent_count: 0,
+            active_subagent_jsonl_paths: Vec::new(),
+            subagent_rollups: HashMap::new(),
             activity_history: Vec::new(),
             files_modified: HashMap::new(),
             tool_usage: HashMap::new(),
@@ -220,6 +338,87 @@ impl ClaudeSession {
         } else {
             &self.project_name
         }
+    }
+
+    pub fn format_subagent_summary(&self) -> String {
+        if self.subagent_count == 0 {
+            return "0".to_string();
+        }
+        if self.active_subagent_count == 0 || self.active_subagent_count == self.subagent_count {
+            return self.subagent_count.to_string();
+        }
+        format!(
+            "{} total ({} active)",
+            self.subagent_count, self.active_subagent_count
+        )
+    }
+
+    pub fn subagent_breakdown(&self) -> Vec<SubagentBreakdown> {
+        if self.subagent_rollups.is_empty() {
+            return Vec::new();
+        }
+
+        let active_paths: HashSet<&PathBuf> = self.active_subagent_jsonl_paths.iter().collect();
+        let mut active_rows = Vec::new();
+        let mut completed_rows = Vec::new();
+
+        for (path, rollup) in &self.subagent_rollups {
+            let row = SubagentBreakdown {
+                label: subagent_label(path),
+                state: if active_paths.contains(path) {
+                    SubagentState::Active
+                } else {
+                    SubagentState::Completed
+                },
+                count: 1,
+                input_tokens: rollup.input_tokens,
+                output_tokens: rollup.output_tokens,
+                cache_read_tokens: rollup.cache_read_tokens,
+                cache_write_tokens: rollup.cache_write_tokens,
+                cost_usd: rollup.cost_usd,
+                usage_metrics_available: rollup.usage_metrics_available,
+                cost_estimate_unverified: rollup.cost_estimate_unverified,
+            };
+
+            if row.state == SubagentState::Active {
+                active_rows.push(row);
+            } else {
+                completed_rows.push(row);
+            }
+        }
+
+        active_rows.sort_by(|a, b| a.label.cmp(&b.label));
+
+        let mut rows = Vec::new();
+        if !completed_rows.is_empty() {
+            let mut aggregate = SubagentBreakdown {
+                label: "completed".to_string(),
+                state: SubagentState::Completed,
+                count: completed_rows.len(),
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+                cost_usd: 0.0,
+                usage_metrics_available: false,
+                cost_estimate_unverified: false,
+            };
+
+            for row in completed_rows {
+                aggregate.input_tokens += row.input_tokens;
+                aggregate.output_tokens += row.output_tokens;
+                aggregate.cache_read_tokens += row.cache_read_tokens;
+                aggregate.cache_write_tokens += row.cache_write_tokens;
+                aggregate.cost_usd += row.cost_usd;
+                aggregate.usage_metrics_available |= row.usage_metrics_available;
+                aggregate.cost_estimate_unverified |= row.cost_estimate_unverified;
+            }
+
+            rows.push(aggregate);
+        }
+
+        rows.extend(active_rows);
+        rows
     }
 
     pub fn format_elapsed(&self) -> String {
@@ -372,6 +571,29 @@ impl ClaudeSession {
             "tokens_in": tokens_in,
             "tokens_out": tokens_out,
             "subagents": self.subagent_count,
+            "active_subagents": self.active_subagent_count,
+            "subagent_breakdown": self.subagent_breakdown().into_iter().map(|row| {
+                serde_json::json!({
+                    "label": row.display_label(),
+                    "state": row.state_label(),
+                    "count": row.count,
+                    "tokens_in": if row.usage_metrics_available {
+                        serde_json::json!(row.total_input_tokens())
+                    } else {
+                        serde_json::Value::Null
+                    },
+                    "tokens_out": if row.usage_metrics_available {
+                        serde_json::json!(row.output_tokens)
+                    } else {
+                        serde_json::Value::Null
+                    },
+                    "cost_usd": if row.usage_metrics_available {
+                        serde_json::json!((row.cost_usd * 100.0).round() / 100.0)
+                    } else {
+                        serde_json::Value::Null
+                    },
+                })
+            }).collect::<Vec<_>>(),
             "files_modified": self.files_modified,
             "tool_usage": self.tool_usage.iter().map(|(k, v)| {
                 (k.clone(), serde_json::json!({"calls": v.calls}))
@@ -425,5 +647,107 @@ fn format_count(n: u64) -> String {
         format!("{:.1}k", n as f64 / 1_000.0)
     } else {
         n.to_string()
+    }
+}
+
+fn subagent_label(path: &Path) -> String {
+    let components: Vec<String> = path
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().to_string())
+        .collect();
+
+    if let Some(tasks_idx) = components.iter().position(|component| component == "tasks") {
+        let relative = &components[tasks_idx + 1..];
+        if !relative.is_empty() {
+            let mut label = relative.join("/");
+            if let Some(stripped) = label.strip_suffix(".jsonl") {
+                label = stripped.to_string();
+            }
+            return label;
+        }
+    }
+
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("subagent")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_session() -> ClaudeSession {
+        ClaudeSession::from_raw(RawSession {
+            pid: 1,
+            session_id: "session-1".into(),
+            cwd: "/tmp/project".into(),
+            started_at: 0,
+        })
+    }
+
+    #[test]
+    fn subagent_breakdown_groups_completed_and_lists_active_rows() {
+        let mut session = make_session();
+        let completed = PathBuf::from("/tmp/claude-1/-tmp-project/session-1/tasks/agent-1.jsonl");
+        let active =
+            PathBuf::from("/tmp/claude-1/-tmp-project/session-1/tasks/nested/agent-2.jsonl");
+
+        session.active_subagent_jsonl_paths = vec![active.clone()];
+        session.subagent_rollups.insert(
+            completed,
+            SubagentRollup {
+                input_tokens: 10_000,
+                output_tokens: 2_000,
+                cost_usd: 0.25,
+                usage_metrics_available: true,
+                ..SubagentRollup::default()
+            },
+        );
+        session.subagent_rollups.insert(
+            active,
+            SubagentRollup {
+                input_tokens: 40_000,
+                output_tokens: 8_000,
+                cost_usd: 1.5,
+                usage_metrics_available: true,
+                ..SubagentRollup::default()
+            },
+        );
+
+        let rows = session.subagent_breakdown();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].display_label(), "completed");
+        assert_eq!(rows[0].state, SubagentState::Completed);
+        assert_eq!(rows[0].count, 1);
+        assert_eq!(rows[0].format_tokens(), "10.0k/2.0k");
+        assert_eq!(rows[1].display_label(), "nested/agent-2");
+        assert_eq!(rows[1].state, SubagentState::Active);
+        assert_eq!(rows[1].format_cost(), "$1.5");
+    }
+
+    #[test]
+    fn subagent_breakdown_collapses_multiple_completed_rows() {
+        let mut session = make_session();
+
+        for name in ["agent-1.jsonl", "agent-2.jsonl"] {
+            let path = PathBuf::from(format!("/tmp/claude-1/-tmp-project/session-1/tasks/{name}"));
+            session.subagent_rollups.insert(
+                path,
+                SubagentRollup {
+                    input_tokens: 10_000,
+                    output_tokens: 1_000,
+                    cost_usd: 0.2,
+                    usage_metrics_available: true,
+                    ..SubagentRollup::default()
+                },
+            );
+        }
+
+        let rows = session.subagent_breakdown();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].display_label(), "completed (2)");
+        assert_eq!(rows[0].count, 2);
+        assert_eq!(rows[0].format_tokens(), "20.0k/2.0k");
     }
 }

--- a/src/terminals/gnome_terminal.rs
+++ b/src/terminals/gnome_terminal.rs
@@ -1,0 +1,40 @@
+use crate::session::ClaudeSession;
+
+pub fn launch(cwd: &str, prompt: Option<&str>, resume: Option<&str>) -> Result<String, String> {
+    let mut cmd = std::process::Command::new("gnome-terminal");
+    cmd.args(["--window", "--working-directory", cwd, "--", "claude"]);
+    for arg in super::build_claude_args(prompt, resume) {
+        cmd.arg(arg);
+    }
+
+    let output = cmd
+        .output()
+        .map_err(|e| format!("gnome-terminal launch failed: {e}"))?;
+
+    if output.status.success() {
+        Ok("gnome-terminal window".into())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+    }
+}
+
+pub fn switch(_session: &ClaudeSession) -> Result<(), String> {
+    Err(
+        "GNOME Terminal launch is supported, but remote focus/input control is not yet reliable. Use tmux or Kitty for session switching and input automation."
+            .into(),
+    )
+}
+
+pub fn send_input(_session: &ClaudeSession, _text: &str) -> Result<(), String> {
+    Err(
+        "GNOME Terminal launch is supported, but remote focus/input control is not yet reliable. Use tmux or Kitty for session input automation."
+            .into(),
+    )
+}
+
+pub fn approve(_session: &ClaudeSession) -> Result<(), String> {
+    Err(
+        "GNOME Terminal launch is supported, but remote focus/input control is not yet reliable. Use tmux or Kitty for approval automation."
+            .into(),
+    )
+}

--- a/src/terminals/mod.rs
+++ b/src/terminals/mod.rs
@@ -2,6 +2,7 @@
 mod apple;
 #[cfg(target_os = "macos")]
 mod ghostty;
+mod gnome_terminal;
 #[cfg(target_os = "macos")]
 mod iterm2;
 mod kitty;
@@ -110,6 +111,7 @@ pub struct DoctorReport {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Terminal {
+    Gnome,
     Ghostty,
     Warp,
     ITerm2,
@@ -122,6 +124,7 @@ pub enum Terminal {
 
 fn terminal_name(t: &Terminal) -> &str {
     match t {
+        Terminal::Gnome => "GNOME Terminal",
         Terminal::Ghostty => "Ghostty",
         Terminal::Warp => "Warp",
         Terminal::ITerm2 => "iTerm2",
@@ -139,6 +142,7 @@ fn platform_name() -> &'static str {
 
 fn supported_actions(terminal: &Terminal) -> Vec<TerminalAction> {
     match terminal {
+        Terminal::Gnome => vec![TerminalAction::Launch],
         Terminal::Kitty | Terminal::Tmux => vec![
             TerminalAction::Launch,
             TerminalAction::Switch,
@@ -180,6 +184,13 @@ pub fn detect_terminal() -> Terminal {
         return Terminal::Tmux;
     }
 
+    if std::env::var("GNOME_TERMINAL_SERVICE").is_ok()
+        || std::env::var("GNOME_TERMINAL_SCREEN").is_ok()
+        || ancestor_process_contains("gnome-terminal")
+    {
+        return Terminal::Gnome;
+    }
+
     match std::env::var("TERM_PROGRAM").as_deref() {
         Ok("ghostty") => Terminal::Ghostty,
         Ok("WarpTerminal") => Terminal::Warp,
@@ -190,6 +201,44 @@ pub fn detect_terminal() -> Terminal {
         Ok(other) => Terminal::Unknown(other.to_string()),
         Err(_) => Terminal::Unknown("unknown".to_string()),
     }
+}
+
+fn ancestor_process_contains(needle: &str) -> bool {
+    let mut pid = unsafe { libc::getppid() } as u32;
+    let needle = needle.to_ascii_lowercase();
+
+    for _ in 0..8 {
+        if pid == 0 {
+            break;
+        }
+
+        let output = match std::process::Command::new("ps")
+            .args(["-o", "ppid=,comm=", "-p", &pid.to_string()])
+            .output()
+        {
+            Ok(output) => output,
+            Err(_) => return false,
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let line = stdout.trim();
+        if line.is_empty() {
+            break;
+        }
+
+        let mut parts = line.split_whitespace();
+        let parent = parts
+            .next()
+            .and_then(|value| value.parse::<u32>().ok())
+            .unwrap_or(0);
+        let command = parts.collect::<Vec<_>>().join(" ").to_ascii_lowercase();
+        if command.contains(&needle) {
+            return true;
+        }
+        pid = parent;
+    }
+
+    false
 }
 
 pub fn can_launch_session() -> bool {
@@ -338,6 +387,51 @@ fn doctor_report_for(terminal: Terminal) -> DoctorReport {
     ];
 
     match terminal {
+        Terminal::Gnome => {
+            let gnome_check = binary_check("gnome-terminal");
+            let gnome_ready = gnome_check.status == DoctorStatus::Ready;
+            prerequisites.push(gnome_check);
+
+            let launch_status = if gnome_ready {
+                DoctorStatus::Ready
+            } else {
+                DoctorStatus::Blocked
+            };
+            let launch_detail = if gnome_ready {
+                "GNOME Terminal can launch visible Claude sessions with `gnome-terminal --window`."
+            } else {
+                "GNOME Terminal CLI is unavailable, so visible launch cannot run."
+            };
+            let launch_fix =
+                Some("Install GNOME Terminal and ensure `gnome-terminal` is on PATH.".to_string());
+            actions.push(action_check(
+                TerminalAction::Launch,
+                launch_status,
+                launch_detail,
+                launch_fix.clone(),
+            ));
+
+            for action in [
+                TerminalAction::Switch,
+                TerminalAction::Input,
+                TerminalAction::Approve,
+            ] {
+                actions.push(action_check(
+                    action,
+                    DoctorStatus::Unsupported,
+                    "GNOME Terminal launch is supported, but reliable remote focus/input automation is not currently available.",
+                    Some(
+                        "Use tmux or Kitty when you need remote switching, input, or approval from claudectl."
+                            .to_string(),
+                    ),
+                ));
+            }
+
+            notes.push(
+                "GNOME Terminal launch works on Linux and was smoke-tested under Docker/X11. Remote focus/input automation is intentionally disabled until window targeting is reliable."
+                    .to_string(),
+            );
+        }
         Terminal::Kitty => {
             let kitty_check = binary_check("kitty");
             let kitty_ready = kitty_check.status == DoctorStatus::Ready;
@@ -594,7 +688,7 @@ fn doctor_report_for(terminal: Terminal) -> DoctorReport {
                     action,
                     DoctorStatus::Unsupported,
                     format!(
-                        "No integration is configured for `{name}`. Supported terminals: tmux, Kitty, WezTerm, Ghostty, Warp, iTerm2, Terminal.app."
+                        "No integration is configured for `{name}`. Supported terminals: GNOME Terminal, tmux, Kitty, WezTerm, Ghostty, Warp, iTerm2, Terminal.app."
                     ),
                     None::<String>,
                 ));
@@ -622,10 +716,10 @@ fn doctor_report_for(terminal: Terminal) -> DoctorReport {
                     None::<String>,
                 ));
             }
-            notes.push(format!(
-                "{} was detected, but terminal control for it is only available on macOS right now.",
-                terminal_name(&terminal)
-            ));
+            notes.push(
+                "Monitoring still works in unsupported terminals, but control actions stay manual."
+                    .to_string(),
+            );
         }
     }
 
@@ -696,11 +790,12 @@ pub fn launch_session(
 ) -> Result<String, String> {
     let terminal = detect_terminal();
     match terminal {
+        Terminal::Gnome => gnome_terminal::launch(cwd, prompt, resume),
         Terminal::Kitty => kitty::launch(cwd, prompt, resume),
         Terminal::Tmux => tmux::launch(cwd, prompt, resume),
         Terminal::WezTerm => wezterm::launch(cwd, prompt, resume),
         other => Err(format!(
-            "Visible session launch is not supported in {}. Start `claude` manually, use tmux/Kitty/WezTerm, or run `claudectl --doctor` for setup guidance.",
+            "Visible session launch is not supported in {}. Start `claude` manually, use tmux/Kitty/WezTerm/GNOME Terminal, or run `claudectl --doctor` for setup guidance.",
             terminal_name(&other)
         )),
     }
@@ -723,6 +818,7 @@ pub fn switch_to_terminal(session: &ClaudeSession) -> Result<(), String> {
     );
 
     match terminal {
+        Terminal::Gnome => gnome_terminal::switch(session),
         Terminal::Kitty => kitty::switch(session),
         Terminal::WezTerm => wezterm::switch(session),
         Terminal::Tmux => tmux::switch(session),
@@ -735,7 +831,7 @@ pub fn switch_to_terminal(session: &ClaudeSession) -> Result<(), String> {
         #[cfg(target_os = "macos")]
         Terminal::Apple => apple::switch(session),
         Terminal::Unknown(name) => Err(format!(
-            "Unsupported terminal: {name}. Supported: Ghostty, Warp, iTerm2, Kitty, WezTerm, Terminal.app, tmux. Run `claudectl --doctor` for details."
+            "Unsupported terminal: {name}. Supported: GNOME Terminal, Ghostty, Warp, iTerm2, Kitty, WezTerm, Terminal.app, tmux. Run `claudectl --doctor` for details."
         )),
         #[cfg(not(target_os = "macos"))]
         _ => Err("Terminal switching not supported on this platform. Run `claudectl --doctor` for details.".into()),
@@ -744,6 +840,7 @@ pub fn switch_to_terminal(session: &ClaudeSession) -> Result<(), String> {
 
 pub fn send_input(session: &ClaudeSession, text: &str) -> Result<(), String> {
     match detect_terminal() {
+        Terminal::Gnome => gnome_terminal::send_input(session, text),
         #[cfg(target_os = "macos")]
         Terminal::Ghostty => ghostty::send_input(session, text),
         Terminal::Kitty => kitty::send_input(session, text),
@@ -767,6 +864,7 @@ pub fn send_input(session: &ClaudeSession, text: &str) -> Result<(), String> {
 
 pub fn approve_session(session: &ClaudeSession) -> Result<(), String> {
     match detect_terminal() {
+        Terminal::Gnome => gnome_terminal::approve(session),
         #[cfg(target_os = "macos")]
         Terminal::Ghostty => ghostty::approve(session),
         Terminal::Kitty => kitty::approve(session),
@@ -817,6 +915,12 @@ mod tests {
     fn help_summary_marks_unknown_terminal_monitor_only() {
         let summary = help_capability_summary_for(&Terminal::Unknown("foot".into()));
         assert_eq!(summary, "Current terminal: foot (monitor-only)");
+    }
+
+    #[test]
+    fn help_summary_mentions_gnome_terminal() {
+        let summary = help_capability_summary_for(&Terminal::Gnome);
+        assert!(summary.starts_with("Current terminal: GNOME Terminal"));
     }
 
     #[test]

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -56,7 +56,8 @@ pub fn render_detail_panel(frame: &mut Frame, area: Rect, session: &ClaudeSessio
         .as_ref()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| "-".into());
-    let subagents = session.subagent_count.to_string();
+    let subagents = session.format_subagent_summary();
+    let subagent_breakdown = session.subagent_breakdown();
     let telemetry = if session.has_usage_metrics() {
         format!("{} (usage metrics available)", session.telemetry_label())
     } else {
@@ -96,6 +97,33 @@ pub fn render_detail_panel(frame: &mut Frame, area: Rect, session: &ClaudeSessio
         detail_line("JSONL", &jsonl, t),
         detail_line("Subagents", &subagents, t),
     ];
+
+    if !subagent_breakdown.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            " Subagent Breakdown",
+            Style::default().fg(t.header).add_modifier(Modifier::BOLD),
+        )));
+        for row in subagent_breakdown.iter().take(10) {
+            lines.push(detail_line(
+                &format!("  {}", row.display_label()),
+                &format!(
+                    "{} | {} | {}",
+                    row.state_label(),
+                    row.format_cost(),
+                    row.format_tokens()
+                ),
+                t,
+            ));
+        }
+        if subagent_breakdown.len() > 10 {
+            lines.push(detail_line(
+                "",
+                &format!("  ... and {} more", subagent_breakdown.len() - 10),
+                t,
+            ));
+        }
+    }
 
     // Tool usage section
     if !session.tool_usage.is_empty() {

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -74,7 +74,9 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
         ]),
         Line::from(vec![
             Span::styled("  n              ", Style::default().fg(t.highlight_key)),
-            Span::raw("  Launch wizard for cwd, prompt, and resume (tmux/Kitty/WezTerm)"),
+            Span::raw(
+                "  Launch wizard for cwd, prompt, and resume (GNOME Terminal/tmux/Kitty/WezTerm)",
+            ),
         ]),
         Line::from(vec![
             Span::styled("  Enter/Tab      ", Style::default().fg(t.highlight_key)),
@@ -150,7 +152,7 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
         ]),
         Line::from(vec![
             Span::styled("  +N ", Style::default().fg(t.highlight_key)),
-            Span::raw("after project = N sub-agents running"),
+            Span::raw("after project = N sub-agents tracked"),
         ]),
         Line::from(vec![
             Span::styled("  !! ", Style::default().fg(t.highlight_key)),

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 use crate::app::{App, SORT_COLUMNS};
-use crate::session::SessionStatus;
+use crate::session::{ClaudeSession, SessionStatus, SubagentBreakdown, SubagentState};
 
 use super::detail::render_detail_panel;
 use super::help::render_help_overlay;
@@ -45,7 +45,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         let launch_hint = if crate::terminals::can_launch_session() {
             "  Press n for the launch wizard, or start claude in another terminal."
         } else {
-            "  Start claude in tmux, Kitty, WezTerm, or another terminal."
+            "  Start claude in GNOME Terminal, tmux, Kitty, WezTerm, or another terminal."
         };
         let empty_lines = vec![
             Line::from(""),
@@ -159,7 +159,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let header = Row::new(header_cells).height(1);
 
     let selected_pid = app.selected_session().map(|s| s.pid);
-    let mut selected_row_idx = app.table_state.selected();
+    let mut selected_row_idx = None;
     let rows: Vec<Row> = if app.grouped_view {
         let groups = app.project_groups();
         let mut rows = Vec::new();
@@ -199,17 +199,24 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                 if Some(s.pid) == selected_pid {
                     selected_row_idx = Some(row_idx);
                 }
-                rows.push(session_row(s, app));
-                row_idx += 1;
+                let session_rows = render_rows_for_session(s, app);
+                row_idx += session_rows.len();
+                rows.extend(session_rows);
             }
         }
         rows
     } else {
-        visible_sessions
-            .iter()
-            .copied()
-            .map(|s| session_row(s, app))
-            .collect()
+        let mut rows = Vec::new();
+        let mut row_idx = 0usize;
+        for s in visible_sessions.iter().copied() {
+            if Some(s.pid) == selected_pid {
+                selected_row_idx = Some(row_idx);
+            }
+            let session_rows = render_rows_for_session(s, app);
+            row_idx += session_rows.len();
+            rows.extend(session_rows);
+        }
+        rows
     };
 
     let widths = [
@@ -417,7 +424,17 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     }
 }
 
-fn session_row<'a>(s: &'a crate::session::ClaudeSession, app: &'a App) -> Row<'a> {
+fn render_rows_for_session(s: &ClaudeSession, app: &App) -> Vec<Row<'static>> {
+    let mut rows = vec![session_row(s, app)];
+    let breakdown = s.subagent_breakdown();
+    let total = breakdown.len();
+    for (index, row) in breakdown.iter().enumerate() {
+        rows.push(subagent_row(row, app, index, total));
+    }
+    rows
+}
+
+fn session_row(s: &ClaudeSession, app: &App) -> Row<'static> {
     let t = &app.theme;
     // Color escalation for NeedsInput based on wait time
     let status_style = if s.status == SessionStatus::NeedsInput {
@@ -512,6 +529,36 @@ fn session_row<'a>(s: &'a crate::session::ClaudeSession, app: &'a App) -> Row<'a
         Cell::from(s.format_mem()),
         Cell::from(s.format_tokens()),
         Cell::from(s.format_sparkline()).style(Style::default().fg(t.sparkline)),
+    ])
+}
+
+fn subagent_row(row: &SubagentBreakdown, app: &App, index: usize, total: usize) -> Row<'static> {
+    let t = &app.theme;
+    let branch = if index + 1 == total {
+        "\u{2514}\u{2500} "
+    } else {
+        "\u{251c}\u{2500} "
+    };
+    let project_text = format!("{branch}{}", row.display_label());
+    let status_text = row.state_label();
+    let status_style = match row.state {
+        SubagentState::Active => Style::default().fg(t.status_processing),
+        SubagentState::Completed => Style::default().fg(t.text_muted),
+    };
+    let row_style = Style::default().fg(t.text_muted);
+
+    Row::new(vec![
+        Cell::from(""),
+        Cell::from(project_text).style(row_style),
+        Cell::from(status_text).style(status_style),
+        Cell::from("-").style(row_style),
+        Cell::from(row.format_cost()).style(Style::default().fg(t.cost)),
+        Cell::from("-").style(row_style),
+        Cell::from("-").style(row_style),
+        Cell::from("-").style(row_style),
+        Cell::from("-").style(row_style),
+        Cell::from(row.format_tokens()).style(row_style),
+        Cell::from("-").style(row_style),
     ])
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,6 +1,8 @@
 use std::io::Write;
 use std::time::Duration;
 
+use claudectl::discovery;
+use claudectl::models;
 use claudectl::monitor;
 use claudectl::session::{ClaudeSession, RawSession, SessionStatus, TelemetryStatus};
 
@@ -336,6 +338,35 @@ fn make_session_with_jsonl(content: &str) -> (ClaudeSession, tempfile::NamedTemp
     (s, file)
 }
 
+fn make_session_with_paths(
+    cwd: String,
+    session_id: String,
+    jsonl_path: std::path::PathBuf,
+) -> ClaudeSession {
+    let raw = RawSession {
+        pid: 1,
+        session_id,
+        cwd,
+        started_at: 0,
+    };
+    let mut s = ClaudeSession::from_raw(raw);
+    s.jsonl_path = Some(jsonl_path);
+    s
+}
+
+fn write_jsonl(path: &std::path::Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, content).unwrap();
+}
+
+fn expected_cost(model: &str, input_tokens: u64, output_tokens: u64) -> f64 {
+    let profile = models::resolve(model).profile;
+    (input_tokens as f64 / 1_000_000.0) * profile.input_per_m
+        + (output_tokens as f64 / 1_000_000.0) * profile.output_per_m
+}
+
 #[test]
 fn jsonl_parse_token_usage() {
     let jsonl = r#"{"type":"assistant","message":{"model":"claude-opus-4-6-20260401","stop_reason":"end_turn","usage":{"input_tokens":50000,"output_tokens":10000,"cache_read_input_tokens":20000,"cache_creation_input_tokens":5000}}}"#;
@@ -477,6 +508,96 @@ fn jsonl_no_path() {
     assert_eq!(s.total_input_tokens, 0);
 }
 
+#[test]
+fn jsonl_rolls_up_subagent_tokens_and_cost() {
+    let temp = tempfile::tempdir().unwrap();
+    let parent_jsonl = temp.path().join("parent.jsonl");
+    write_jsonl(
+        &parent_jsonl,
+        r#"{"type":"assistant","message":{"model":"claude-sonnet-4-6-20260401","stop_reason":"end_turn","usage":{"input_tokens":100000,"output_tokens":50000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}"#,
+    );
+
+    let session_id = format!("subagent-rollup-{}", std::process::id());
+    let cwd = format!("/tmp/claudectl-rollup-{}", std::process::id());
+    let slug = cwd.replace('/', "-");
+    let uid = unsafe { libc::getuid() };
+    let tasks_dir = std::path::PathBuf::from(format!("/tmp/claude-{uid}"))
+        .join(&slug)
+        .join(&session_id)
+        .join("tasks");
+    write_jsonl(
+        &tasks_dir.join("agent-1.jsonl"),
+        r#"{"type":"assistant","message":{"model":"claude-opus-4-6-20260401","stop_reason":"end_turn","usage":{"input_tokens":200000,"output_tokens":50000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}"#,
+    );
+    write_jsonl(
+        &tasks_dir.join("nested/agent-2.jsonl"),
+        r#"{"type":"assistant","message":{"model":"claude-haiku-4-5-20260101","stop_reason":"end_turn","usage":{"input_tokens":50000,"output_tokens":10000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}"#,
+    );
+
+    let mut s = make_session_with_paths(cwd, session_id, parent_jsonl);
+    discovery::scan_subagents(std::slice::from_mut(&mut s));
+    monitor::update_tokens(&mut s);
+
+    assert_eq!(s.active_subagent_count, 2);
+    assert_eq!(s.subagent_count, 2);
+    assert_eq!(s.total_input_tokens, 350_000);
+    assert_eq!(s.total_output_tokens, 110_000);
+
+    let expected = expected_cost("sonnet-4.6", 100_000, 50_000)
+        + expected_cost("opus-4.6", 200_000, 50_000)
+        + expected_cost("haiku", 50_000, 10_000);
+    assert!((s.cost_usd - expected).abs() < 0.0001);
+    assert!(!s.cost_estimate_unverified);
+
+    let _ = std::fs::remove_dir_all(
+        std::path::PathBuf::from(format!("/tmp/claude-{uid}"))
+            .join(&slug)
+            .join(&s.session_id),
+    );
+}
+
+#[test]
+fn subagent_rollup_persists_after_task_file_disappears() {
+    let temp = tempfile::tempdir().unwrap();
+    let parent_jsonl = temp.path().join("parent.jsonl");
+    write_jsonl(
+        &parent_jsonl,
+        r#"{"type":"assistant","message":{"model":"claude-sonnet-4-6-20260401","stop_reason":"end_turn","usage":{"input_tokens":100000,"output_tokens":10000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}"#,
+    );
+
+    let session_id = format!("subagent-persist-{}", std::process::id());
+    let cwd = format!("/tmp/claudectl-persist-{}", std::process::id());
+    let slug = cwd.replace('/', "-");
+    let uid = unsafe { libc::getuid() };
+    let subagent_root = std::path::PathBuf::from(format!("/tmp/claude-{uid}"))
+        .join(&slug)
+        .join(&session_id);
+    let tasks_dir = subagent_root.join("tasks");
+    write_jsonl(
+        &tasks_dir.join("agent-1.jsonl"),
+        r#"{"type":"assistant","message":{"model":"claude-sonnet-4-6-20260401","stop_reason":"end_turn","usage":{"input_tokens":200000,"output_tokens":20000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}"#,
+    );
+
+    let mut s = make_session_with_paths(cwd, session_id, parent_jsonl);
+    discovery::scan_subagents(std::slice::from_mut(&mut s));
+    monitor::update_tokens(&mut s);
+
+    assert_eq!(s.active_subagent_count, 1);
+    assert_eq!(s.subagent_count, 1);
+    assert_eq!(s.total_input_tokens, 300_000);
+    assert_eq!(s.total_output_tokens, 30_000);
+
+    std::fs::remove_dir_all(&subagent_root).unwrap();
+
+    discovery::scan_subagents(std::slice::from_mut(&mut s));
+    monitor::update_tokens(&mut s);
+
+    assert_eq!(s.active_subagent_count, 0);
+    assert_eq!(s.subagent_count, 1);
+    assert_eq!(s.total_input_tokens, 300_000);
+    assert_eq!(s.total_output_tokens, 30_000);
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Session Formatting Edge Cases
 // ────────────────────────────────────────────────────────────────────────────
@@ -549,6 +670,46 @@ fn json_export_format() {
     assert_eq!(json["elapsed_secs"], 300);
     assert_eq!(json["tokens_in"], 50000);
     assert_eq!(json["tokens_out"], 10000);
+    assert!(json["subagent_breakdown"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn json_export_includes_subagent_breakdown() {
+    let mut s = make_session(0.0, 0);
+    s.active_subagent_jsonl_paths = vec![std::path::PathBuf::from(
+        "/tmp/claude-1/-tmp-project/session-1/tasks/agent-2.jsonl",
+    )];
+    s.subagent_rollups.insert(
+        std::path::PathBuf::from("/tmp/claude-1/-tmp-project/session-1/tasks/agent-1.jsonl"),
+        claudectl::session::SubagentRollup {
+            input_tokens: 20_000,
+            output_tokens: 2_000,
+            cost_usd: 0.4,
+            usage_metrics_available: true,
+            ..claudectl::session::SubagentRollup::default()
+        },
+    );
+    s.subagent_rollups.insert(
+        std::path::PathBuf::from("/tmp/claude-1/-tmp-project/session-1/tasks/agent-2.jsonl"),
+        claudectl::session::SubagentRollup {
+            input_tokens: 10_000,
+            output_tokens: 1_000,
+            cost_usd: 0.2,
+            usage_metrics_available: true,
+            ..claudectl::session::SubagentRollup::default()
+        },
+    );
+    s.subagent_count = 2;
+    s.active_subagent_count = 1;
+
+    let json = s.to_json_value();
+    let breakdown = json["subagent_breakdown"].as_array().unwrap();
+    assert_eq!(breakdown.len(), 2);
+    assert_eq!(breakdown[0]["label"], "completed");
+    assert_eq!(breakdown[0]["state"], "Completed");
+    assert_eq!(breakdown[0]["tokens_in"], 20000);
+    assert_eq!(breakdown[1]["label"], "agent-2");
+    assert_eq!(breakdown[1]["state"], "Active");
 }
 
 #[test]


### PR DESCRIPTION
This PR completes the remaining work around issue #67 and folds in the supporting release/distribution changes that now ship with the same branch.

The user-facing problem in #67 was that parent sessions only counted their own transcript usage, while spawned subagents were effectively invisible to the token and cost model. In real workflows that meant the dashboard could under-report usage by a large margin, so the cost and token columns were directionally wrong whenever delegation was happening. The issue also called out that GNOME Terminal, the default terminal on Ubuntu, was not explicitly supported or documented.

The root cause for the accounting side was that claudectl only treated subagents as a count of task JSONL files. It discovered that delegation existed, but it did not parse those subagent transcripts, did not retain their usage over time, and did not expose any structured breakdown beyond a simple +N badge on the parent row. That left both the main dashboard and JSON export without a credible view of subagent spend.

This change fixes that in two layers. First, the monitor now discovers subagent JSONLs recursively, parses their usage incrementally, rolls their tokens and cost into the parent session totals, and keeps those rollups even if the ephemeral task files disappear from /tmp. Second, the UI now surfaces that information as an actual hierarchy: parent rows expand into child subagent rows, with completed subagents collapsed into an aggregate completed row and active subagents shown individually underneath. The same subagent breakdown is also exposed in the detail panel and JSON output.

The branch also adds GNOME Terminal launch support for --new and the launch wizard, updates the README/help text so GNOME Terminal support is explicit, and prepares the 0.16.0 release path by bumping the crate version, publishing through the release workflow, and updating the Homebrew tap formula automatically from release artifacts. During verification I tested GNOME Terminal launch in a temporary Docker/X11 environment. That smoke test confirmed launch support, but it also showed that remote focus/input automation was not reliable enough to expose as a supported GNOME capability, so the doctor output and docs now state that limitation explicitly rather than overstating support.

Checks run for this branch:

- cargo fmt --all -- --check
- cargo check --all-targets
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets
- cargo run -- --help
- cargo publish --dry-run --locked --allow-dirty
- Docker/X11 GNOME Terminal launch smoke

Closes #67.
