### PR TITLE
feat(brain): agent registry and config parsing

### DIFF
--- a/src/brain/agents.rs
+++ b/src/brain/agents.rs
@@ -1,0 +1,107 @@
+#![allow(dead_code)]
+
+/// Configuration for an external agent (Codex, Aider, custom scripts).
+#[derive(Debug, Clone)]
+pub struct AgentConfig {
+    pub name: String,
+    pub agent_type: String,
+    pub command: String,
+    pub capabilities: Vec<String>,
+    pub cwd: String,
+}
+
+impl AgentConfig {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            agent_type: "custom".into(),
+            command: String::new(),
+            capabilities: Vec::new(),
+            cwd: ".".into(),
+        }
+    }
+
+    /// Format as a compact line for the brain prompt.
+    pub fn prompt_line(&self) -> String {
+        let caps = if self.capabilities.is_empty() {
+            "general".to_string()
+        } else {
+            self.capabilities.join(", ")
+        };
+        format!("- {}: {} ({})", self.name, caps, self.agent_type)
+    }
+}
+
+/// Format all registered agents as a prompt section for the brain.
+pub fn format_agents_prompt(agents: &[AgentConfig]) -> String {
+    if agents.is_empty() {
+        return String::new();
+    }
+
+    let mut lines = vec!["## Available Agents".to_string()];
+    for agent in agents {
+        lines.push(agent.prompt_line());
+    }
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_config_defaults() {
+        let a = AgentConfig::new("test".into());
+        assert_eq!(a.name, "test");
+        assert_eq!(a.agent_type, "custom");
+        assert_eq!(a.cwd, ".");
+        assert!(a.capabilities.is_empty());
+    }
+
+    #[test]
+    fn prompt_line_format() {
+        let mut a = AgentConfig::new("codex".into());
+        a.agent_type = "codex".into();
+        a.capabilities = vec!["code-review".into(), "refactoring".into()];
+        let line = a.prompt_line();
+        assert!(line.contains("codex"));
+        assert!(line.contains("code-review, refactoring"));
+    }
+
+    #[test]
+    fn format_agents_prompt_empty() {
+        assert_eq!(format_agents_prompt(&[]), "");
+    }
+
+    #[test]
+    fn format_agents_prompt_multiple() {
+        let agents = vec![
+            {
+                let mut a = AgentConfig::new("codex".into());
+                a.capabilities = vec!["review".into()];
+                a
+            },
+            {
+                let mut a = AgentConfig::new("aider".into());
+                a.capabilities = vec!["implementation".into()];
+                a
+            },
+        ];
+        let output = format_agents_prompt(&agents);
+        assert!(output.contains("Available Agents"));
+        assert!(output.contains("codex"));
+        assert!(output.contains("aider"));
+    }
+
+    #[test]
+    fn parse_agent_config_from_fields() {
+        let mut a = AgentConfig::new("test-agent".into());
+        a.agent_type = "aider".into();
+        a.command = "aider --yes".into();
+        a.capabilities = vec!["debugging".into(), "implementation".into()];
+        a.cwd = "/tmp/project".into();
+
+        assert_eq!(a.command, "aider --yes");
+        assert_eq!(a.capabilities.len(), 2);
+    }
+}

--- a/src/brain/mod.rs
+++ b/src/brain/mod.rs
@@ -1,3 +1,4 @@
+pub mod agents;
 pub mod client;
 pub mod context;
 pub mod decisions;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 
+use crate::brain::agents::AgentConfig;
 use crate::models::{ModelOverride, ModelProfile};
 use crate::rules::{AutoRule, RuleAction};
 
@@ -23,6 +24,7 @@ pub struct Config {
     pub model_overrides: Vec<ModelOverride>,
     pub rules: Vec<AutoRule>,
     pub brain: Option<BrainConfig>,
+    pub agents: Vec<AgentConfig>,
 }
 
 /// Configuration for the optional local LLM brain.
@@ -76,6 +78,7 @@ impl Default for Config {
             model_overrides: Vec::new(),
             rules: Vec::new(),
             brain: None,
+            agents: Vec::new(),
         }
     }
 }
