### PR TITLE
feat(brain): inter-session routing with auto-summarization

### DIFF
--- a/src/brain/client.rs
+++ b/src/brain/client.rs
@@ -51,6 +51,66 @@ pub fn infer(config: &BrainConfig, prompt: &str) -> Result<BrainSuggestion, Stri
     parse_ollama_response(&stdout)
 }
 
+/// Summarize source session output for routing to a target session.
+/// Returns a compact summary that won't bloat the target's context.
+pub fn summarize_for_routing(
+    config: &BrainConfig,
+    source_output: &str,
+    source_project: &str,
+    target_task: &str,
+) -> Result<String, String> {
+    let prompt = format!(
+        "Summarize this output from session '{source_project}' for another Claude Code session \
+         working on: {target_task}\n\n\
+         Keep ONLY what's relevant to the target task. Be concise — this will be injected into \
+         another session's context. Max 500 words.\n\n\
+         Output to summarize:\n{source_output}"
+    );
+
+    let payload = serde_json::json!({
+        "model": config.model,
+        "prompt": prompt,
+        "stream": false,
+    });
+
+    let body = serde_json::to_string(&payload).map_err(|e| format!("json error: {e}"))?;
+    let timeout_secs = (config.timeout_ms / 1000).max(1);
+
+    let output = Command::new("curl")
+        .args([
+            "-s",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            &body,
+            "--max-time",
+            &timeout_secs.to_string(),
+            &config.endpoint,
+        ])
+        .output()
+        .map_err(|e| format!("curl failed: {e}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "curl error: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).map_err(|e| format!("invalid response: {e}"))?;
+
+    let text = json
+        .get("response")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&stdout);
+
+    Ok(text.trim().to_string())
+}
+
 /// Parse the ollama `/api/generate` response format.
 fn parse_ollama_response(response: &str) -> Result<BrainSuggestion, String> {
     let json: serde_json::Value =
@@ -77,8 +137,15 @@ pub fn parse_suggestion_json(text: &str) -> Result<BrainSuggestion, String> {
         .and_then(|v| v.as_str())
         .ok_or("missing 'action' field")?;
 
-    let action =
-        RuleAction::parse(action_str).ok_or_else(|| format!("unknown action '{action_str}'"))?;
+    let action = if action_str == "route" {
+        let target_pid = json
+            .get("target_pid")
+            .and_then(|v| v.as_u64())
+            .ok_or("route action requires 'target_pid' field")? as u32;
+        RuleAction::Route { target_pid }
+    } else {
+        RuleAction::parse(action_str).ok_or_else(|| format!("unknown action '{action_str}'"))?
+    };
 
     let message = json
         .get("message")

--- a/src/brain/context.rs
+++ b/src/brain/context.rs
@@ -85,8 +85,10 @@ fn format_decision_prompt(session: &ClaudeSession) -> String {
             format!(
                 "The session is waiting for approval of a '{}' tool call. \
                  Should this be approved, denied, or should a message be sent instead? \
-                 Respond with JSON: {{\"action\": \"approve\"|\"deny\"|\"send\"|\"terminate\", \
-                 \"message\": \"...\", \"reasoning\": \"...\", \"confidence\": 0.0-1.0}}",
+                 Respond with JSON: {{\"action\": \"approve\"|\"deny\"|\"send\"|\"terminate\"|\"route\", \
+                 \"message\": \"...\", \"reasoning\": \"...\", \"confidence\": 0.0-1.0, \
+                 \"target_pid\": <pid if action is route>}}. \
+                 Use 'route' to send summarized output from this session to another session.",
                 tool
             )
         }

--- a/src/brain/engine.rs
+++ b/src/brain/engine.rs
@@ -87,10 +87,30 @@ impl BrainEngine {
                     if self.config.auto_mode {
                         // Auto mode: execute immediately
                         if let Some(session) = session {
-                            let rule_match = suggestion_to_rule_match(&suggestion);
-                            match rules::execute(&rule_match, session) {
-                                Ok(msg) => actions.push((result.pid, msg)),
-                                Err(e) => actions.push((result.pid, format!("Brain error: {e}"))),
+                            // Route action needs special handling (summarize + send to target)
+                            if let RuleAction::Route { target_pid } = &suggestion.action {
+                                let target = sessions.iter().find(|s| s.pid == *target_pid);
+                                if let Some(target) = target {
+                                    match self.execute_route(session, target) {
+                                        Ok(msg) => actions.push((result.pid, msg)),
+                                        Err(e) => {
+                                            actions.push((result.pid, format!("Route error: {e}")))
+                                        }
+                                    }
+                                } else {
+                                    actions.push((
+                                        result.pid,
+                                        format!("Route error: target PID {} not found", target_pid),
+                                    ));
+                                }
+                            } else {
+                                let rule_match = suggestion_to_rule_match(&suggestion);
+                                match rules::execute(&rule_match, session) {
+                                    Ok(msg) => actions.push((result.pid, msg)),
+                                    Err(e) => {
+                                        actions.push((result.pid, format!("Brain error: {e}")))
+                                    }
+                                }
                             }
                         }
                     } else {
@@ -164,6 +184,30 @@ impl BrainEngine {
             let suggestion = super::client::infer(&config, &prompt);
             let _ = tx.send(BrainResult { pid, suggestion });
         });
+    }
+
+    /// Execute a route: read source's recent transcript, summarize via LLM, send to target.
+    fn execute_route(
+        &self,
+        source: &ClaudeSession,
+        target: &ClaudeSession,
+    ) -> Result<String, String> {
+        // Build source context to get recent transcript
+        let source_ctx = context::build_context(
+            source,
+            std::slice::from_ref(source),
+            self.config.max_context_tokens,
+        );
+
+        // Summarize for target's task
+        let summary = super::client::summarize_for_routing(
+            &self.config,
+            &source_ctx.recent_transcript,
+            source.display_name(),
+            target.display_name(),
+        )?;
+
+        rules::execute_route(source, target, &summary, "brain")
     }
 
     /// Accept a pending brain suggestion (user pressed 'b').

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -7,6 +7,10 @@ pub enum RuleAction {
     Deny,
     Send,
     Terminate,
+    /// Route summarized output from the current session to another session.
+    Route {
+        target_pid: u32,
+    },
 }
 
 impl RuleAction {
@@ -27,6 +31,7 @@ impl RuleAction {
             Self::Deny => "deny",
             Self::Send => "send",
             Self::Terminate => "terminate",
+            Self::Route { .. } => "route",
         }
     }
 }
@@ -202,7 +207,33 @@ pub fn execute(result: &RuleMatch, session: &ClaudeSession) -> Result<String, St
                 Err(format!("Rule '{}': kill {} failed", result.rule_name, pid))
             }
         }
+        RuleAction::Route { .. } => {
+            // Route execution happens in the brain engine (needs access to
+            // target session + LLM for summarization). This arm should not
+            // be reached via rules::execute() directly.
+            Ok(format!(
+                "Rule '{}': route queued for {}",
+                result.rule_name, name
+            ))
+        }
     }
+}
+
+/// Execute a Route action: summarize source output and send to target session.
+pub fn execute_route(
+    source: &ClaudeSession,
+    target: &ClaudeSession,
+    summary: &str,
+    rule_name: &str,
+) -> Result<String, String> {
+    let msg = format!("[From {}] {}", source.display_name(), summary);
+    terminals::send_input(target, &msg)?;
+    Ok(format!(
+        "Rule '{}': routed summary from {} → {}",
+        rule_name,
+        source.display_name(),
+        target.display_name(),
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

The brain can now route summarized information between live sessions. When session A has output relevant to session B, the brain summarizes it via the local LLM and sends the summary to B — preventing raw logs from bloating B's context window.

## How it works

```
Brain sees: session A found auth bugs, session B is working on auth
Brain decides: route A's findings to B
→ LLM summarizes A's transcript for B's task context
→ send_input(B, "[From arg-agi3] Found auth bugs in login.rs:42, session.rs:88...")
```

## Changes

- `RuleAction::Route { target_pid }` — new action variant
- `summarize_for_routing()` — LLM call to compress source output for target
- `execute_route()` — sends `[From source] summary` to target session
- Brain engine handles Route in auto-mode execution
- Decision prompt updated to include "route" action

## Test plan
- [x] All 295 tests pass
- [x] clippy clean (all targets)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)