### PR TITLE
feat: file-level conflict detection with predictive deny

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.25.0] - 2026-04-15
+
+### Added
+- File-level conflict detection: detects when multiple sessions edit the same file, with `!F` indicator in dashboard and per-file detail in the expanded panel
+- Predictive conflict detection: flags pending Edit/Write tool calls that target files already modified by another session
+- Auto-deny for file conflicts: `[orchestrate] auto_deny_file_conflicts = true` automatically denies writes to files being edited by another session, with actionable error message naming the conflicting session
+- `match_file_conflict` rule condition: match sessions with pending file conflicts in the auto-rule engine
+- `pending_file_path` tracking: Edit/Write/NotebookEdit tool calls now track the target file path for conflict detection
+- `[orchestrate]` config section with `file_conflicts` (default true) and `auto_deny_file_conflicts` (default false)
+- Configurable health check thresholds via `[health]` TOML section — all 5 checks (cache, cost spike, loop, stall, context) accept user-defined thresholds
+- Capture actual error messages from tool results — detail panel shows "Recent Errors" section with tool name and message text
+- `--config-template` flag prints a fully annotated `.claudectl.toml` with all available settings
+- CLI flags grouped by purpose in `--help`: Dashboard, Output Modes, Filtering, Session Management, Budget & Notifications, Brain, Orchestration, Recording, Cleanup, History & Diagnostics
+
+### Fixed
+- Brain connection failure now shows in the TUI status bar instead of being lost to stderr
+
+### Changed
+- Orchestrator shows task plan at launch, uses `[n/total]` progress fractions and terminal-width-aware status line
+
 ## [0.24.0] - 2026-04-15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 description = "Mission control for Claude Code — supervise, budget, orchestrate, and auto-pilot sessions with a local LLM brain"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ claudectl --run tasks.json --parallel     # Orchestrate multiple sessions
 | Know which session is blocked | Tab-hunt | **At a glance** |
 | Track cost per session | Manually | **Live $/hr burn rate** |
 | Enforce spend budgets | No | **Auto-kill at limit** |
+| File conflict detection | No | **Auto-detect + auto-deny** |
 | Auto-rule engine | No | **Match by tool/command/project/cost** |
 | Approve prompts without switching | No | **Press `y`** |
 | Get notified on stalls/blocks | No | **Desktop + webhook** |
@@ -149,6 +150,31 @@ claudectl continuously checks each session for problems and surfaces them with s
 - **Context saturation** — warns when a session approaches its context window limit
 
 Health issues appear as icons in the session table and as a summary in the status bar. No configuration needed.
