### PR TITLE
fix: Ghostty pane targeting with name-based disambiguation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2024"
 description = "Auto-pilot for Claude Code — a local model watches every session and decides what to approve"
 license = "MIT"

--- a/src/app.rs
+++ b/src/app.rs
@@ -882,7 +882,7 @@ impl App {
                     .partial_cmp(&a.burn_rate_per_hr)
                     .unwrap_or(std::cmp::Ordering::Equal)
             }),
-            4 => sessions.sort_by(|a, b| b.elapsed.cmp(&a.elapsed)),
+            4 => sessions.sort_by_key(|s| std::cmp::Reverse(s.elapsed)),
             _ => {}
         }
     }

--- a/src/brain/metrics.rs
+++ b/src/brain/metrics.rs
@@ -366,7 +366,7 @@ pub fn print_accuracy() {
     println!();
     println!("  By project:");
     let mut project_list: Vec<CategoryAccuracy> = by_project.into_values().collect();
-    project_list.sort_by(|a, b| b.total.cmp(&a.total));
+    project_list.sort_by_key(|p| std::cmp::Reverse(p.total));
     project_list.truncate(10);
     print_accuracy_table(&mut project_list);
 
@@ -377,7 +377,7 @@ pub fn print_accuracy() {
 }
 
 fn print_accuracy_table(entries: &mut Vec<CategoryAccuracy>) {
-    entries.sort_by(|a, b| b.total.cmp(&a.total));
+    entries.sort_by_key(|e| std::cmp::Reverse(e.total));
 
     println!(
         "    {:<20} {:>6} {:>8} {:>8} {:>8}",

--- a/src/process.rs
+++ b/src/process.rs
@@ -99,22 +99,18 @@ fn extract_session_meta(cmd: &[&str], session: &mut ClaudeSession) {
     let mut i = 0;
     while i < cmd.len() {
         match cmd[i] {
-            "--name" | "-n" => {
-                if i + 1 < cmd.len() {
-                    session.session_name = cmd[i + 1].to_string();
-                    i += 2;
-                    continue;
-                }
+            "--name" | "-n" if i + 1 < cmd.len() => {
+                session.session_name = cmd[i + 1].to_string();
+                i += 2;
+                continue;
             }
-            "--resume" | "-r" => {
-                if i + 1 < cmd.len() {
-                    let val = cmd[i + 1];
-                    if !looks_like_uuid(val) {
-                        session.session_name = val.to_string();
-                    }
-                    i += 2;
-                    continue;
+            "--resume" | "-r" if i + 1 < cmd.len() => {
+                let val = cmd[i + 1];
+                if !looks_like_uuid(val) {
+                    session.session_name = val.to_string();
                 }
+                i += 2;
+                continue;
             }
             _ => {}
         }

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -239,7 +239,9 @@ impl SessionRecorder {
                             frame.push_str(&format!(
                                 "    \x1b[90mAdded \x1b[1;37m{new_count}\x1b[0m\x1b[90m lines, removed \x1b[1;37m{old_count}\x1b[0m\x1b[90m lines\x1b[0m\r\n"
                             ));
-                            for (line_num, line) in (1u32..).zip(diff_content.lines().take(MAX_DIFF_LINES)) {
+                            for (line_num, line) in
+                                (1u32..).zip(diff_content.lines().take(MAX_DIFF_LINES))
+                            {
                                 let colored = if let Some(content) = line.strip_prefix('+') {
                                     format!("    \x1b[42;30m{line_num:>3} +{content}\x1b[0m\r\n")
                                 } else if let Some(content) = line.strip_prefix('-') {

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -239,8 +239,7 @@ impl SessionRecorder {
                             frame.push_str(&format!(
                                 "    \x1b[90mAdded \x1b[1;37m{new_count}\x1b[0m\x1b[90m lines, removed \x1b[1;37m{old_count}\x1b[0m\x1b[90m lines\x1b[0m\r\n"
                             ));
-                            let mut line_num = 1u32;
-                            for line in diff_content.lines().take(MAX_DIFF_LINES) {
+                            for (line_num, line) in (1u32..).zip(diff_content.lines().take(MAX_DIFF_LINES)) {
                                 let colored = if let Some(content) = line.strip_prefix('+') {
                                     format!("    \x1b[42;30m{line_num:>3} +{content}\x1b[0m\r\n")
                                 } else if let Some(content) = line.strip_prefix('-') {
@@ -248,7 +247,6 @@ impl SessionRecorder {
                                 } else {
                                     format!("    \x1b[90m{line_num:>3}  {line}\x1b[0m\r\n")
                                 };
-                                line_num += 1;
                                 frame.push_str(&colored);
                             }
                             let total = diff_content.lines().count();

--- a/src/terminals/ghostty.rs
+++ b/src/terminals/ghostty.rs
@@ -1,33 +1,54 @@
 use super::run_osascript;
 use crate::session::ClaudeSession;
 
-pub fn switch(session: &ClaudeSession) -> Result<(), String> {
+/// Find the best matching Ghostty terminal for a session.
+/// Ghostty's AppleScript API exposes: id, name, working directory (no tty/pid).
+/// Strategy: match by CWD, disambiguate by session name in terminal title.
+fn find_terminal_script(session: &ClaudeSession) -> String {
     let cwd = session.cwd.replace('"', "\\\"");
-    let tty = &session.tty;
+    let session_name = session.session_name.replace('"', "\\\"");
+
+    // If we have a session name, try to match it against the terminal title first.
+    // Claude Code sets the terminal title to "<spinner> <task_description>" which
+    // often contains the session name (from --name or --resume flags).
+    if session_name.is_empty() {
+        // No session name — match by CWD only, take first match
+        format!(
+            r#"
+            set matches to every terminal whose working directory contains "{cwd}"
+            if (count of matches) = 0 then error "No Ghostty terminal found for {cwd}"
+            set t to item 1 of matches
+            "#,
+        )
+    } else {
+        // Try CWD + name match first, fall back to CWD-only
+        format!(
+            r#"
+            set matches to every terminal whose working directory contains "{cwd}"
+            if (count of matches) = 0 then error "No Ghostty terminal found for {cwd}"
+
+            -- Disambiguate: find the terminal whose title contains our session name
+            set t to item 1 of matches
+            repeat with candidate in matches
+                if name of candidate contains "{session_name}" then
+                    set t to candidate
+                    exit repeat
+                end if
+            end repeat
+            "#,
+        )
+    }
+}
+
+pub fn switch(session: &ClaudeSession) -> Result<(), String> {
+    let find = find_terminal_script(session);
 
     let script = format!(
         r#"
         tell application "Ghostty"
-            -- Try matching by working directory first
-            set matches to every terminal whose working directory contains "{cwd}"
-
-            -- Find the one matching our TTY if multiple matches
-            repeat with t in matches
-                if tty of t contains "{tty}" then
-                    focus t
-                    activate
-                    return "ok"
-                end if
-            end repeat
-
-            -- Fallback: focus first match by cwd
-            if (count of matches) > 0 then
-                focus (item 1 of matches)
-                activate
-                return "ok"
-            end if
-
-            error "Session not found in Ghostty"
+            {find}
+            focus t
+            activate
         end tell
         "#,
     );
@@ -37,26 +58,13 @@ pub fn switch(session: &ClaudeSession) -> Result<(), String> {
 
 pub fn send_input(session: &ClaudeSession, text: &str) -> Result<(), String> {
     let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
-    let cwd = session.cwd.replace('"', "\\\"");
-    let tty = &session.tty;
+    let find = find_terminal_script(session);
 
     let script = format!(
         r#"
         tell application "Ghostty"
-            set matches to every terminal whose working directory contains "{cwd}"
-
-            -- Find the one matching our TTY if multiple matches
-            repeat with t in matches
-                if tty of t contains "{tty}" then
-                    input text "{escaped}" to t
-                    return "ok"
-                end if
-            end repeat
-
-            -- Fallback: send to first match by cwd
-            if (count of matches) > 0 then
-                input text "{escaped}" to (item 1 of matches)
-            end if
+            {find}
+            input text "{escaped}" to t
         end tell
         "#,
     );
@@ -64,26 +72,13 @@ pub fn send_input(session: &ClaudeSession, text: &str) -> Result<(), String> {
 }
 
 pub fn approve(session: &ClaudeSession) -> Result<(), String> {
-    let cwd = session.cwd.replace('"', "\\\"");
-    let tty = &session.tty;
+    let find = find_terminal_script(session);
 
     let script = format!(
         r#"
         tell application "Ghostty"
-            set matches to every terminal whose working directory contains "{cwd}"
-
-            -- Find the one matching our TTY if multiple matches
-            repeat with t in matches
-                if tty of t contains "{tty}" then
-                    input text "\r" to t
-                    return "ok"
-                end if
-            end repeat
-
-            -- Fallback: send to first match by cwd
-            if (count of matches) > 0 then
-                input text "\r" to (item 1 of matches)
-            end if
+            {find}
+            send key "enter" to t
         end tell
         "#,
     );

--- a/src/terminals/ghostty.rs
+++ b/src/terminals/ghostty.rs
@@ -1,12 +1,17 @@
 use super::run_osascript;
 use crate::session::ClaudeSession;
 
+/// Escape a string for embedding inside an AppleScript double-quoted literal.
+fn applescript_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 /// Find the best matching Ghostty terminal for a session.
 /// Ghostty's AppleScript API exposes: id, name, working directory (no tty/pid).
 /// Strategy: match by CWD, disambiguate by session name in terminal title.
 fn find_terminal_script(session: &ClaudeSession) -> String {
-    let cwd = session.cwd.replace('"', "\\\"");
-    let session_name = session.session_name.replace('"', "\\\"");
+    let cwd = applescript_escape(&session.cwd);
+    let session_name = applescript_escape(&session.session_name);
 
     // If we have a session name, try to match it against the terminal title first.
     // Claude Code sets the terminal title to "<spinner> <task_description>" which
@@ -57,14 +62,25 @@ pub fn switch(session: &ClaudeSession) -> Result<(), String> {
 }
 
 pub fn send_input(session: &ClaudeSession, text: &str) -> Result<(), String> {
-    let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
     let find = find_terminal_script(session);
+
+    // Strip trailing newline — we append AppleScript `return` instead so the
+    // newline is a proper CR rather than a literal embedded in the string.
+    let trimmed = text.trim_end_matches('\n').trim_end_matches('\r');
+    let escaped = applescript_escape(trimmed);
+    let has_trailing_newline = text.ends_with('\n') || text.ends_with('\r');
+
+    let text_expr = if has_trailing_newline {
+        format!("\"{escaped}\" & return")
+    } else {
+        format!("\"{escaped}\"")
+    };
 
     let script = format!(
         r#"
         tell application "Ghostty"
             {find}
-            input text "{escaped}" to t
+            input text {text_expr} to t
         end tell
         "#,
     );
@@ -83,4 +99,93 @@ pub fn approve(session: &ClaudeSession) -> Result<(), String> {
         "#,
     );
     run_osascript(&script)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{ClaudeSession, RawSession};
+
+    fn make_session(cwd: &str, name: &str) -> ClaudeSession {
+        let raw = RawSession {
+            pid: 100,
+            session_id: "test".into(),
+            cwd: cwd.into(),
+            started_at: 0,
+        };
+        let mut s = ClaudeSession::from_raw(raw);
+        s.session_name = name.into();
+        s
+    }
+
+    #[test]
+    fn find_script_unnamed_session() {
+        let s = make_session("/tmp/my-project", "");
+        let script = find_terminal_script(&s);
+        assert!(script.contains("working directory contains \"/tmp/my-project\""));
+        // Should NOT have name-matching logic
+        assert!(!script.contains("name of candidate"));
+    }
+
+    #[test]
+    fn find_script_named_session() {
+        let s = make_session("/tmp/my-project", "my-task");
+        let script = find_terminal_script(&s);
+        assert!(script.contains("working directory contains \"/tmp/my-project\""));
+        assert!(script.contains("name of candidate contains \"my-task\""));
+        // Should set fallback before loop
+        assert!(script.contains("set t to item 1 of matches"));
+    }
+
+    #[test]
+    fn find_script_escapes_quotes() {
+        let s = make_session("/tmp/project \"alpha\"", "task \"beta\"");
+        let script = find_terminal_script(&s);
+        assert!(script.contains("project \\\"alpha\\\""));
+        assert!(script.contains("task \\\"beta\\\""));
+    }
+
+    #[test]
+    fn find_script_escapes_backslashes() {
+        let s = make_session("/tmp/path\\with\\slashes", "name\\here");
+        let script = find_terminal_script(&s);
+        assert!(script.contains("path\\\\with\\\\slashes"));
+        assert!(script.contains("name\\\\here"));
+    }
+
+    #[test]
+    fn applescript_escape_handles_both() {
+        assert_eq!(applescript_escape(r#"a"b\c"#), r#"a\"b\\c"#);
+    }
+
+    #[test]
+    fn send_input_trailing_newline_uses_return() {
+        let s = make_session("/tmp/proj", "");
+        // We can't call send_input directly (it runs osascript), but we can
+        // verify the text processing logic by checking the escaping.
+        let text = "continue\n";
+        let trimmed = text.trim_end_matches('\n').trim_end_matches('\r');
+        let escaped = applescript_escape(trimmed);
+        let has_trailing = text.ends_with('\n') || text.ends_with('\r');
+        assert_eq!(trimmed, "continue");
+        assert_eq!(escaped, "continue");
+        assert!(has_trailing);
+        // The expression should use & return
+        let expr = if has_trailing {
+            format!("\"{escaped}\" & return")
+        } else {
+            format!("\"{escaped}\"")
+        };
+        assert_eq!(expr, "\"continue\" & return");
+        let _ = s; // suppress unused
+    }
+
+    #[test]
+    fn send_input_no_trailing_newline() {
+        let text = "some text";
+        let trimmed = text.trim_end_matches('\n').trim_end_matches('\r');
+        let has_trailing = text.ends_with('\n') || text.ends_with('\r');
+        assert_eq!(trimmed, "some text");
+        assert!(!has_trailing);
+    }
 }

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -184,7 +184,7 @@ pub fn render_detail_panel(frame: &mut Frame, area: Rect, session: &ClaudeSessio
             Style::default().fg(t.header).add_modifier(Modifier::BOLD),
         )));
         let mut tools: Vec<_> = session.tool_usage.iter().collect();
-        tools.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        tools.sort_by_key(|t| std::cmp::Reverse(t.1.calls));
         for (name, stats) in tools.iter().take(10) {
             lines.push(detail_line(
                 &format!("  {name}"),


### PR DESCRIPTION
## Summary
- Ghostty's AppleScript API exposes only `id`, `name`, and `working directory` on terminal objects — **no `tty` or `pid` property**. The previous `tty of t` matching silently failed on every invocation, always falling through to "first CWD match" which sent input to an arbitrary pane when multiple splits share a directory.
- `input text "\r"` sent literal backslash-r characters (AppleScript doesn't use C-style escapes). Changed `approve()` to use `send key "enter"` which sends a proper keyboard event.
- Refactored all three functions (`switch`, `send_input`, `approve`) to share a `find_terminal_script()` helper that uses **session name → terminal title matching** as the disambiguation strategy.

### Matching strategy
1. Filter terminals by `working directory contains <cwd>`
2. If the session has a name (from `--name` or `--resume`), match it against the terminal's `name` property (title set by Claude Code via OSC escape sequences)
3. Fall back to first CWD match when no name match is found

### Known limitation
Sessions without a `--name` flag in the same directory cannot be reliably distinguished. Ghostty would need to expose a `tty` or `pid` property on terminal objects for exact matching.

## Test plan
- [ ] Run two Claude Code sessions in the same directory with `--name` flags (`claude --name foo`, `claude --name bar`)
- [ ] Run `claudectl` and press `y` on each — verify the correct session receives the approval
- [ ] Run a single unnamed session — verify approve still works (CWD fallback)
- [ ] Verify `switch` (Enter on session) focuses the correct Ghostty pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)