### PR TITLE
feat: configurable health, error capture, grouped CLI, and demo mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ social/
 
 #/target
 .claude/worktrees/
+docs/reddit*

--- a/scripts/record-demos.sh
+++ b/scripts/record-demos.sh
@@ -64,12 +64,14 @@ record_gif() {
     echo "  Output: $output"
     echo ""
 
-    # Use timeout to auto-stop. The TUI handles SIGTERM gracefully.
-    timeout --signal=INT "${duration}" "$BINARY" --demo --record "$cast" 2>/dev/null || true
+    # Use --duration for graceful auto-quit (flushes recording properly)
+    "$BINARY" --demo --record "$cast" --duration "${duration}" 2>/dev/null || true
 
     if [ -f "$cast" ] && [ "$(wc -l < "$cast")" -gt 1 ]; then
         echo "  Converting to GIF..."
-        agg --cols 120 --rows 35 --speed 1.5 "$cast" "$output" 2>/dev/null
+        # Use resvg renderer for proper Unicode block character support.
+        # Don't override cols/rows — use the terminal dimensions from the cast file.
+        agg --font-size 14 --speed 1.5 --renderer resvg --theme dracula "$cast" "$output" 2>/dev/null
         rm -f "$cast"
         local size
         size=$(du -h "$output" | cut -f1)

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,176 +55,191 @@ struct ViewFilters {
     about = "Monitor and manage Claude Code CLI agents"
 )]
 struct Cli {
+    // ── Dashboard ───────────────────────────────────────────────────────
     /// Refresh interval in milliseconds
-    #[arg(short, long, default_value_t = 2000)]
+    #[arg(short, long, default_value_t = 2000, help_heading = "Dashboard")]
     interval: u64,
 
+    /// Color theme: dark, light, or none (respects NO_COLOR env var)
+    #[arg(long, help_heading = "Dashboard")]
+    theme: Option<String>,
+
+    /// Enable debug mode: show timing metrics in the footer
+    #[arg(long, help_heading = "Dashboard")]
+    debug: bool,
+
+    /// Run with deterministic fake sessions for screenshots and recordings
+    #[arg(long, help_heading = "Dashboard")]
+    demo: bool,
+
+    // ── Output Modes ───────────────────────────────────────────────────
     /// Print session list to stdout and exit (no TUI)
-    #[arg(short, long)]
+    #[arg(short, long, help_heading = "Output Modes")]
     list: bool,
 
-    /// Enable desktop notifications on NeedsInput transitions
-    #[arg(long)]
-    notify: bool,
-
     /// Print JSON array of sessions and exit
-    #[arg(long)]
+    #[arg(long, help_heading = "Output Modes")]
     json: bool,
 
     /// Stream status changes to stdout (no TUI). Only prints when status changes.
-    #[arg(short, long)]
+    #[arg(short, long, help_heading = "Output Modes")]
     watch: bool,
 
     /// Output format for watch mode. Placeholders: {pid}, {project}, {status}, {cost}, {context}
     #[arg(
         long,
-        default_value = "{pid} {project}: {status} (${cost}, ctx {context}%)"
+        default_value = "{pid} {project}: {status} (${cost}, ctx {context}%)",
+        help_heading = "Output Modes"
     )]
     format: String,
 
-    /// Filter sessions by status for TUI and non-TUI views
-    #[arg(long)]
-    filter_status: Option<String>,
-
-    /// Focus on a high-signal subset (`attention`, `over-budget`, `high-context`, `unknown-telemetry`, `conflict`)
-    #[arg(long)]
-    focus: Option<String>,
-
-    /// Search project/model/session text for TUI and non-TUI views
-    #[arg(long)]
-    search: Option<String>,
-
-    /// Enable debug mode: show timing metrics in the footer
-    #[arg(long)]
-    debug: bool,
-
     /// Show summary of session activity and exit
-    #[arg(long)]
+    #[arg(long, help_heading = "Output Modes")]
     summary: bool,
 
-    /// Time window for summary (e.g., "8h", "24h", "30m"). Default: 24h.
-    #[arg(long, default_value = "24h")]
+    /// Time window for --summary, --history, --stats (e.g., "8h", "24h", "30m")
+    #[arg(long, default_value = "24h", help_heading = "Output Modes")]
     since: String,
 