+
+## File Conflict Detection
+
+When multiple sessions edit the same file, claudectl detects the conflict and flags it:
+
+- **`!F` prefix** in the session table for sessions with file-level conflicts
+- **File Conflicts section** in the detail panel showing which files conflict and with which sessions
+- **Predictive detection** — flags pending Edit/Write calls targeting files another session has already modified
+- **Auto-deny** — optionally deny writes to conflicting files with an actionable message
+
+```toml
+# .claudectl.toml
+[orchestrate]
+file_conflicts = true              # Detect file-level conflicts (default: on)
+auto_deny_file_conflicts = true    # Auto-deny conflicting writes (default: off)
+```
+
+File conflicts can also be matched in auto-rules:
+
+```toml
+[rules.deny_conflicts]
+match_file_conflict = true
+action = "deny"
+message = "Another session is editing this file"
+```
 
 ## Launch and Resume Sessions
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -291,6 +291,11 @@ pub struct App {
     pub needs_input_since: HashMap<u32, std::time::Instant>, // When each PID entered NeedsInput
     pub conflict_pids: HashSet<u32>,  // PIDs that share a working directory with another session
     pub conflict_alerted: HashSet<String>, // cwds that have already triggered a conflict alert
+    pub file_conflict_pids: HashSet<u32>, // PIDs involved in file-level conflicts
+    pub file_conflicts: HashMap<String, Vec<u32>>, // file path → PIDs that modified it
+    pub file_conflict_alerted: HashSet<String>, // Files already alerted
+    pub file_conflicts_enabled: bool, // Config: detect file-level conflicts
+    pub auto_deny_file_conflicts: bool, // Config: auto-deny conflicting writes
     pub demo_mode: bool,
     pub demo_tick: u32,
     pub session_recordings: HashMap<u32, String>, // pid -> output_path for active recordings
@@ -397,6 +402,11 @@ impl App {
             needs_input_since: HashMap::new(),
             conflict_pids: HashSet::new(),
             conflict_alerted: HashSet::new(),
+            file_conflict_pids: HashSet::new(),
+            file_conflicts: HashMap::new(),
+            file_conflict_alerted: HashSet::new(),
+            file_conflicts_enabled: true,
+            auto_deny_file_conflicts: false,
             demo_mode: false,
             demo_tick: 0,
             session_recordings: HashMap::new(),
@@ -747,6 +757,84 @@ impl App {
                 .unwrap_or(false)
         });
 
+        // File-level conflict detection: find files edited by multiple sessions
+        self.file_conflict_pids.clear();
+        self.file_conflicts.clear();
+        // Reset has_file_conflict on all sessions
+        for session in &mut sessions {
+            session.has_file_conflict = false;
+        }
+
+        if self.file_conflicts_enabled {
+            // Build file → PIDs map from files_modified across active sessions
+            let mut file_pids: HashMap<String, Vec<u32>> = HashMap::new();
+            for session in &sessions {
+                if session.status == SessionStatus::Finished {
+                    continue;
+                }
+                for file in session.files_modified.keys() {
+                    file_pids.entry(file.clone()).or_default().push(session.pid);
+                }
+                // Also consider pending file edits (predictive conflict)
+                if let Some(ref pending) = session.pending_file_path {
+                    file_pids
+                        .entry(pending.clone())
+                        .or_default()
+                        .push(session.pid);
+                }
+            }
+
+            // Deduplicate PIDs per file (a session may appear twice if it both modified and is pending)
+            for pids in file_pids.values_mut() {
+                pids.sort_unstable();
+                pids.dedup();
+            }
+
+            // Record conflicts where 2+ sessions touch the same file
+            for (file, pids) in &file_pids {
+                if pids.len() >= 2 {
+                    for &pid in pids {
+                        self.file_conflict_pids.insert(pid);
+                    }
+                    self.file_conflicts.insert(file.clone(), pids.clone());
+
+                    // Mark sessions with pending file conflicts
+                    for session in &mut sessions {
+                        if let Some(ref pending) = session.pending_file_path {
+                            if pending == file && pids.contains(&session.pid) {
+                                session.has_file_conflict = true;
+                            }
+                        }
+                    }
+
+                    // Fire alert once per conflicting file
+                    if !self.file_conflict_alerted.contains(file) {
+                        self.file_conflict_alerted.insert(file.clone());
+                        let names: Vec<&str> = pids
+                            .iter()
+                            .filter_map(|pid| {
+                                sessions
+                                    .iter()
+                                    .find(|s| s.pid == *pid)
+                                    .map(|s| s.display_name())
+                            })
+                            .collect();
+                        let short = file.rsplit('/').next().unwrap_or(file);
+                        self.status_msg =
+                            format!("FILE CONFLICT: {} edited by {}", short, names.join(", "));
+                        fire_notification(&format!("File conflict: {short}"));
+                        if let Some(session) = sessions.iter().find(|s| s.pid == pids[0]) {
+                            self.hooks.fire(HookEvent::ConflictDetected, session);
+                        }
+                    }
+                }
+            }
+
+            // Clear alerts for files no longer in conflict
+            self.file_conflict_alerted
+                .retain(|f| self.file_conflicts.contains_key(f));
+        }
+
         // Update prev_statuses
         self.prev_statuses = sessions.iter().map(|s| (s.pid, s.status)).collect();
 
@@ -1064,6 +1152,62 @@ impl App {
                 match terminals::approve_session(session) {
                     Ok(()) => self.status_msg = format!("Auto-approved {}", session.display_name()),
                     Err(e) => self.status_msg = format!("Auto-approve error: {e}"),
+                }
+            }
+        }
+
+        // Built-in file conflict auto-deny: deny writes to files being edited by another session
+        if self.auto_deny_file_conflicts {
+            let conflict_candidates: Vec<(u32, String, String)> = self
+                .sessions
+                .iter()
+                .filter(|s| {
+                    s.status == SessionStatus::NeedsInput
+                        && s.has_file_conflict
+                        && s.pending_file_path.is_some()
+                })
+                .filter_map(|s| {
+                    let file = s.pending_file_path.as_ref()?;
+                    let other_pids = self.file_conflicts.get(file)?;
+                    let other_name = other_pids
+                        .iter()
+                        .filter(|&&p| p != s.pid)
+                        .find_map(|pid| {
+                            self.sessions
+                                .iter()
+                                .find(|o| o.pid == *pid)
+                                .map(|o| format!("{} (PID {})", o.display_name(), o.pid))
+                        })
+                        .unwrap_or_else(|| "another session".into());
+                    Some((s.pid, file.clone(), other_name))
+                })
+                .collect();
+
+            for (pid, file, other) in conflict_candidates {
+                // Debounce
+                if let Some(last) = self.auto_actions_fired.get(&pid) {
+                    if last.elapsed().as_secs() < 5 {
+                        continue;
+                    }
+                }
+                if let Some(session) = self.sessions.iter().find(|s| s.pid == pid) {
+                    let short = file.rsplit('/').next().unwrap_or(&file);
+                    let msg = format!("File {short} is being edited by {other}");
+                    match terminals::send_input(session, &msg) {
+                        Ok(()) => {
+                            let status = format!(
+                                "File conflict: denied {} edit to {short}",
+                                session.display_name()
+                            );
+                            crate::logger::log("CONFLICT", &status);
+                            self.status_msg = status;
+                        }
+                        Err(e) => {
+                            self.status_msg = format!("File conflict deny error: {e}");
+                        }
+                    }
+                    self.auto_actions_fired
+                        .insert(pid, std::time::Instant::now());
                 }
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,8 @@ pub struct Config {
     pub model_overrides: Vec<ModelOverride>,
     pub rules: Vec<AutoRule>,
     pub health: HealthThresholds,
+    pub file_conflicts: bool, // Detect file-level conflicts across sessions
+    pub auto_deny_file_conflicts: bool, // Auto-deny writes to conflicting files
     pub brain: Option<BrainConfig>,
     pub agents: Vec<AgentConfig>,
 }
@@ -127,6 +129,8 @@ impl Default for Config {
             model_overrides: Vec::new(),
             rules: Vec::new(),
             health: HealthThresholds::default(),
+            file_conflicts: true,
+            auto_deny_file_conflicts: false,
             brain: None,
             agents: Vec::new(),
         }
@@ -151,6 +155,8 @@ struct RawConfig {
     model_overrides: Vec<ModelOverride>,
     rules: Vec<AutoRule>,
     health: Option<RawHealthThresholds>,
+    file_conflicts: Option<bool>,
+    auto_deny_file_conflicts: Option<bool>,
     brain: Option<BrainConfig>,
     agents: Vec<AgentConfig>,
 }
@@ -245,6 +251,12 @@ impl Config {
                 self.health.context_warning_pct = v;
             }
         }
+        if let Some(v) = raw.file_conflicts {
+            self.file_conflicts = v;
+        }
+        if let Some(v) = raw.auto_deny_file_conflicts {
+            self.auto_deny_file_conflicts = v;
+        }
         for override_ in raw.model_overrides {
             upsert_model_override(&mut self.model_overrides, override_);
         }
@@ -328,6 +340,13 @@ impl Config {
                 .unwrap_or_else(|| "none".into())
         );
         println!("  context_warn: {}%", self.context_warn_threshold);
+        println!();
+        println!("  [orchestrate]");
+        println!("  file_conflicts:           {}", self.file_conflicts);
+        println!(
+            "  auto_deny_file_conflicts: {}",
+            self.auto_deny_file_conflicts
+        );
         println!();
         println!("  [health]");
         println!(
@@ -423,6 +442,15 @@ impl Config {
 [context]
 # Fire on_context_high hook when context usage crosses this percentage
 # warn_threshold = 75
+
+# ── Orchestration ───────────────────────────────────────────────────
+
+[orchestrate]
+# Detect file-level conflicts when multiple sessions edit the same file
+# file_conflicts = true
+
+# Auto-deny writes to files being edited by another session
+# auto_deny_file_conflicts = false
 
 # ── Health Check Thresholds ─────────────────────────────────────────
 
@@ -595,6 +623,12 @@ fn parse_config_file(path: &PathBuf) -> Option<RawConfig> {
             ("context", "warn_threshold") => {
                 raw.context_warn_threshold = value.parse().ok();
             }
+            ("orchestrate", "file_conflicts") => {
+                raw.file_conflicts = parse_bool(value);
+            }
+            ("orchestrate", "auto_deny_file_conflicts") => {
+                raw.auto_deny_file_conflicts = parse_bool(value);
+            }
             ("health", key) => {
                 let h = raw.health.get_or_insert_with(RawHealthThresholds::default);
                 match key {
@@ -649,6 +683,7 @@ fn parse_config_file(path: &PathBuf) -> Option<RawConfig> {
                     "match_project" => rule.match_project = parse_string_array(value),
                     "match_cost_above" => rule.match_cost_above = value.parse().ok(),
                     "match_last_error" => rule.match_last_error = parse_bool(value),
+                    "match_file_conflict" => rule.match_file_conflict = parse_bool(value),
                     "action" => {
                         if let Some(a) = RuleAction::parse(&unquote(value)) {
                             rule.action = a;
@@ -1142,5 +1177,32 @@ context_warning_pct = 85.0
         });
         assert_eq!(config.health.cache_critical_pct, 5.0); // overridden
         assert_eq!(config.health.cache_warning_pct, 30.0); // unchanged default
+    }
+
+    #[test]
+    fn test_parse_orchestrate_config() {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+[orchestrate]
+file_conflicts = true
+auto_deny_file_conflicts = true
+"#
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let raw = parse_config_file(&file.path().to_path_buf()).unwrap();
+        assert_eq!(raw.file_conflicts, Some(true));
+        assert_eq!(raw.auto_deny_file_conflicts, Some(true));
+    }
+
+    #[test]
+    fn test_orchestrate_defaults() {
+        let config = Config::default();
+        assert!(config.file_conflicts); // on by default
+        assert!(!config.auto_deny_file_conflicts); // off by default
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1107,6 +1107,8 @@ fn run_tui<W: io::Write>(
     app.context_warn_threshold = cfg.context_warn_threshold;
     app.rules = cfg.rules.clone();
     app.health_thresholds = cfg.health.clone();
+    app.file_conflicts_enabled = cfg.file_conflicts;
+    app.auto_deny_file_conflicts = cfg.auto_deny_file_conflicts;
     app.brain_config = cfg.brain.clone();
     if let Some(ref brain_cfg) = cfg.brain {
         if brain_cfg.enabled {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -163,6 +163,18 @@ pub fn update_tokens(session: &mut ClaudeSession) {
                                                 .get("command")
                                                 .and_then(|v| v.as_str())
                                                 .map(|s| s.to_string());
+                                            // Track pending file path for conflict detection
+                                            session.pending_file_path = if matches!(
+                                                name.as_str(),
+                                                "Edit" | "Write" | "NotebookEdit"
+                                            ) {
+                                                input
+                                                    .get("file_path")
+                                                    .and_then(|v| v.as_str())
+                                                    .map(|s| s.to_string())
+                                            } else {
+                                                None
+                                            };
                                         }
                                         TranscriptBlock::ToolResult {
                                             is_error, content, ..
@@ -195,6 +207,7 @@ pub fn update_tokens(session: &mut ClaudeSession) {
                                             // Tool was executed — no longer pending
                                             session.pending_tool_name = None;
                                             session.pending_tool_input = None;
+                                            session.pending_file_path = None;
                                         }
                                         _ => {}
                                     }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -57,6 +57,7 @@ pub struct AutoRule {
     pub match_project: Vec<String>,
     pub match_cost_above: Option<f64>,
     pub match_last_error: Option<bool>,
+    pub match_file_conflict: Option<bool>,
     pub action: RuleAction,
     pub message: Option<String>,
 }
@@ -71,6 +72,7 @@ impl AutoRule {
             match_project: Vec::new(),
             match_cost_above: None,
             match_last_error: None,
+            match_file_conflict: None,
             action,
             message: None,
         }
@@ -173,6 +175,12 @@ fn matches_rule(rule: &AutoRule, session: &ClaudeSession) -> bool {
 
     if let Some(expected) = rule.match_last_error {
         if session.last_tool_error != expected {
+            return false;
+        }
+    }
+
+    if let Some(expected) = rule.match_file_conflict {
+        if session.has_file_conflict != expected {
             return false;
         }
     }
@@ -397,6 +405,29 @@ mod tests {
         let mut rule2 = approve_rule("no_error");
         rule2.match_last_error = Some(false);
         assert!(evaluate(&[rule2], &s).is_none());
+    }
+
+    #[test]
+    fn match_file_conflict() {
+        let mut s = make_session();
+        s.has_file_conflict = true;
+
+        let mut rule = deny_rule("deny_conflict");
+        rule.match_file_conflict = Some(true);
+        assert!(evaluate(&[rule], &s).is_some());
+
+        let mut rule2 = approve_rule("no_conflict");
+        rule2.match_file_conflict = Some(false);
+        assert!(evaluate(&[rule2], &s).is_none());
+    }
+
+    #[test]
+    fn match_file_conflict_false_matches_clean() {
+        let s = make_session(); // has_file_conflict defaults to false
+
+        let mut rule = approve_rule("clean");
+        rule.match_file_conflict = Some(false);
+        assert!(evaluate(&[rule], &s).is_some());
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -142,6 +142,8 @@ pub struct ClaudeSession {
     /// Pending tool call details for rule-based auto-actions.
     pub pending_tool_name: Option<String>,
     pub pending_tool_input: Option<String>, // Extracted command string (for Bash)
+    pub pending_file_path: Option<String>,  // File path for pending Edit/Write/NotebookEdit
+    pub has_file_conflict: bool,            // Pending file edit conflicts with another session
     pub last_tool_error: bool,
     pub last_error_message: Option<String>,
     pub recent_errors: Vec<ErrorEntry>, // Last 5 errors (ring buffer)
@@ -319,6 +321,8 @@ impl ClaudeSession {
             is_waiting_for_task: false,
             pending_tool_name: None,
             pending_tool_input: None,
+            pending_file_path: None,
+            has_file_conflict: false,
             last_tool_error: false,
             last_error_message: None,
             recent_errors: Vec::new(),

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -141,6 +141,41 @@ pub fn render_detail_panel(frame: &mut Frame, area: Rect, session: &ClaudeSessio
         }
     }
 
+    // File conflicts section
+    {
+        let pid = session.pid;
+        let conflicting_files: Vec<(&String, &Vec<u32>)> = app
+            .file_conflicts
+            .iter()
+            .filter(|(_, pids)| pids.contains(&pid))
+            .collect();
+        if !conflicting_files.is_empty() {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                format!(" File Conflicts ({})", conflicting_files.len()),
+                Style::default().fg(t.error).add_modifier(Modifier::BOLD),
+            )));
+            for (file, pids) in conflicting_files.iter().take(10) {
+                let others: Vec<&str> = pids
+                    .iter()
+                    .filter(|&&p| p != pid)
+                    .filter_map(|p| {
+                        app.sessions
+                            .iter()
+                            .find(|s| s.pid == *p)
+                            .map(|s| s.display_name())
+                    })
+                    .collect();
+                let short = file.rsplit('/').next().unwrap_or(file);
+                lines.push(detail_line(
+                    &format!("  {short}"),
+                    &format!("also edited by {}", others.join(", ")),
+                    t,
+                ));
+            }
+        }
+    }
+
     // Tool usage section
     if !session.tool_usage.is_empty() {
         lines.push(Line::from(""));

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -477,13 +477,16 @@ fn session_row(s: &ClaudeSession, app: &App) -> Row<'static> {
         s.status.to_string()
     };
 
-    let conflict = app.conflict_pids.contains(&s.pid);
+    let file_conflict = app.file_conflict_pids.contains(&s.pid);
+    let wt_conflict = app.conflict_pids.contains(&s.pid);
     let recording = app.session_recordings.contains_key(&s.pid);
-    let prefix = match (conflict, recording) {
-        (true, true) => "!! REC ",
-        (true, false) => "!! ",
-        (false, true) => "REC ",
-        (false, false) => "",
+    let prefix = match (file_conflict, wt_conflict, recording) {
+        (true, _, true) => "!F REC ",
+        (true, _, false) => "!F ",
+        (false, true, true) => "!! REC ",
+        (false, true, false) => "!! ",
+        (false, false, true) => "REC ",
+        (false, false, false) => "",
     };
     let health_icon = crate::health::status_icon(s, &app.health_thresholds);
     let health_suffix = if health_icon.is_empty() {


### PR DESCRIPTION
## Summary

Implements **Phase 1 + 2** of #124 — file-level conflict detection and auto-deny for conflicting writes.

- **File-level conflict detection** — compares `files_modified` across all active sessions every tick. When 2+ sessions have edited the same file, flags them with `!F` in the table and a "File Conflicts" section in the detail panel.
- **Predictive detection** — also checks `pending_file_path` (newly tracked for Edit/Write/NotebookEdit tool calls), so a conflict is flagged *before* the edit happens.
- **Auto-deny** — when `auto_deny_file_conflicts = true`, pending writes to conflicting files are automatically denied with a message: "File {name} is being edited by {session} (PID {pid})".
- **`match_file_conflict` rule condition** — lets users write custom rules that trigger on file conflicts.
- **`[orchestrate]` config section** — `file_conflicts` (default true), `auto_deny_file_conflicts` (default false).

Also bumps version `0.24.0` -> `0.25.0` with full CHANGELOG and README updates.

### Files changed (11)

| File | Change |
|------|--------|
| `session.rs` | `pending_file_path`, `has_file_conflict` fields |
| `monitor.rs` | Extract `file_path` from Edit/Write/NotebookEdit input JSON |
| `app.rs` | File conflict detection loop, built-in auto-deny in `run_auto_actions()`, new fields |
| `rules.rs` | `match_file_conflict` condition + 2 tests |
| `config.rs` | `[orchestrate]` section, parsing, merge, print_resolved, print_template + 2 tests |
| `main.rs` | Wire config to App |
| `ui/table.rs` | `!F` prefix for file conflicts |
| `ui/detail.rs` | "File Conflicts" section in detail panel |
| `Cargo.toml` | Version bump 0.24.0 -> 0.25.0 |
| `CHANGELOG.md` | 0.25.0 entry |
| `README.md` | File Conflict Detection section + comparison table row |

## Test plan

- [x] 155 lib tests pass (4 new: match_file_conflict, match_file_conflict_false_matches_clean, parse_orchestrate_config, orchestrate_defaults)
- [x] 57 integration + 8 unit tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: `claudectl --config` shows `[orchestrate]` section
- [ ] Manual: `claudectl --config-template` includes orchestrate section
- [ ] Manual: verify `!F` prefix appears when two sessions share a modified file

## Release

After merge, tag `v0.25.0` to trigger the automated release pipeline (GitHub Releases + crates.io + Homebrew tap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)