### PR TITLE
feat(brain): Spawn action — brain launches new sessions

### DIFF
--- a/src/brain/client.rs
+++ b/src/brain/client.rs
@@ -143,6 +143,18 @@ pub fn parse_suggestion_json(text: &str) -> Result<BrainSuggestion, String> {
             .and_then(|v| v.as_u64())
             .ok_or("route action requires 'target_pid' field")? as u32;
         RuleAction::Route { target_pid }
+    } else if action_str == "spawn" {
+        let prompt = json
+            .get("spawn_prompt")
+            .and_then(|v| v.as_str())
+            .ok_or("spawn action requires 'spawn_prompt' field")?
+            .to_string();
+        let cwd = json
+            .get("spawn_cwd")
+            .and_then(|v| v.as_str())
+            .unwrap_or(".")
+            .to_string();
+        RuleAction::Spawn { prompt, cwd }
     } else {
         RuleAction::parse(action_str).ok_or_else(|| format!("unknown action '{action_str}'"))?
     };

--- a/src/brain/engine.rs
+++ b/src/brain/engine.rs
@@ -87,28 +87,52 @@ impl BrainEngine {
                     if self.config.auto_mode {
                         // Auto mode: execute immediately
                         if let Some(session) = session {
-                            // Route action needs special handling (summarize + send to target)
-                            if let RuleAction::Route { target_pid } = &suggestion.action {
-                                let target = sessions.iter().find(|s| s.pid == *target_pid);
-                                if let Some(target) = target {
-                                    match self.execute_route(session, target) {
-                                        Ok(msg) => actions.push((result.pid, msg)),
-                                        Err(e) => {
-                                            actions.push((result.pid, format!("Route error: {e}")))
+                            match &suggestion.action {
+                                RuleAction::Route { target_pid } => {
+                                    let target = sessions.iter().find(|s| s.pid == *target_pid);
+                                    if let Some(target) = target {
+                                        match self.execute_route(session, target) {
+                                            Ok(msg) => actions.push((result.pid, msg)),
+                                            Err(e) => actions
+                                                .push((result.pid, format!("Route error: {e}"))),
+                                        }
+                                    } else {
+                                        actions.push((
+                                            result.pid,
+                                            format!(
+                                                "Route error: target PID {} not found",
+                                                target_pid
+                                            ),
+                                        ));
+                                    }
+                                }
+                                RuleAction::Spawn { .. } => {
+                                    // Enforce max_sessions limit
+                                    if sessions.len() >= self.config.max_sessions {
+                                        actions.push((
+                                            result.pid,
+                                            format!(
+                                                "Spawn blocked: {} sessions active (max {})",
+                                                sessions.len(),
+                                                self.config.max_sessions
+                                            ),
+                                        ));
+                                    } else {
+                                        let rule_match = suggestion_to_rule_match(&suggestion);
+                                        match rules::execute(&rule_match, session) {
+                                            Ok(msg) => actions.push((result.pid, msg)),
+                                            Err(e) => actions
+                                                .push((result.pid, format!("Spawn error: {e}"))),
                                         }
                                     }
-                                } else {
-                                    actions.push((
-                                        result.pid,
-                                        format!("Route error: target PID {} not found", target_pid),
-                                    ));
                                 }
-                            } else {
-                                let rule_match = suggestion_to_rule_match(&suggestion);
-                                match rules::execute(&rule_match, session) {
-                                    Ok(msg) => actions.push((result.pid, msg)),
-                                    Err(e) => {
-                                        actions.push((result.pid, format!("Brain error: {e}")))
+                                _ => {
+                                    let rule_match = suggestion_to_rule_match(&suggestion);
+                                    match rules::execute(&rule_match, session) {
+                                        Ok(msg) => actions.push((result.pid, msg)),
+                                        Err(e) => {
+                                            actions.push((result.pid, format!("Brain error: {e}")))
+                                        }
                                     }
                                 }
                             }
@@ -267,6 +291,7 @@ mod tests {
             timeout_ms: 1000,
             max_context_tokens: 1000,
             few_shot_count: 5,
+            max_sessions: 10,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ pub struct BrainConfig {
     pub timeout_ms: u64,
     pub max_context_tokens: u32,
     pub few_shot_count: usize,
+    pub max_sessions: usize,
 }
 
 impl Default for BrainConfig {
@@ -48,6 +49,7 @@ impl Default for BrainConfig {
             timeout_ms: 5000,
             max_context_tokens: 4000,
             few_shot_count: 5,
+            max_sessions: 10,
         }
     }
 }
@@ -397,6 +399,11 @@ fn parse_config_file(path: &PathBuf) -> Option<RawConfig> {
                     "few_shot_count" => {
                         if let Ok(v) = value.parse() {
                             brain.few_shot_count = v;
+                        }
+                    }
+                    "max_sessions" => {
+                        if let Ok(v) = value.parse() {
+                            brain.max_sessions = v;
                         }
                     }
                     _ => {}

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -11,6 +11,11 @@ pub enum RuleAction {
     Route {
         target_pid: u32,
     },
+    /// Spawn a new Claude Code session with a derived prompt.
+    Spawn {
+        prompt: String,
+        cwd: String,
+    },
 }
 
 impl RuleAction {
@@ -32,6 +37,7 @@ impl RuleAction {
             Self::Send => "send",
             Self::Terminate => "terminate",
             Self::Route { .. } => "route",
+            Self::Spawn { .. } => "spawn",
         }
     }
 }
@@ -208,14 +214,25 @@ pub fn execute(result: &RuleMatch, session: &ClaudeSession) -> Result<String, St
             }
         }
         RuleAction::Route { .. } => {
-            // Route execution happens in the brain engine (needs access to
-            // target session + LLM for summarization). This arm should not
-            // be reached via rules::execute() directly.
+            // Route execution happens in the brain engine.
             Ok(format!(
                 "Rule '{}': route queued for {}",
                 result.rule_name, name
             ))
         }
+        RuleAction::Spawn {
+            ref prompt,
+            ref cwd,
+        } => match terminals::launch_session(cwd, Some(prompt), None) {
+            Ok(msg) => Ok(format!(
+                "Rule '{}': spawned new session for {} — {msg}",
+                result.rule_name, name
+            )),
+            Err(e) => Err(format!(
+                "Rule '{}': spawn failed for {}: {e}",
+                result.rule_name, name
+            )),
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

The brain can now spawn new Claude Code sessions with derived prompts. When it determines work should be delegated, parallelized, or a session's context is too full, it can launch a new session.

## Changes

- `RuleAction::Spawn { prompt, cwd }` — new action variant
- `max_sessions` config (default 10) — prevents runaway spawning
- Spawn execution via existing `terminals::launch_session()`
- Brain JSON parsing handles `{"action": "spawn", "spawn_prompt": "...", "spawn_cwd": "."}`
- Only available in auto mode

## Test plan
- [x] All 295 tests pass
- [x] clippy clean (all targets)

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)