-    /// Webhook URL to POST JSON on status changes
-    #[arg(long)]
-    webhook: Option<String>,
+    // ── Filtering ──────────────────────────────────────────────────────
+    /// Filter sessions by status (e.g., "NeedsInput", "Processing", "Finished")
+    #[arg(long, help_heading = "Filtering")]
+    filter_status: Option<String>,
 
-    /// Only fire webhook on these status transitions (comma-separated, e.g. "NeedsInput,Finished")
-    #[arg(long)]
-    webhook_on: Option<String>,
+    /// Focus on a high-signal subset: attention, over-budget, high-context, unknown-telemetry, conflict
+    #[arg(long, help_heading = "Filtering")]
+    focus: Option<String>,
 
+    /// Search project/model/session text
+    #[arg(long, help_heading = "Filtering")]
+    search: Option<String>,
+
+    // ── Session Management ─────────────────────────────────────────────
     /// Launch a new Claude Code session in the given directory
-    #[arg(long = "new")]
+    #[arg(long = "new", help_heading = "Session Management")]
     new_session: bool,
 
     /// Working directory for the new session (used with --new)
-    #[arg(long, default_value = ".")]
+    #[arg(long, default_value = ".", help_heading = "Session Management")]
     cwd: String,
 
     /// Prompt to send to the new session (used with --new)
-    #[arg(long)]
+    #[arg(long, help_heading = "Session Management")]
     prompt: Option<String>,
 
     /// Resume a session by ID (used with --new)
-    #[arg(long)]
+    #[arg(long, help_heading = "Session Management")]
     resume: Option<String>,
 
+    // ── Budget & Notifications ─────────────────────────────────────────
     /// Per-session budget in USD. Alert at 80%, optionally kill at 100%.
-    #[arg(long)]
+    #[arg(long, help_heading = "Budget & Notifications")]
     budget: Option<f64>,
 
     /// Auto-kill sessions that exceed the budget (requires --budget)
-    #[arg(long)]
+    #[arg(long, help_heading = "Budget & Notifications")]
     kill_on_budget: bool,
 
-    /// Show resolved configuration and exit
-    #[arg(long)]
-    config: bool,
+    /// Enable desktop notifications on NeedsInput transitions
+    #[arg(long, help_heading = "Budget & Notifications")]
+    notify: bool,
 
-    /// Print an annotated default config template to stdout and exit
-    #[arg(long)]
-    config_template: bool,
+    /// Webhook URL to POST JSON on status changes
+    #[arg(long, help_heading = "Budget & Notifications")]
+    webhook: Option<String>,
 
-    /// Color theme: dark, light, or none (respects NO_COLOR env var)
-    #[arg(long)]
-    theme: Option<String>,
+    /// Only fire webhook on these status transitions (comma-separated, e.g. "NeedsInput,Finished")
+    #[arg(long, help_heading = "Budget & Notifications")]
+    webhook_on: Option<String>,
 
-    /// Write diagnostic logs to a file (for debugging/bug reports)
-    #[arg(long)]
-    log: Option<String>,
-
-    /// List configured event hooks and exit
-    #[arg(long)]
-    hooks: bool,
-
-    /// Show history of completed sessions and exit
-    #[arg(long)]
-    history: bool,
-
-    /// Show aggregated session statistics and exit
-    #[arg(long)]
-    stats: bool,
-
-    /// Diagnose terminal integration and setup requirements
-    #[arg(long)]
-    doctor: bool,
-
-    /// Run tasks from a JSON file (e.g., claudectl --run tasks.json)
-    #[arg(long)]
-    run: Option<String>,
-
-    /// Run independent tasks in parallel (used with --run)
-    #[arg(long)]
-    parallel: bool,
-
-    /// Clean up old session data (JSONL transcripts, session JSON files)
-    #[arg(long)]
-    clean: bool,
-
-    /// Only clean sessions older than this duration (e.g., "7d", "24h"). Used with --clean.
-    #[arg(long)]
-    older_than: Option<String>,
-
-    /// Only clean sessions that have finished. Used with --clean.
-    #[arg(long)]
-    finished: bool,
-
-    /// Show what would be removed without deleting. Used with --clean.
-    #[arg(long)]
-    dry_run: bool,
-
-    /// Run with deterministic fake sessions for screenshots and recordings
-    #[arg(long)]
-    demo: bool,
-
-    /// Record the TUI session as an asciicast v2 file (e.g., --record demo.cast)
-    #[arg(long)]
-    record: Option<String>,
-
+    // ── Brain (Local LLM) ──────────────────────────────────────────────
     /// Enable local LLM brain for session advisory (requires ollama or compatible endpoint)