@@ -98,6 +101,7 @@ struct RawConfig {
     model_overrides: Vec<ModelOverride>,
     rules: Vec<AutoRule>,
     brain: Option<BrainConfig>,
+    agents: Vec<AgentConfig>,
 }
 
 impl Config {
@@ -171,6 +175,13 @@ impl Config {
         }
         if let Some(brain) = raw.brain {
             self.brain = Some(brain);
+        }
+        for agent in raw.agents {
+            if let Some(pos) = self.agents.iter().position(|a| a.name == agent.name) {
+                self.agents[pos] = agent;
+            } else {
+                self.agents.push(agent);
+            }
         }
     }
 
@@ -423,6 +434,19 @@ fn parse_config_file(path: &PathBuf) -> Option<RawConfig> {
                     _ => {}
                 }
             }
+            _ if parse_agent_section(&section).is_some() => {
+                let Some(agent_name) = parse_agent_section(&section) else {
+                    continue;
+                };
+                let agent = ensure_agent(&mut raw.agents, &agent_name);
+                match key {
+                    "type" => agent.agent_type = unquote(value),
+                    "command" => agent.command = unquote(value),
+                    "capabilities" => agent.capabilities = parse_string_array(value),
+                    "cwd" => agent.cwd = unquote(value),
+                    _ => {}
+                }
+            }
             _ => {} // Ignore unknown keys
         }
     }
@@ -548,6 +572,18 @@ fn ensure_rule<'a>(rules: &'a mut Vec<AutoRule>, name: &str) -> &'a mut AutoRule
     }
     rules.push(AutoRule::new(name.to_string(), RuleAction::Approve));
     rules.last_mut().expect("rule was just pushed")
+}
+
+fn parse_agent_section(section: &str) -> Option<String> {
+    section.strip_prefix("agents.").map(unquote)
+}
+
+fn ensure_agent<'a>(agents: &'a mut Vec<AgentConfig>, name: &str) -> &'a mut AgentConfig {
+    if let Some(index) = agents.iter().position(|a| a.name == name) {
+        return &mut agents[index];
+    }
+    agents.push(AgentConfig::new(name.to_string()));
+    agents.last_mut().expect("agent was just pushed")
 }
 
 #[cfg(test)]
@@ -744,5 +780,42 @@ max_context_tokens = 8000
 
         let raw = parse_config_file(&file.path().to_path_buf()).unwrap();
         assert!(raw.brain.is_none());
+    }
+
+    #[test]
+    fn test_parse_agents_from_config() {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+[agents.codex]
+type = "codex"
+command = "codex --quiet"
+capabilities = ["code-review", "refactoring"]
+cwd = "/tmp/project"
+
+[agents.aider]
+type = "aider"
+command = "aider --yes"
+capabilities = ["implementation", "debugging"]
+"#
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let raw = parse_config_file(&file.path().to_path_buf()).unwrap();
+        assert_eq!(raw.agents.len(), 2);
+
+        let codex = &raw.agents[0];
+        assert_eq!(codex.name, "codex");
+        assert_eq!(codex.agent_type, "codex");
+        assert_eq!(codex.command, "codex --quiet");
+        assert_eq!(codex.capabilities, vec!["code-review", "refactoring"]);
+        assert_eq!(codex.cwd, "/tmp/project");
+
+        let aider = &raw.agents[1];
+        assert_eq!(aider.name, "aider");
+        assert_eq!(aider.command, "aider --yes");
     }
 }


### PR DESCRIPTION
## Summary

Register external agents (Codex, Aider, custom scripts) via `[agents.*]` config sections. Foundation for capability-based routing (#111) and output capture (#112).

## Config

```toml
[agents.codex]
type = "codex"
command = "codex --quiet"
capabilities = ["code-review", "refactoring"]
cwd = "/tmp/project"
```

## Test plan
- [x] 6 new tests (5 agent module + 1 config parsing)
- [x] All 335 tests pass
- [x] clippy clean

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)