### PR TITLE
feat: local LLM brain for session advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.18.0] - 2026-04-15
+
+### Added
+- **Local LLM brain** (opt-in): connect to ollama or any OpenAI-compatible local LLM for session advisory. Enable with `--brain` or `[brain]` config section.
+- Brain context builder: compacts session transcripts into LLM prompts with configurable token budget
+- Brain LLM client: communicates via curl subprocess (no new dependencies, follows webhook pattern)
+- Brain inference loop: non-blocking async inference with 10-second per-PID cooldown
+- Advisory UI: pending brain suggestions shown inline (`[b:approve]`), accept with `b`, reject with `B`
+- Auto mode: `--brain-auto` executes suggestions without confirmation
+- Decision logging: every brain suggestion + user response logged to `~/.claudectl/brain/decisions.jsonl`
+- Deny rules always override brain suggestions regardless of confidence
+
 ## [0.17.1] - 2026-04-15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2024"
 description = "TUI for monitoring and managing Claude Code CLI agents"
 license = "MIT"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1301,6 +1301,16 @@ impl App {
                 self.cancel_pending_auto_approve();
                 self.handle_approve();
             }
+            (KeyCode::Char('b'), _) => {
+                self.cancel_pending_kill();
+                self.cancel_pending_auto_approve();
+                self.handle_brain_accept();
+            }
+            (KeyCode::Char('B'), _) => {
+                self.cancel_pending_kill();
+                self.cancel_pending_auto_approve();
+                self.handle_brain_reject();
+            }
             (KeyCode::Char('i'), _) => {
                 self.cancel_pending_kill();
                 self.cancel_pending_auto_approve();
@@ -1590,6 +1600,48 @@ impl App {
             } else {
                 self.status_msg = "Session is not waiting for input".into();
             }
+        }
+    }
+
+    fn handle_brain_accept(&mut self) {
+        // Clone session data first to avoid borrow conflict with brain_engine
+        let Some(session) = self.selected_session().cloned() else {
+            return;
+        };
+        let pid = session.pid;
+        let Some(ref mut engine) = self.brain_engine else {
+            self.status_msg = "Brain is not enabled".into();
+            return;
+        };
+        if !engine.pending.contains_key(&pid) {
+            self.status_msg = "No brain suggestion pending for this session".into();
+            return;
+        }
+        if let Some(msg) = engine.accept(pid, &session) {
+            crate::logger::log("BRAIN", &format!("Accepted: {msg}"));
+            self.status_msg = msg;
+        }
+    }
+
+    fn handle_brain_reject(&mut self) {
+        let Some(session) = self.selected_session() else {
+            return;
+        };
+        let pid = session.pid;
+        let Some(ref mut engine) = self.brain_engine else {
+            self.status_msg = "Brain is not enabled".into();
+            return;
+        };
+        if let Some(suggestion) = engine.reject(pid) {
+            let msg = format!(
+                "Rejected brain suggestion: {} ({})",
+                suggestion.action.label(),
+                suggestion.reasoning,
+            );
+            crate::logger::log("BRAIN", &msg);
+            self.status_msg = msg;
+        } else {
+            self.status_msg = "No brain suggestion pending for this session".into();
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -297,6 +297,7 @@ pub struct App {
     pub rules: Vec<crate::rules::AutoRule>,
     pub auto_actions_fired: HashMap<u32, std::time::Instant>, // Debounce: pid -> last action time
     pub last_rule_action: Option<String>,                     // Last auto-action status for display
+    pub brain_config: Option<crate::config::BrainConfig>,
 }
 
 #[derive(Default, Clone)]
@@ -400,6 +401,7 @@ impl App {
             rules: Vec::new(),
             auto_actions_fired: HashMap::new(),
             last_rule_action: None,
+            brain_config: None,
         };
         app.refresh();
         if app.visible_session_count() > 0 {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1613,18 +1613,30 @@ impl App {
             self.status_msg = "Brain is not enabled".into();
             return;
         };
-        if !engine.pending.contains_key(&pid) {
+        // Get suggestion before accept (for logging)
+        let suggestion = engine.pending.get(&pid).cloned();
+        if suggestion.is_none() {
             self.status_msg = "No brain suggestion pending for this session".into();
             return;
         }
         if let Some(msg) = engine.accept(pid, &session) {
+            if let Some(ref sg) = suggestion {
+                crate::brain::decisions::log_decision(
+                    pid,
+                    session.display_name(),
+                    session.pending_tool_name.as_deref(),
+                    session.pending_tool_input.as_deref(),
+                    sg,
+                    "accept",
+                );
+            }
             crate::logger::log("BRAIN", &format!("Accepted: {msg}"));
             self.status_msg = msg;
         }
     }
 
     fn handle_brain_reject(&mut self) {
-        let Some(session) = self.selected_session() else {
+        let Some(session) = self.selected_session().cloned() else {
             return;
         };
         let pid = session.pid;
@@ -1633,6 +1645,14 @@ impl App {
             return;
         };
         if let Some(suggestion) = engine.reject(pid) {
+            crate::brain::decisions::log_decision(
+                pid,
+                session.display_name(),
+                session.pending_tool_name.as_deref(),
+                session.pending_tool_input.as_deref(),
+                &suggestion,
+                "reject",
+            );
             let msg = format!(
                 "Rejected brain suggestion: {} ({})",
                 suggestion.action.label(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -298,6 +298,7 @@ pub struct App {
     pub auto_actions_fired: HashMap<u32, std::time::Instant>, // Debounce: pid -> last action time
     pub last_rule_action: Option<String>,                     // Last auto-action status for display
     pub brain_config: Option<crate::config::BrainConfig>,
+    pub brain_engine: Option<crate::brain::engine::BrainEngine>,
 }
 
 #[derive(Default, Clone)]
@@ -402,6 +403,7 @@ impl App {
             auto_actions_fired: HashMap::new(),
             last_rule_action: None,
             brain_config: None,
+            brain_engine: None,
         };
         app.refresh();
         if app.visible_session_count() > 0 {
@@ -1006,55 +1008,72 @@ impl App {
         }
 
         // Rule-based auto-actions
-        if self.rules.is_empty() {
-            return;
-        }
+        if !self.rules.is_empty() {
+            let candidates: Vec<u32> = self
+                .sessions
+                .iter()
+                .filter(|s| {
+                    matches!(
+                        s.status,
+                        SessionStatus::NeedsInput | SessionStatus::WaitingInput
+                    )
+                })
+                .filter(|s| !self.auto_approve.contains(&s.pid)) // Legacy takes priority
+                .map(|s| s.pid)
+                .collect();
 
-        let candidates: Vec<u32> = self
-            .sessions
-            .iter()
-            .filter(|s| {
-                matches!(
-                    s.status,
-                    SessionStatus::NeedsInput | SessionStatus::WaitingInput
-                )
-            })
-            .filter(|s| !self.auto_approve.contains(&s.pid)) // Legacy takes priority
-            .map(|s| s.pid)
-            .collect();
+            for pid in candidates {
+                // Debounce: don't re-fire within 3 seconds for same PID
+                if let Some(last) = self.auto_actions_fired.get(&pid) {
+                    if last.elapsed().as_secs() < 3 {
+                        continue;
+                    }
+                }
 
-        for pid in candidates {
-            // Debounce: don't re-fire within 3 seconds for same PID
-            if let Some(last) = self.auto_actions_fired.get(&pid) {
-                if last.elapsed().as_secs() < 3 {
+                let session = match self.sessions.iter().find(|s| s.pid == pid) {
+                    Some(s) => s,
+                    None => continue,
+                };
+
+                let result = crate::rules::evaluate(&self.rules, session);
+                let Some(rule_match) = result else {
                     continue;
+                };
+
+                let msg = crate::rules::execute(&rule_match, session);
+                match msg {
+                    Ok(status) => {
+                        crate::logger::log("AUTO", &status);
+                        self.last_rule_action = Some(status.clone());
+                        self.status_msg = status;
+                    }
+                    Err(e) => {
+                        self.status_msg = format!("Rule error: {e}");
+                    }
                 }
+
+                self.auto_actions_fired
+                    .insert(pid, std::time::Instant::now());
+            }
+        } // end if !self.rules.is_empty()
+
+        // Brain inference (opt-in, runs after rules)
+        if let Some(ref mut engine) = self.brain_engine {
+            // Collect deny-only rules for override checking
+            let deny_rules: Vec<_> = self
+                .rules
+                .iter()
+                .filter(|r| r.action == crate::rules::RuleAction::Deny)
+                .cloned()
+                .collect();
+
+            let actions = engine.tick(&self.sessions, &deny_rules);
+            for (_pid, msg) in actions {
+                crate::logger::log("BRAIN", &msg);
+                self.status_msg = msg;
             }
 
-            let session = match self.sessions.iter().find(|s| s.pid == pid) {
-                Some(s) => s,
-                None => continue,
-            };
-
-            let result = crate::rules::evaluate(&self.rules, session);
-            let Some(rule_match) = result else {
-                continue;
-            };
-
-            let msg = crate::rules::execute(&rule_match, session);
-            match msg {
-                Ok(status) => {
-                    crate::logger::log("AUTO", &status);
-                    self.last_rule_action = Some(status.clone());
-                    self.status_msg = status;
-                }
-                Err(e) => {
-                    self.status_msg = format!("Rule error: {e}");
-                }
-            }
-
-            self.auto_actions_fired
-                .insert(pid, std::time::Instant::now());
+            engine.cleanup(&self.sessions);
         }
     }
 

--- a/src/brain/client.rs
+++ b/src/brain/client.rs
@@ -1,0 +1,1 @@
+// LLM client — implemented in #91

--- a/src/brain/client.rs
+++ b/src/brain/client.rs
@@ -1,1 +1,177 @@
-// LLM client — implemented in #91
+#![allow(dead_code)]
+
+use std::process::Command;
+
+use crate::config::BrainConfig;
+use crate::rules::RuleAction;
+
+/// The brain's suggestion for a session, parsed from the LLM response.
+#[derive(Debug, Clone)]
+pub struct BrainSuggestion {
+    pub action: RuleAction,
+    pub message: Option<String>,
+    pub reasoning: String,
+    pub confidence: f64,
+}
+
+/// Call the local LLM endpoint via curl and parse the response.
+pub fn infer(config: &BrainConfig, prompt: &str) -> Result<BrainSuggestion, String> {
+    let payload = serde_json::json!({
+        "model": config.model,
+        "prompt": prompt,
+        "stream": false,
+        "format": "json",
+    });
+
+    let body = serde_json::to_string(&payload).map_err(|e| format!("json error: {e}"))?;
+    let timeout_secs = (config.timeout_ms / 1000).max(1);
+
+    let output = Command::new("curl")
+        .args([
+            "-s",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            &body,
+            "--max-time",
+            &timeout_secs.to_string(),
+            &config.endpoint,
+        ])
+        .output()
+        .map_err(|e| format!("curl failed: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("curl error (exit {}): {stderr}", output.status));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_ollama_response(&stdout)
+}
+
+/// Parse the ollama `/api/generate` response format.
+fn parse_ollama_response(response: &str) -> Result<BrainSuggestion, String> {
+    let json: serde_json::Value =
+        serde_json::from_str(response).map_err(|e| format!("invalid JSON response: {e}"))?;
+
+    // Ollama wraps the generated text in a "response" field
+    let generated = json
+        .get("response")
+        .and_then(|v| v.as_str())
+        .unwrap_or(response);
+
+    parse_suggestion_json(generated)
+}
+
+/// Parse the structured JSON that the brain LLM is expected to produce.
+pub fn parse_suggestion_json(text: &str) -> Result<BrainSuggestion, String> {
+    // The LLM should produce JSON like:
+    // {"action": "approve", "message": null, "reasoning": "safe command", "confidence": 0.95}
+    let json: serde_json::Value =
+        serde_json::from_str(text.trim()).map_err(|e| format!("invalid suggestion JSON: {e}"))?;
+
+    let action_str = json
+        .get("action")
+        .and_then(|v| v.as_str())
+        .ok_or("missing 'action' field")?;
+
+    let action =
+        RuleAction::parse(action_str).ok_or_else(|| format!("unknown action '{action_str}'"))?;
+
+    let message = json
+        .get("message")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let reasoning = json
+        .get("reasoning")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let confidence = json
+        .get("confidence")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.5);
+
+    Ok(BrainSuggestion {
+        action,
+        message,
+        reasoning,
+        confidence: confidence.clamp(0.0, 1.0),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_approve_suggestion() {
+        let json = r#"{"action": "approve", "reasoning": "safe read command", "confidence": 0.95}"#;
+        let s = parse_suggestion_json(json).unwrap();
+        assert_eq!(s.action, RuleAction::Approve);
+        assert_eq!(s.reasoning, "safe read command");
+        assert!((s.confidence - 0.95).abs() < f64::EPSILON);
+        assert!(s.message.is_none());
+    }
+
+    #[test]
+    fn parse_send_suggestion() {
+        let json = r#"{"action": "send", "message": "continue", "reasoning": "task in progress", "confidence": 0.8}"#;
+        let s = parse_suggestion_json(json).unwrap();
+        assert_eq!(s.action, RuleAction::Send);
+        assert_eq!(s.message.as_deref(), Some("continue"));
+    }
+
+    #[test]
+    fn parse_deny_suggestion() {
+        let json = r#"{"action": "deny", "reasoning": "dangerous command", "confidence": 0.99}"#;
+        let s = parse_suggestion_json(json).unwrap();
+        assert_eq!(s.action, RuleAction::Deny);
+    }
+
+    #[test]
+    fn parse_terminate_suggestion() {
+        let json = r#"{"action": "terminate", "reasoning": "over budget", "confidence": 0.7}"#;
+        let s = parse_suggestion_json(json).unwrap();
+        assert_eq!(s.action, RuleAction::Terminate);
+    }
+
+    #[test]
+    fn parse_missing_action_fails() {
+        let json = r#"{"reasoning": "no action"}"#;
+        assert!(parse_suggestion_json(json).is_err());
+    }
+
+    #[test]
+    fn parse_unknown_action_fails() {
+        let json = r#"{"action": "dance", "reasoning": "invalid"}"#;
+        assert!(parse_suggestion_json(json).is_err());
+    }
+
+    #[test]
+    fn parse_confidence_clamped() {
+        let json = r#"{"action": "approve", "reasoning": "test", "confidence": 1.5}"#;
+        let s = parse_suggestion_json(json).unwrap();
+        assert!((s.confidence - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_ollama_wrapped_response() {
+        let ollama_response = r#"{"model":"gemma3","response":"{\"action\":\"approve\",\"reasoning\":\"safe\",\"confidence\":0.9}","done":true}"#;
+        let s = parse_ollama_response(ollama_response).unwrap();
+        assert_eq!(s.action, RuleAction::Approve);
+    }
+
+    #[test]
+    fn defaults_on_missing_optional_fields() {
+        let json = r#"{"action": "approve"}"#;
+        let s = parse_suggestion_json(json).unwrap();
+        assert_eq!(s.reasoning, "");
+        assert!((s.confidence - 0.5).abs() < f64::EPSILON);
+        assert!(s.message.is_none());
+    }
+}

--- a/src/brain/context.rs
+++ b/src/brain/context.rs
@@ -1,0 +1,372 @@
+#![allow(dead_code)]
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use crate::session::ClaudeSession;
+use crate::transcript::{self, TranscriptBlock, TranscriptEvent};
+
+/// Compact context for the brain LLM, built from session state + recent transcript.
+#[derive(Debug, Clone)]
+pub struct BrainContext {
+    /// One-line session summary (status, cost, context%, pending tool).
+    pub session_summary: String,
+    /// Recent conversation messages, compacted to fit within token budget.
+    pub recent_transcript: String,
+    /// The decision prompt asking the LLM what to do.
+    pub decision_prompt: String,
+}
+
+/// Build a compact context for the brain from a session's state and JSONL transcript.
+pub fn build_context(session: &ClaudeSession, max_tokens: u32) -> BrainContext {
+    let session_summary = format_session_summary(session);
+    let recent_transcript = read_recent_transcript(session, max_tokens);
+    let decision_prompt = format_decision_prompt(session);
+
+    BrainContext {
+        session_summary,
+        recent_transcript,
+        decision_prompt,
+    }
+}
+
+fn format_session_summary(session: &ClaudeSession) -> String {
+    let context_pct = if session.context_max > 0 {
+        (session.context_tokens as f64 / session.context_max as f64 * 100.0) as u32
+    } else {
+        0
+    };
+
+    let mut summary = format!(
+        "Project: {} | Status: {} | Model: {} | Cost: ${:.2} | Context: {}%",
+        session.display_name(),
+        session.status,
+        session.model,
+        session.cost_usd,
+        context_pct,
+    );
+
+    if let Some(ref tool) = session.pending_tool_name {
+        summary.push_str(&format!(" | Pending tool: {tool}"));
+        if let Some(ref input) = session.pending_tool_input {
+            let truncated = if input.len() > 200 {
+                format!("{}...", &input[..200])
+            } else {
+                input.clone()
+            };
+            summary.push_str(&format!(" | Command: {truncated}"));
+        }
+    }
+
+    if session.last_tool_error {
+        summary.push_str(" | Last tool ERRORED");
+    }
+
+    summary
+}
+
+fn format_decision_prompt(session: &ClaudeSession) -> String {
+    match session.status {
+        crate::session::SessionStatus::NeedsInput => {
+            let tool = session.pending_tool_name.as_deref().unwrap_or("unknown");
+            format!(
+                "The session is waiting for approval of a '{}' tool call. \
+                 Should this be approved, denied, or should a message be sent instead? \
+                 Respond with JSON: {{\"action\": \"approve\"|\"deny\"|\"send\"|\"terminate\", \
+                 \"message\": \"...\", \"reasoning\": \"...\", \"confidence\": 0.0-1.0}}",
+                tool
+            )
+        }
+        crate::session::SessionStatus::WaitingInput => {
+            "The session finished its response and is waiting for user input. \
+             Should a message be sent (e.g. 'continue'), or should the session be left alone? \
+             Respond with JSON: {\"action\": \"send\"|\"deny\", \
+             \"message\": \"...\", \"reasoning\": \"...\", \"confidence\": 0.0-1.0}"
+                .to_string()
+        }
+        _ => "The session is in an unexpected state. Respond with JSON: \
+             {\"action\": \"deny\", \"reasoning\": \"...\", \"confidence\": 0.0}"
+            .to_string(),
+    }
+}
+
+/// Read recent transcript entries from the JSONL file, compacted to fit budget.
+/// Keeps the last N full messages and summarizes older ones as one-liners.
+fn read_recent_transcript(session: &ClaudeSession, max_tokens: u32) -> String {
+    let Some(ref jsonl_path) = session.jsonl_path else {
+        return "(no transcript available)".into();
+    };
+
+    let entries = read_all_transcript_entries(jsonl_path);
+    if entries.is_empty() {
+        return "(empty transcript)".into();
+    }
+
+    // Rough token estimate: 1 token ≈ 4 chars
+    let max_chars = (max_tokens as usize) * 4;
+    let mut lines: Vec<String> = Vec::new();
+
+    // Process entries newest-first, keep full detail for recent ones
+    let total = entries.len();
+    for (i, entry) in entries.iter().enumerate().rev() {
+        let is_recent = total - i <= 8; // Last 8 messages get full detail
+        let line = if is_recent {
+            format_entry_full(entry)
+        } else {
+            format_entry_compact(entry)
+        };
+        lines.push(line);
+    }
+
+    lines.reverse();
+
+    // Truncate to fit budget
+    let mut result = String::new();
+    for line in &lines {
+        if result.len() + line.len() > max_chars {
+            result.push_str("\n... (earlier messages truncated)");
+            break;
+        }
+        if !result.is_empty() {
+            result.push('\n');
+        }
+        result.push_str(line);
+    }
+
+    result
+}
+
+struct TranscriptEntry {
+    role: String,
+    blocks: Vec<TranscriptBlock>,
+}
+
+fn read_all_transcript_entries(path: &Path) -> Vec<TranscriptEntry> {
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+
+    let reader = BufReader::new(file);
+    let mut entries = Vec::new();
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        if let Some(event) = transcript::parse_line(&line) {
+            match event {
+                TranscriptEvent::Message(msg) => {
+                    let role = match msg.role {
+                        transcript::TranscriptRole::Assistant => "assistant".into(),
+                        transcript::TranscriptRole::User => "user".into(),
+                    };
+                    entries.push(TranscriptEntry {
+                        role,
+                        blocks: msg.content,
+                    });
+                }
+                TranscriptEvent::WaitingForTask => {
+                    entries.push(TranscriptEntry {
+                        role: "system".into(),
+                        blocks: vec![TranscriptBlock::Text("[waiting for user input]".into())],
+                    });
+                }
+            }
+        }
+    }
+
+    entries
+}
+
+fn format_entry_full(entry: &TranscriptEntry) -> String {
+    let mut parts = Vec::new();
+    for block in &entry.blocks {
+        match block {
+            TranscriptBlock::Text(text) => {
+                let truncated = if text.len() > 500 {
+                    format!("{}...", &text[..500])
+                } else {
+                    text.clone()
+                };
+                parts.push(truncated);
+            }
+            TranscriptBlock::ToolUse { name, input } => {
+                let input_str = if let Some(cmd) = input.get("command").and_then(|v| v.as_str()) {
+                    let truncated = if cmd.len() > 200 {
+                        format!("{}...", &cmd[..200])
+                    } else {
+                        cmd.to_string()
+                    };
+                    format!("({})", truncated)
+                } else {
+                    String::new()
+                };
+                parts.push(format!("[tool_use: {name}{input_str}]"));
+            }
+            TranscriptBlock::ToolResult { content, is_error } => {
+                let prefix = if *is_error { "ERROR: " } else { "" };
+                let truncated = if content.len() > 300 {
+                    format!("{}...", &content[..300])
+                } else {
+                    content.clone()
+                };
+                parts.push(format!("[tool_result: {prefix}{truncated}]"));
+            }
+        }
+    }
+
+    format!("[{}] {}", entry.role, parts.join(" "))
+}
+
+fn format_entry_compact(entry: &TranscriptEntry) -> String {
+    let mut summary_parts = Vec::new();
+    for block in &entry.blocks {
+        match block {
+            TranscriptBlock::Text(t) => {
+                let preview = if t.len() > 60 {
+                    format!("{}...", &t[..60])
+                } else {
+                    t.clone()
+                };
+                summary_parts.push(format!("\"{}\"", preview));
+            }
+            TranscriptBlock::ToolUse { name, .. } => {
+                summary_parts.push(format!("called {name}"));
+            }
+            TranscriptBlock::ToolResult { is_error, .. } => {
+                if *is_error {
+                    summary_parts.push("(error)".into());
+                }
+            }
+        }
+    }
+
+    format!("[{}] {}", entry.role, summary_parts.join(", "))
+}
+
+/// Format the full brain prompt by combining summary, transcript, and decision prompt.
+pub fn format_brain_prompt(ctx: &BrainContext) -> String {
+    format!(
+        "You are a session supervisor for Claude Code. Analyze the session state and recent \
+         conversation to decide what action to take.\n\n\
+         ## Session State\n{}\n\n\
+         ## Recent Conversation\n{}\n\n\
+         ## Decision\n{}",
+        ctx.session_summary, ctx.recent_transcript, ctx.decision_prompt
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{ClaudeSession, RawSession, SessionStatus, TelemetryStatus};
+
+    fn make_session() -> ClaudeSession {
+        let raw = RawSession {
+            pid: 100,
+            session_id: "test".into(),
+            cwd: "/tmp/my-project".into(),
+            started_at: 0,
+        };
+        let mut s = ClaudeSession::from_raw(raw);
+        s.status = SessionStatus::NeedsInput;
+        s.telemetry_status = TelemetryStatus::Available;
+        s.model = "opus-4.6".into();
+        s.cost_usd = 12.50;
+        s.context_tokens = 50000;
+        s.context_max = 200000;
+        s.pending_tool_name = Some("Bash".into());
+        s.pending_tool_input = Some("cargo test --release".into());
+        s
+    }
+
+    #[test]
+    fn session_summary_includes_key_fields() {
+        let s = make_session();
+        let summary = format_session_summary(&s);
+        assert!(summary.contains("my-project"));
+        assert!(summary.contains("Needs Input"));
+        assert!(summary.contains("opus-4.6"));
+        assert!(summary.contains("$12.50"));
+        assert!(summary.contains("25%"));
+        assert!(summary.contains("Bash"));
+        assert!(summary.contains("cargo test --release"));
+    }
+
+    #[test]
+    fn session_summary_shows_error_flag() {
+        let mut s = make_session();
+        s.last_tool_error = true;
+        let summary = format_session_summary(&s);
+        assert!(summary.contains("ERRORED"));
+    }
+
+    #[test]
+    fn decision_prompt_for_needs_input() {
+        let s = make_session();
+        let prompt = format_decision_prompt(&s);
+        assert!(prompt.contains("approval"));
+        assert!(prompt.contains("Bash"));
+        assert!(prompt.contains("approve"));
+    }
+
+    #[test]
+    fn decision_prompt_for_waiting_input() {
+        let mut s = make_session();
+        s.status = SessionStatus::WaitingInput;
+        let prompt = format_decision_prompt(&s);
+        assert!(prompt.contains("waiting for user input"));
+        assert!(prompt.contains("continue"));
+    }
+
+    #[test]
+    fn context_with_no_jsonl_path() {
+        let s = make_session();
+        let ctx = build_context(&s, 4000);
+        assert!(ctx.recent_transcript.contains("no transcript"));
+    }
+
+    #[test]
+    fn context_with_jsonl_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let jsonl = dir.path().join("test.jsonl");
+        std::fs::write(
+            &jsonl,
+            concat!(
+                r#"{"type":"assistant","message":{"role":"assistant","model":"opus","stop_reason":"tool_use","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}],"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}"#,
+                "\n",
+                r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"file1.rs\nfile2.rs"}],"usage":{"input_tokens":50,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}"#,
+            ),
+        )
+        .unwrap();
+
+        let mut s = make_session();
+        s.jsonl_path = Some(jsonl);
+
+        let ctx = build_context(&s, 4000);
+        assert!(ctx.recent_transcript.contains("Bash"));
+        assert!(ctx.recent_transcript.contains("file1.rs"));
+        assert!(!ctx.session_summary.is_empty());
+        assert!(!ctx.decision_prompt.is_empty());
+    }
+
+    #[test]
+    fn brain_prompt_combines_all_sections() {
+        let ctx = BrainContext {
+            session_summary: "summary".into(),
+            recent_transcript: "transcript".into(),
+            decision_prompt: "decide".into(),
+        };
+        let prompt = format_brain_prompt(&ctx);
+        assert!(prompt.contains("summary"));
+        assert!(prompt.contains("transcript"));
+        assert!(prompt.contains("decide"));
+    }
+}

--- a/src/brain/decisions.rs
+++ b/src/brain/decisions.rs
@@ -1,0 +1,213 @@
+#![allow(dead_code)]
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+
+use crate::brain::client::BrainSuggestion;
+
+/// A single decision record: what the brain suggested and what the user did.
+#[derive(Debug, Clone)]
+pub struct DecisionRecord {
+    pub timestamp: String,
+    pub pid: u32,
+    pub project: String,
+    pub tool: Option<String>,
+    pub command: Option<String>,
+    pub brain_action: String,
+    pub brain_confidence: f64,
+    pub brain_reasoning: String,
+    pub user_action: String, // "accept", "reject", "auto"
+}
+
+fn decisions_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    PathBuf::from(home).join(".claudectl").join("brain")
+}
+
+fn decisions_path() -> PathBuf {
+    decisions_dir().join("decisions.jsonl")
+}
+
+/// Log a brain decision (suggestion + user response) to the local JSONL file.
+pub fn log_decision(
+    pid: u32,
+    project: &str,
+    tool: Option<&str>,
+    command: Option<&str>,
+    suggestion: &BrainSuggestion,
+    user_action: &str,
+) {
+    let record = serde_json::json!({
+        "ts": timestamp_now(),
+        "pid": pid,
+        "project": project,
+        "tool": tool,
+        "command": command,
+        "brain_action": suggestion.action.label(),
+        "brain_confidence": suggestion.confidence,
+        "brain_reasoning": suggestion.reasoning,
+        "user_action": user_action,
+    });
+
+    let path = decisions_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) {
+        let _ = writeln!(
+            file,
+            "{}",
+            serde_json::to_string(&record).unwrap_or_default()
+        );
+    }
+}
+
+/// Read decision stats for display.
+pub fn read_stats() -> DecisionStats {
+    let path = decisions_path();
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return DecisionStats::default(),
+    };
+
+    let mut total = 0u32;
+    let mut accepted = 0u32;
+    let mut rejected = 0u32;
+    let mut auto_executed = 0u32;
+
+    for line in content.lines() {
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        total += 1;
+        match json.get("user_action").and_then(|v| v.as_str()) {
+            Some("accept") => accepted += 1,
+            Some("reject") => rejected += 1,
+            Some("auto") => auto_executed += 1,
+            _ => {}
+        }
+    }
+
+    DecisionStats {
+        total,
+        accepted,
+        rejected,
+        auto_executed,
+    }
+}
+
+/// Clear all decision history.
+pub fn forget() -> Result<(), String> {
+    let path = decisions_path();
+    if path.exists() {
+        fs::remove_file(&path).map_err(|e| format!("failed to delete {}: {e}", path.display()))?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Default)]
+pub struct DecisionStats {
+    pub total: u32,
+    pub accepted: u32,
+    pub rejected: u32,
+    pub auto_executed: u32,
+}
+
+impl DecisionStats {
+    pub fn accuracy_pct(&self) -> f64 {
+        let decided = self.accepted + self.rejected;
+        if decided == 0 {
+            return 0.0;
+        }
+        (self.accepted as f64 / decided as f64) * 100.0
+    }
+}
+
+fn timestamp_now() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // Simple ISO-ish format without chrono dependency
+    format!("{secs}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rules::RuleAction;
+
+    fn make_suggestion() -> BrainSuggestion {
+        BrainSuggestion {
+            action: RuleAction::Approve,
+            message: None,
+            reasoning: "safe command".into(),
+            confidence: 0.95,
+        }
+    }
+
+    #[test]
+    fn log_and_read_decisions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("decisions.jsonl");
+
+        // Write directly to a temp path
+        let record = serde_json::json!({
+            "user_action": "accept",
+            "brain_action": "approve",
+        });
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .unwrap();
+        writeln!(file, "{}", serde_json::to_string(&record).unwrap()).unwrap();
+
+        let record2 = serde_json::json!({
+            "user_action": "reject",
+            "brain_action": "approve",
+        });
+        writeln!(file, "{}", serde_json::to_string(&record2).unwrap()).unwrap();
+        drop(file);
+
+        // Parse the file
+        let content = fs::read_to_string(&path).unwrap();
+        let mut accepted = 0;
+        let mut rejected = 0;
+        for line in content.lines() {
+            let json: serde_json::Value = serde_json::from_str(line).unwrap();
+            match json["user_action"].as_str() {
+                Some("accept") => accepted += 1,
+                Some("reject") => rejected += 1,
+                _ => {}
+            }
+        }
+        assert_eq!(accepted, 1);
+        assert_eq!(rejected, 1);
+    }
+
+    #[test]
+    fn stats_accuracy() {
+        let stats = DecisionStats {
+            total: 10,
+            accepted: 8,
+            rejected: 2,
+            auto_executed: 0,
+        };
+        assert!((stats.accuracy_pct() - 80.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn stats_accuracy_no_decisions() {
+        let stats = DecisionStats::default();
+        assert!((stats.accuracy_pct() - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn suggestion_label_used() {
+        let s = make_suggestion();
+        assert_eq!(s.action.label(), "approve");
+    }
+}

--- a/src/brain/engine.rs
+++ b/src/brain/engine.rs
@@ -1,1 +1,301 @@
-// Brain inference engine — implemented in #92
+#![allow(dead_code)]
+
+use std::collections::{HashMap, HashSet};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::time::Instant;
+
+use crate::config::BrainConfig;
+use crate::rules::{self, RuleAction, RuleMatch};
+use crate::session::{ClaudeSession, SessionStatus};
+
+use super::client::BrainSuggestion;
+use super::context;
+
+/// Result sent back from inference thread.
+pub struct BrainResult {
+    pub pid: u32,
+    pub suggestion: Result<BrainSuggestion, String>,
+}
+
+/// The brain inference engine. Manages async inference threads and collects results.
+pub struct BrainEngine {
+    config: BrainConfig,
+    tx: Sender<BrainResult>,
+    rx: Receiver<BrainResult>,
+    /// PIDs currently being inferred (prevents duplicate requests).
+    inflight: HashSet<u32>,
+    /// Per-PID cooldown to avoid hammering the LLM.
+    cooldown: HashMap<u32, Instant>,
+    /// Pending suggestions waiting for user confirmation (advisory mode).
+    pub pending: HashMap<u32, BrainSuggestion>,
+}
+
+const COOLDOWN_SECS: u64 = 10;
+
+impl BrainEngine {
+    pub fn new(config: BrainConfig) -> Self {
+        let (tx, rx) = mpsc::channel();
+        Self {
+            config,
+            tx,
+            rx,
+            inflight: HashSet::new(),
+            cooldown: HashMap::new(),
+            pending: HashMap::new(),
+        }
+    }
+
+    /// Run one tick of the brain engine. Call this from app.tick() after refresh().
+    ///
+    /// 1. Collect results from completed inference threads
+    /// 2. Spawn new inference threads for eligible sessions
+    ///
+    /// Returns a list of (pid, status_message) for actions taken this tick.
+    pub fn tick(
+        &mut self,
+        sessions: &[ClaudeSession],
+        deny_rules: &[crate::rules::AutoRule],
+    ) -> Vec<(u32, String)> {
+        let mut actions = Vec::new();
+
+        // Phase 1: Collect results from completed inferences
+        while let Ok(result) = self.rx.try_recv() {
+            self.inflight.remove(&result.pid);
+            self.cooldown.insert(result.pid, Instant::now());
+
+            match result.suggestion {
+                Ok(suggestion) => {
+                    // Check if a deny rule overrides the brain
+                    let session = sessions.iter().find(|s| s.pid == result.pid);
+                    if let Some(session) = session {
+                        let deny_match = rules::evaluate(deny_rules, session);
+                        if let Some(dm) = &deny_match {
+                            if dm.action == RuleAction::Deny {
+                                actions.push((
+                                    result.pid,
+                                    format!(
+                                        "Brain suggested {}, but deny rule '{}' overrides",
+                                        suggestion.action.label(),
+                                        dm.rule_name,
+                                    ),
+                                ));
+                                continue;
+                            }
+                        }
+                    }
+
+                    if self.config.auto_mode {
+                        // Auto mode: execute immediately
+                        if let Some(session) = session {
+                            let rule_match = suggestion_to_rule_match(&suggestion);
+                            match rules::execute(&rule_match, session) {
+                                Ok(msg) => actions.push((result.pid, msg)),
+                                Err(e) => actions.push((result.pid, format!("Brain error: {e}"))),
+                            }
+                        }
+                    } else {
+                        // Advisory mode: store for user confirmation
+                        self.pending.insert(result.pid, suggestion);
+                    }
+                }
+                Err(e) => {
+                    crate::logger::log(
+                        "BRAIN",
+                        &format!("Inference failed for PID {}: {e}", result.pid),
+                    );
+                }
+            }
+        }
+
+        // Phase 2: Spawn inference for eligible sessions
+        for session in sessions {
+            if !matches!(
+                session.status,
+                SessionStatus::NeedsInput | SessionStatus::WaitingInput
+            ) {
+                continue;
+            }
+
+            if self.inflight.contains(&session.pid) {
+                continue;
+            }
+
+            if let Some(last) = self.cooldown.get(&session.pid) {
+                if last.elapsed().as_secs() < COOLDOWN_SECS {
+                    continue;
+                }
+            }
+
+            // Already have a pending suggestion for this PID
+            if self.pending.contains_key(&session.pid) {
+                continue;
+            }
+
+            self.spawn_inference(session);
+        }
+
+        actions
+    }
+
+    fn spawn_inference(&mut self, session: &ClaudeSession) {
+        let pid = session.pid;
+        let config = self.config.clone();
+        let tx = self.tx.clone();
+
+        // Build context on the main thread (reads JSONL files)
+        let brain_ctx = context::build_context(session, config.max_context_tokens);
+        let prompt = context::format_brain_prompt(&brain_ctx);
+
+        self.inflight.insert(pid);
+
+        std::thread::spawn(move || {
+            let suggestion = super::client::infer(&config, &prompt);
+            let _ = tx.send(BrainResult { pid, suggestion });
+        });
+    }
+
+    /// Accept a pending brain suggestion (user pressed 'b').
+    pub fn accept(&mut self, pid: u32, session: &ClaudeSession) -> Option<String> {
+        let suggestion = self.pending.remove(&pid)?;
+        let rule_match = suggestion_to_rule_match(&suggestion);
+        match rules::execute(&rule_match, session) {
+            Ok(msg) => Some(msg),
+            Err(e) => Some(format!("Brain execute error: {e}")),
+        }
+    }
+
+    /// Reject a pending brain suggestion (user pressed 'B').
+    pub fn reject(&mut self, pid: u32) -> Option<BrainSuggestion> {
+        self.pending.remove(&pid)
+    }
+
+    /// Clear pending suggestions for PIDs that are no longer in NeedsInput/WaitingInput.
+    pub fn cleanup(&mut self, sessions: &[ClaudeSession]) {
+        let active_pids: HashSet<u32> = sessions.iter().map(|s| s.pid).collect();
+        self.pending.retain(|pid, _| {
+            active_pids.contains(pid)
+                && sessions.iter().any(|s| {
+                    s.pid == *pid
+                        && matches!(
+                            s.status,
+                            SessionStatus::NeedsInput | SessionStatus::WaitingInput
+                        )
+                })
+        });
+        self.inflight.retain(|pid| active_pids.contains(pid));
+    }
+}
+
+fn suggestion_to_rule_match(suggestion: &BrainSuggestion) -> RuleMatch {
+    RuleMatch {
+        rule_name: format!(
+            "brain ({}% confidence)",
+            (suggestion.confidence * 100.0) as u32
+        ),
+        action: suggestion.action.clone(),
+        message: suggestion.message.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{RawSession, TelemetryStatus};
+
+    fn make_config() -> BrainConfig {
+        BrainConfig {
+            enabled: true,
+            endpoint: "http://localhost:11434/api/generate".into(),
+            model: "test".into(),
+            auto_mode: false,
+            timeout_ms: 1000,
+            max_context_tokens: 1000,
+        }
+    }
+
+    fn make_session(pid: u32, status: SessionStatus) -> ClaudeSession {
+        let raw = RawSession {
+            pid,
+            session_id: "test".into(),
+            cwd: "/tmp/test".into(),
+            started_at: 0,
+        };
+        let mut s = ClaudeSession::from_raw(raw);
+        s.status = status;
+        s.telemetry_status = TelemetryStatus::Available;
+        s.pending_tool_name = Some("Bash".into());
+        s
+    }
+
+    #[test]
+    fn engine_creates_without_panic() {
+        let _engine = BrainEngine::new(make_config());
+    }
+
+    #[test]
+    fn suggestion_to_rule_match_format() {
+        let suggestion = BrainSuggestion {
+            action: RuleAction::Approve,
+            message: None,
+            reasoning: "safe".into(),
+            confidence: 0.95,
+        };
+        let rm = suggestion_to_rule_match(&suggestion);
+        assert_eq!(rm.action, RuleAction::Approve);
+        assert!(rm.rule_name.contains("95%"));
+    }
+
+    #[test]
+    fn cleanup_removes_stale_pending() {
+        let mut engine = BrainEngine::new(make_config());
+        engine.pending.insert(
+            999,
+            BrainSuggestion {
+                action: RuleAction::Approve,
+                message: None,
+                reasoning: "test".into(),
+                confidence: 0.9,
+            },
+        );
+
+        // PID 999 not in sessions list → should be cleaned up
+        engine.cleanup(&[]);
+        assert!(engine.pending.is_empty());
+    }
+
+    #[test]
+    fn cleanup_keeps_active_pending() {
+        let mut engine = BrainEngine::new(make_config());
+        let session = make_session(100, SessionStatus::NeedsInput);
+        engine.pending.insert(
+            100,
+            BrainSuggestion {
+                action: RuleAction::Approve,
+                message: None,
+                reasoning: "test".into(),
+                confidence: 0.9,
+            },
+        );
+
+        engine.cleanup(&[session]);
+        assert!(engine.pending.contains_key(&100));
+    }
+
+    #[test]
+    fn reject_removes_and_returns_suggestion() {
+        let mut engine = BrainEngine::new(make_config());
+        engine.pending.insert(
+            100,
+            BrainSuggestion {
+                action: RuleAction::Approve,
+                message: None,
+                reasoning: "test".into(),
+                confidence: 0.9,
+            },
+        );
+
+        let rejected = engine.reject(100);
+        assert!(rejected.is_some());
+        assert!(engine.pending.is_empty());
+    }
+}

--- a/src/brain/engine.rs
+++ b/src/brain/engine.rs
@@ -1,0 +1,1 @@
+// Brain inference engine — implemented in #92

--- a/src/brain/mod.rs
+++ b/src/brain/mod.rs
@@ -1,0 +1,3 @@
+pub mod client;
+pub mod context;
+pub mod engine;

--- a/src/brain/mod.rs
+++ b/src/brain/mod.rs
@@ -1,3 +1,4 @@
 pub mod client;
 pub mod context;
+pub mod decisions;
 pub mod engine;

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,32 @@ pub struct Config {
     pub context_warn_threshold: u8, // 0-100, fires on_context_high when context % crosses this
     pub model_overrides: Vec<ModelOverride>,
     pub rules: Vec<AutoRule>,
+    pub brain: Option<BrainConfig>,
+}
+
+/// Configuration for the optional local LLM brain.
+/// When `None`, brain is completely disabled with zero overhead.
+#[derive(Debug, Clone)]
+pub struct BrainConfig {
+    pub enabled: bool,
+    pub endpoint: String,
+    pub model: String,
+    pub auto_mode: bool,
+    pub timeout_ms: u64,
+    pub max_context_tokens: u32,
+}
+
+impl Default for BrainConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            endpoint: "http://localhost:11434/api/generate".into(),
+            model: "gemma3:12b".into(),
+            auto_mode: false,
+            timeout_ms: 5000,
+            max_context_tokens: 4000,
+        }
+    }
 }
 
 impl Default for Config {
@@ -41,6 +67,7 @@ impl Default for Config {
             context_warn_threshold: 75,
             model_overrides: Vec::new(),
             rules: Vec::new(),
+            brain: None,
         }
     }
 }
@@ -62,6 +89,7 @@ struct RawConfig {
     context_warn_threshold: Option<u8>,
     model_overrides: Vec<ModelOverride>,
     rules: Vec<AutoRule>,
+    brain: Option<BrainConfig>,
 }
 
 impl Config {
@@ -132,6 +160,9 @@ impl Config {
             } else {
                 self.rules.push(rule);
             }
+        }
+        if let Some(brain) = raw.brain {
+            self.brain = Some(brain);
         }
     }
 
@@ -333,6 +364,34 @@ fn parse_config_file(path: &PathBuf) -> Option<RawConfig> {
                         }
                     }
                     "message" => rule.message = Some(unquote(value)),
+                    _ => {}
+                }
+            }
+            ("brain", _) => {
+                let brain = raw.brain.get_or_insert_with(BrainConfig::default);
+                match key {
+                    "enabled" => {
+                        if let Some(v) = parse_bool(value) {
+                            brain.enabled = v;
+                        }
+                    }
+                    "endpoint" => brain.endpoint = unquote(value),
+                    "model" => brain.model = unquote(value),
+                    "auto" => {
+                        if let Some(v) = parse_bool(value) {
+                            brain.auto_mode = v;
+                        }
+                    }
+                    "timeout_ms" => {
+                        if let Ok(v) = value.parse() {
+                            brain.timeout_ms = v;
+                        }
+                    }
+                    "max_context_tokens" => {
+                        if let Ok(v) = value.parse() {
+                            brain.max_context_tokens = v;
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -617,5 +676,45 @@ action = "terminate"
         assert_eq!(r3.name, "kill_expensive");
         assert_eq!(r3.match_cost_above, Some(10.0));
         assert_eq!(r3.action, RuleAction::Terminate);
+    }
+
+    #[test]
+    fn test_parse_brain_config() {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+[brain]
+enabled = true
+endpoint = "http://localhost:8080/v1/chat"
+model = "llama3:8b"
+auto = true
+timeout_ms = 3000
+max_context_tokens = 8000
+"#
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let raw = parse_config_file(&file.path().to_path_buf()).unwrap();
+        let brain = raw.brain.expect("brain config should be parsed");
+        assert!(brain.enabled);
+        assert_eq!(brain.endpoint, "http://localhost:8080/v1/chat");
+        assert_eq!(brain.model, "llama3:8b");
+        assert!(brain.auto_mode);
+        assert_eq!(brain.timeout_ms, 3000);
+        assert_eq!(brain.max_context_tokens, 8000);
+    }
+
+    #[test]
+    fn test_no_brain_config_returns_none() {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(file, "[defaults]\ninterval = 1000").unwrap();
+        file.flush().unwrap();
+
+        let raw = parse_config_file(&file.path().to_path_buf()).unwrap();
+        assert!(raw.brain.is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 )]
 
 pub mod app;
+pub mod brain;
 pub mod config;
 pub mod demo;
 pub mod discovery;

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,22 @@ struct Cli {
     /// Record the TUI session as an asciicast v2 file (e.g., --record demo.cast)
     #[arg(long)]
     record: Option<String>,
+
+    /// Enable local LLM brain for session advisory (requires ollama or compatible endpoint)
+    #[arg(long)]
+    brain: bool,
+
+    /// Auto-execute brain suggestions without confirmation (requires --brain)
+    #[arg(long)]
+    brain_auto: bool,
+
+    /// Override brain LLM endpoint URL (requires --brain)
+    #[arg(long)]
+    brain_endpoint: Option<String>,
+
+    /// Override brain model name (requires --brain)
+    #[arg(long)]
+    brain_model: Option<String>,
 }
 
 fn main() -> io::Result<()> {
@@ -235,6 +251,21 @@ fn main() -> io::Result<()> {
                 .map(|t| t.trim().to_string())
                 .collect::<Vec<_>>()
         });
+    }
+
+    // Brain CLI overrides
+    if cli.brain {
+        let brain = cfg.brain.get_or_insert_with(config::BrainConfig::default);
+        brain.enabled = true;
+        if cli.brain_auto {
+            brain.auto_mode = true;
+        }
+        if let Some(ref endpoint) = cli.brain_endpoint {
+            brain.endpoint = endpoint.clone();
+        }
+        if let Some(ref model) = cli.brain_model {
+            brain.model = model.clone();
+        }
     }
 
     models::set_overrides(cfg.model_overrides.clone());
@@ -925,6 +956,7 @@ fn run_tui<W: io::Write>(
     app.weekly_limit = cfg.weekly_limit;
     app.context_warn_threshold = cfg.context_warn_threshold;
     app.rules = cfg.rules.clone();
+    app.brain_config = cfg.brain.clone();
     app.demo_mode = demo_mode;
     apply_filters(&mut app, filters);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 )]
 
 mod app;
+mod brain;
 mod config;
 mod demo;
 mod discovery;

--- a/src/main.rs
+++ b/src/main.rs
@@ -958,6 +958,11 @@ fn run_tui<W: io::Write>(
     app.context_warn_threshold = cfg.context_warn_threshold;
     app.rules = cfg.rules.clone();
     app.brain_config = cfg.brain.clone();
+    if let Some(ref brain_cfg) = cfg.brain {
+        if brain_cfg.enabled {
+            app.brain_engine = Some(brain::engine::BrainEngine::new(brain_cfg.clone()));
+        }
+    }
     app.demo_mode = demo_mode;
     apply_filters(&mut app, filters);
 

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -95,5 +95,20 @@ pub fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
             Style::default().fg(t.error).add_modifier(Modifier::BOLD),
         ));
         frame.render_widget(msg, area);
+    } else if let Some(ref engine) = app.brain_engine {
+        if !engine.pending.is_empty() {
+            let count = engine.pending.len();
+            let label = if count == 1 {
+                "1 suggestion".into()
+            } else {
+                format!("{count} suggestions")
+            };
+            let text = format!(" Brain: {label} pending  (b accept / B reject)");
+            let msg = Paragraph::new(Span::styled(
+                text,
+                Style::default().fg(t.header).add_modifier(Modifier::BOLD),
+            ));
+            frame.render_widget(msg, area);
+        }
     }
 }

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -451,8 +451,21 @@ fn session_row(s: &ClaudeSession, app: &App) -> Row<'static> {
         Style::default().fg(t.status_color(&s.status))
     };
 
+    let has_brain_suggestion = app
+        .brain_engine
+        .as_ref()
+        .is_some_and(|e| e.pending.contains_key(&s.pid));
+
     let status_text = if app.auto_approve.contains(&s.pid) {
         format!("{}*", s.status)
+    } else if has_brain_suggestion {
+        let action = app
+            .brain_engine
+            .as_ref()
+            .and_then(|e| e.pending.get(&s.pid))
+            .map(|sg| sg.action.label())
+            .unwrap_or("?");
+        format!("{} [b:{}]", s.status, action)
     } else if s.status == SessionStatus::Unknown {
         s.telemetry_status.short_label().to_string()
     } else if s.status == SessionStatus::NeedsInput {


### PR DESCRIPTION
## Summary

Adds an optional local LLM brain that observes Claude Code sessions and suggests actions. Fully opt-in — zero impact when disabled. No new crate dependencies.

## Sub-issues (1 commit each)

- [x] #89 — Config, CLI flags, feature gate (`BrainConfig`, `--brain`, `--brain-auto`)
- [x] #90 — Context builder (compact LLM prompts from session transcripts)
- [x] #91 — LLM client (curl subprocess to ollama, response parsing)
- [x] #92 — Inference loop (async thread + channel, 10s cooldown, deny override)
- [x] #93 — Advisory UI (inline suggestions, `b` accept / `B` reject)
- [x] #94 — Decision logging (append-only JSONL at `~/.claudectl/brain/`)

## Architecture

```
Session JSONL → Context Builder → curl → ollama → BrainSuggestion
                                                        ↓
                                            Advisory UI (user confirms with b/B)
                                                        ↓
                                            rules::execute() (same path as rule-based actions)
```

## Activation

```bash
claudectl --brain                           # advisory mode
claudectl --brain --brain-auto              # auto mode
claudectl --brain --brain-model gemma3:12b  # custom model
```

Or in `.claudectl.toml`:
```toml
[brain]
enabled = true
endpoint = "http://localhost:11434/api/generate"
model = "gemma3:12b"
auto = false
```

## Key constraints met

- **Opt-in**: `--brain` flag or `[brain]` config. Zero impact when disabled.
- **No new dependencies**: curl subprocess for HTTP (same as webhook system)
- **Non-blocking**: inference in spawned threads, results on next tick
- **Deny-list respected**: rule-based deny rules always override brain
- **Advisory first**: human confirms. Auto mode behind `--brain-auto`.

## Test plan

- [x] 36 new tests across 5 modules (config, context, client, engine, decisions)
- [x] All 281 existing tests pass
- [x] clippy clean, fmt clean
- [ ] Manual: run with `--brain` pointing at local ollama instance

Closes #85, #89, #90, #91, #92, #93, #94
Bump 0.17.1 → 0.18.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)