-    #[arg(long)]
+    #[arg(long, help_heading = "Brain (Local LLM)")]
     brain: bool,
 
     /// Auto-execute brain suggestions without confirmation (requires --brain)
-    #[arg(long)]
+    #[arg(long, help_heading = "Brain (Local LLM)")]
     auto_run: bool,
 
     /// LLM endpoint URL for brain (requires --brain)
-    #[arg(long)]
+    #[arg(long, help_heading = "Brain (Local LLM)")]
     url: Option<String>,
 
     /// Override brain model name (requires --brain)
-    #[arg(long)]
+    #[arg(long, help_heading = "Brain (Local LLM)")]
     brain_model: Option<String>,
 
     /// Run brain eval scenarios against the local LLM and report results
-    #[arg(long)]
+    #[arg(long, help_heading = "Brain (Local LLM)")]
     brain_eval: bool,
 
     /// List brain prompt templates and their source (built-in vs user override)
-    #[arg(long)]
+    #[arg(long, help_heading = "Brain (Local LLM)")]
     brain_prompts: bool,
+
+    // ── Orchestration ──────────────────────────────────────────────────
+    /// Run tasks from a JSON file (e.g., claudectl --run tasks.json)
+    #[arg(long, help_heading = "Orchestration")]
+    run: Option<String>,
+
+    /// Run independent tasks in parallel (used with --run)
+    #[arg(long, help_heading = "Orchestration")]
+    parallel: bool,
+
+    // ── Recording ──────────────────────────────────────────────────────
+    /// Record the TUI session as an asciicast v2 file (e.g., --record demo.cast)
+    #[arg(long, help_heading = "Recording")]
+    record: Option<String>,
+
+    /// Auto-quit the TUI after this many seconds (useful with --demo --record)
+    #[arg(long, help_heading = "Recording")]
+    duration: Option<u64>,
+
+    // ── Cleanup ────────────────────────────────────────────────────────
+    /// Clean up old session data (JSONL transcripts, session JSON files)
+    #[arg(long, help_heading = "Cleanup")]
+    clean: bool,
+
+    /// Only clean sessions older than this duration (e.g., "7d", "24h"). Used with --clean.
+    #[arg(long, help_heading = "Cleanup")]
+    older_than: Option<String>,
+
+    /// Only clean sessions that have finished. Used with --clean.
+    #[arg(long, help_heading = "Cleanup")]
+    finished: bool,
+
+    /// Show what would be removed without deleting. Used with --clean.
+    #[arg(long, help_heading = "Cleanup")]
+    dry_run: bool,
+
+    // ── History & Diagnostics ──────────────────────────────────────────
+    /// Show history of completed sessions and exit
+    #[arg(long, help_heading = "History & Diagnostics")]
+    history: bool,
+
+    /// Show aggregated session statistics and exit
+    #[arg(long, help_heading = "History & Diagnostics")]
+    stats: bool,
+
+    /// Show resolved configuration and exit
+    #[arg(long, help_heading = "History & Diagnostics")]
+    config: bool,
+
+    /// Print an annotated default config template to stdout and exit
+    #[arg(long, help_heading = "History & Diagnostics")]
+    config_template: bool,
+
+    /// List configured event hooks and exit
+    #[arg(long, help_heading = "History & Diagnostics")]
+    hooks: bool,
+
+    /// Diagnose terminal integration and setup requirements
+    #[arg(long, help_heading = "History & Diagnostics")]
+    doctor: bool,
+
+    /// Write diagnostic logs to a file (for debugging/bug reports)
+    #[arg(long, help_heading = "History & Diagnostics")]
+    log: Option<String>,
 }
 
 fn main() -> io::Result<()> {
@@ -398,6 +413,8 @@ fn main() -> io::Result<()> {
         let backend = CrosstermBackend::new(tee_writer);
         let mut terminal = Terminal::new(backend)?;
 
+        let max_dur = cli.duration.map(Duration::from_secs);
+
         let result = run_tui(
             &mut terminal,
             tick_rate,
@@ -406,6 +423,7 @@ fn main() -> io::Result<()> {
             hook_registry,
             cli.demo,
             &filters,
+            max_dur,
         );
 
         disable_raw_mode()?;
@@ -431,6 +449,8 @@ fn main() -> io::Result<()> {
         let backend = CrosstermBackend::new(stdout);
         let mut terminal = Terminal::new(backend)?;
 
+        let max_dur = cli.duration.map(Duration::from_secs);
+
         let result = run_tui(
             &mut terminal,
             tick_rate,
@@ -439,6 +459,7 @@ fn main() -> io::Result<()> {
             hook_registry,
             cli.demo,
             &filters,
+            max_dur,
         );
 
         disable_raw_mode()?;
@@ -1060,6 +1081,7 @@ fn format_session(fmt: &str, s: &session::ClaudeSession) -> String {
         .replace("{context}", &context)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_tui<W: io::Write>(
     terminal: &mut Terminal<CrosstermBackend<W>>,
     tick_rate: Duration,
@@ -1068,6 +1090,7 @@ fn run_tui<W: io::Write>(
     hook_registry: hooks::HookRegistry,
     demo_mode: bool,
     filters: &ViewFilters,
+    max_duration: Option<Duration>,
 ) -> io::Result<()> {
     let mut app = App::new();
     app.notify = cfg.notify;
@@ -1094,13 +1117,10 @@ fn run_tui<W: io::Write>(
                     brain_cfg.endpoint, brain_cfg.model
                 );
             } else {
-                eprintln!(
-                    "Brain: endpoint {} is not reachable — continuing without brain.",
+                app.status_msg = format!(
+                    "Error: Brain endpoint {} not reachable — run `claudectl --doctor` or start ollama",
                     brain_cfg.endpoint
                 );
-                eprintln!("  Start ollama: ollama serve");
-                eprintln!("  Or check: --brain-endpoint URL");
-                eprintln!("  Run `claudectl --doctor` for full diagnostics.");
             }
         }
     }
@@ -1117,14 +1137,26 @@ fn run_tui<W: io::Write>(
                 config::BrainConfig::default(),
             ));
         }
+        // Re-refresh to replace real sessions discovered during App::new()
+        app.refresh();
     }
 
     let mut last_tick = Instant::now();
+    let tui_start = Instant::now();
     let mut sess_recs: std::collections::HashMap<u32, session_recorder::SessionRecorder> =
         std::collections::HashMap::new();
     let term_size = crossterm::terminal::size().unwrap_or((120, 40));
 
     loop {
+        // Auto-quit after --duration seconds (graceful exit, flushes recordings)
+        if let Some(max) = max_duration {
+            if tui_start.elapsed() >= max {
+                for (_, rec) in sess_recs.iter_mut() {
+                    let _ = rec.finish();
+                }
+                return Ok(());
+            }
+        }
         terminal.draw(|frame| {
             ui::table::render(frame, frame.area(), &app);
         })?;

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -195,7 +195,10 @@ pub fn run_tasks(task_file: TaskFile, parallel: bool) -> io::Result<()> {
         .collect();
 
     let total = tasks.len();
-    println!("Running {total} tasks...");
+    let mode = if parallel { "parallel" } else { "sequential" };
+    println!("Running {total} tasks ({mode}):");
+    println!();
+    print_task_plan(&tasks);
     println!();
 
     let run_dir = create_run_dir()?;
@@ -203,7 +206,6 @@ pub fn run_tasks(task_file: TaskFile, parallel: bool) -> io::Result<()> {
     let summary_path = run_dir.join("summary.json");
     let print_lock = Arc::new(Mutex::new(()));
     println!("Logs: {}", run_dir.display());
-    println!("Status: {}", status_path.display());
     println!();
 
     let cancel_requested = Arc::new(AtomicBool::new(false));
@@ -221,6 +223,8 @@ pub fn run_tasks(task_file: TaskFile, parallel: bool) -> io::Result<()> {
         }
 
         mark_dependency_failures(&mut tasks);
+
+        let done_count = tasks.iter().filter(|t| t.state.is_terminal()).count();
 
         let completed: HashSet<String> = tasks
             .iter()
@@ -315,13 +319,8 @@ pub fn run_tasks(task_file: TaskFile, parallel: bool) -> io::Result<()> {
                     });
 
                     println!(
-                        "  Started: {} (attempt {}/{}, PID {})",
+                        "  [{done_count}/{total}] Started: {} (attempt {}/{}, PID {})",
                         task.def.name, attempt, task.max_attempts, pid
-                    );
-                    println!(
-                        "    logs: {}, {}",
-                        task.stdout_log.as_ref().unwrap().display(),
-                        task.stderr_log.as_ref().unwrap().display()
                     );
                     running_count += 1;
                 }
@@ -372,20 +371,18 @@ pub fn run_tasks(task_file: TaskFile, parallel: bool) -> io::Result<()> {
                     task.start_time = None;
                     if status.success() {
                         set_latest_attempt_outcome(task, "completed".into(), elapsed);
+                        task.state = TaskState::Completed;
                         println!(
-                            "  Finished: {} (attempt {}/{}, {}s)",
+                            "  [+] Finished: {} ({}s)",
                             task.def.name,
-                            task.attempts_started,
-                            task.max_attempts,
                             elapsed.unwrap_or(0)
                         );
-                        task.state = TaskState::Completed;
                     } else {
                         let reason = format!("exit {}", format_exit_status(status));
                         set_latest_attempt_outcome(task, reason.clone(), elapsed);
                         if queue_retry(task, &reason) {
                             println!(
-                                "  Retry queued: {} (attempt {}/{}) — {}",
+                                "  [~] Retry queued: {} (attempt {}/{}) — {}",
                                 task.def.name,
                                 task.attempts_started + 1,
                                 task.max_attempts,
@@ -393,7 +390,7 @@ pub fn run_tasks(task_file: TaskFile, parallel: bool) -> io::Result<()> {
                             );
                             print_task_tail(task);
                         } else {
-                            println!("  Failed: {} ({reason})", task.def.name);
+                            println!("  [!] Failed: {} ({reason})", task.def.name);
                             print_task_tail(task);
                             task.state = TaskState::Failed(reason);
                         }
@@ -409,7 +406,7 @@ pub fn run_tasks(task_file: TaskFile, parallel: bool) -> io::Result<()> {
                     set_latest_attempt_outcome(task, reason.clone(), elapsed);
                     if queue_retry(task, &reason) {
                         println!(
-                            "  Retry queued: {} (attempt {}/{}) — {}",
+                            "  [~] Retry queued: {} (attempt {}/{}) — {}",
                             task.def.name,
                             task.attempts_started + 1,
                             task.max_attempts,
@@ -417,7 +414,7 @@ pub fn run_tasks(task_file: TaskFile, parallel: bool) -> io::Result<()> {
                         );
                         print_task_tail(task);
                     } else {
-                        println!("  Failed: {} ({reason})", task.def.name);
+                        println!("  [!] Failed: {} ({reason})", task.def.name);
                         print_task_tail(task);
                         task.state = TaskState::Failed(reason);
                     }
@@ -475,6 +472,30 @@ pub fn run_tasks(task_file: TaskFile, parallel: bool) -> io::Result<()> {
             "{} failed, {} skipped",
             counts.failed, counts.skipped
         )))
+    }
+}
+
+fn print_task_plan(tasks: &[TaskRun]) {
+    for (i, task) in tasks.iter().enumerate() {
+        let deps = if task.def.depends_on.is_empty() {
+            String::new()
+        } else {
+            format!(" (after {})", task.def.depends_on.join(", "))
+        };
+        let cwd = task.def.cwd.as_deref().unwrap_or(".");
+        let retries = if task.max_attempts > 1 {
+            format!(", {} retries", task.max_attempts - 1)
+        } else {
+            String::new()
+        };
+        println!(
+            "  {}. {}{} in {}{}",
+            i + 1,
+            task.def.name,
+            deps,
+            cwd,
+            retries
+        );
     }
 }
 
@@ -716,7 +737,7 @@ fn print_status(tasks: &[TaskRun]) {
     let done = counts.completed + counts.failed + counts.skipped + counts.aborted;
     let total = tasks.len();
 
-    let running = tasks
+    let running: Vec<_> = tasks
         .iter()
         .filter(|task| matches!(task.state, TaskState::Running))
         .take(3)
@@ -725,44 +746,40 @@ fn print_status(tasks: &[TaskRun]) {
                 .start_time
                 .map(|started| format!("{}s", started.elapsed().as_secs()))
                 .unwrap_or_else(|| "?s".to_string());
-            format!(
-                "{} {}/{} {elapsed}",
-                task.def.name, task.attempts_started, task.max_attempts
-            )
+            format!("{} {elapsed}", task.def.name)
         })
-        .collect::<Vec<_>>();
+        .collect();
 
-    let retrying = tasks
-        .iter()
-        .filter(|task| matches!(task.state, TaskState::RetryQueued(_)))
-        .take(2)
-        .map(|task| {
-            format!(
-                "{} {}/{}",
-                task.def.name,
-                task.attempts_started + 1,
-                task.max_attempts
-            )
-        })
-        .collect::<Vec<_>>();
+    let mut line = format!("\r  [{done}/{total}]");
 
-    let mut line = format!(
-        "\r  [{done}/{total}] {} running, {} pending, {} retrying, {} failed, {} skipped, {} aborted",
-        counts.running,
-        counts.pending,
-        counts.retrying,
-        counts.failed,
-        counts.skipped,
-        counts.aborted
-    );
+    if counts.running > 0 {
+        line.push_str(&format!(" {} running", counts.running));
+    }
+    if counts.pending > 0 {
+        line.push_str(&format!(" {} pending", counts.pending));
+    }
+    if counts.retrying > 0 {
+        line.push_str(&format!(" {} retrying", counts.retrying));
+    }
+    if counts.failed > 0 {
+        line.push_str(&format!(" {} failed", counts.failed));
+    }
+    if counts.skipped > 0 {
+        line.push_str(&format!(" {} skipped", counts.skipped));
+    }
+    if counts.aborted > 0 {
+        line.push_str(&format!(" {} aborted", counts.aborted));
+    }
     if !running.is_empty() {
-        line.push_str(&format!(" | running: {}", running.join(", ")));
-    }
-    if !retrying.is_empty() {
-        line.push_str(&format!(" | retry: {}", retrying.join(", ")));
+        line.push_str(&format!(" | {}", running.join(", ")));
     }
 
-    eprint!("{line:<220}");
+    // Pad to terminal width to clear previous line, capped at 200
+    let width = crossterm::terminal::size()
+        .map(|(w, _)| w as usize)
+        .unwrap_or(120);
+    let pad = width.min(200);
+    eprint!("{line:<pad$}");
     let _ = io::stderr().flush();
 }
 


### PR DESCRIPTION
## Summary

- **Configurable health thresholds** — all 5 health checks (cache ratio, cost spike, loop detection, stall, context saturation) now accept user-defined thresholds via `[health]` TOML section instead of hardcoded constants
- **Error capture from tool results** — sessions store last error message and a ring buffer of recent errors (last 5), surfaced in the detail panel and brain context
- **`--config-template` flag** — prints a fully annotated `.claudectl.toml` with all available settings, sections, and defaults
- **Grouped CLI help** — flags organized by purpose (Dashboard, Output Modes, Filtering, Session Management, Budget, Brain, Orchestration, Recording, etc.)
- **Brain failure in TUI** — connection errors now show in the status bar instead of being lost to stderr before alternate screen entry
- **Orchestrator progress** — task plan at launch, `[n/total]` fractions, terminal-width-aware status line, clearer markers
- **Extended demo mode** — showcases health alerts, brain suggestions, rules, and routing with scripted event timelines; includes `scripts/record-demos.sh` for generating targeted GIFs

## Changed files

`src/config.rs`, `src/health.rs`, `src/monitor.rs`, `src/session.rs`, `src/main.rs`, `src/app.rs`, `src/orchestrator.rs`, `src/demo.rs`, `src/ui/detail.rs`, `src/ui/table.rs`, `src/brain/context.rs`, `scripts/record-demos.sh`

## Test plan

- [ ] `cargo build` compiles cleanly
- [ ] `cargo test` — all existing + new tests pass
- [ ] `cargo clippy -- -D warnings` — no warnings
- [ ] `claudectl --config-template` prints annotated TOML
- [ ] `claudectl --help` shows grouped flag categories
- [ ] `claudectl --demo` cycles through health, brain, and rules events
- [ ] Custom `[health]` thresholds in `.claudectl.toml` are respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)