### PR TITLE
fix: Ghostty approve sends correct AppleScript command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2024"
 description = "Auto-pilot for Claude Code — a local model watches every session and decides what to approve"
 license = "MIT"

--- a/src/terminals/ghostty.rs
+++ b/src/terminals/ghostty.rs
@@ -38,14 +38,24 @@ pub fn switch(session: &ClaudeSession) -> Result<(), String> {
 pub fn send_input(session: &ClaudeSession, text: &str) -> Result<(), String> {
     let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
     let cwd = session.cwd.replace('"', "\\\"");
+    let tty = &session.tty;
 
     let script = format!(
         r#"
         tell application "Ghostty"
             set matches to every terminal whose working directory contains "{cwd}"
+
+            -- Find the one matching our TTY if multiple matches
+            repeat with t in matches
+                if tty of t contains "{tty}" then
+                    input text "{escaped}" to t
+                    return "ok"
+                end if
+            end repeat
+
+            -- Fallback: send to first match by cwd
             if (count of matches) > 0 then
-                set t to item 1 of matches
-                input text "{escaped}" to t
+                input text "{escaped}" to (item 1 of matches)
             end if
         end tell
         "#,
@@ -55,14 +65,24 @@ pub fn send_input(session: &ClaudeSession, text: &str) -> Result<(), String> {
 
 pub fn approve(session: &ClaudeSession) -> Result<(), String> {
     let cwd = session.cwd.replace('"', "\\\"");
+    let tty = &session.tty;
 
     let script = format!(
         r#"
         tell application "Ghostty"
             set matches to every terminal whose working directory contains "{cwd}"
+
+            -- Find the one matching our TTY if multiple matches
+            repeat with t in matches
+                if tty of t contains "{tty}" then
+                    input text "\r" to t
+                    return "ok"
+                end if
+            end repeat
+
+            -- Fallback: send to first match by cwd
             if (count of matches) > 0 then
-                set t to item 1 of matches
-                send key "enter" to t
+                input text "\r" to (item 1 of matches)
             end if
         end tell
         "#,


### PR DESCRIPTION
## Summary
- `approve()` used `send key "enter"` which is not in Ghostty's AppleScript dictionary — silently no-oped, so pressing `y` in the TUI showed "Approved" but the Enter key never reached Claude Code
- Changed to `input text "\r"` which is the correct Ghostty scripting command (already used by `send_input()`)
- Added TTY-based matching to `approve()` and `send_input()` to target the correct terminal when multiple Ghostty windows share the same working directory

## Test plan
- [ ] Open a Claude Code session in Ghostty that is waiting for tool approval
- [ ] Run `claudectl` in another Ghostty tab/window
- [ ] Press `y` — verify the tool is approved and Claude Code continues
- [ ] Test with multiple Ghostty windows open to the same project directory — verify the correct session receives the approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)