### PR TITLE
feat: session lifecycle auto-restart on context saturation

### DIFF
--- a/src/brain/engine.rs
+++ b/src/brain/engine.rs
@@ -33,6 +33,8 @@ pub struct BrainEngine {
     last_orchestrate: Option<Instant>,
     /// Whether an orchestration inference is in-flight.
     orchestrate_inflight: bool,
+    /// PIDs that have been restarted due to context saturation (prevents restart loops).
+    restarted_pids: HashSet<u32>,
 }
 
 const COOLDOWN_SECS: u64 = 10;
@@ -49,6 +51,7 @@ impl BrainEngine {
             pending: HashMap::new(),
             last_orchestrate: None,
             orchestrate_inflight: false,
+            restarted_pids: HashSet::new(),
         }
     }
 
@@ -415,6 +418,86 @@ impl BrainEngine {
         self.pending.remove(&pid)
     }
 
+    /// Check for sessions with saturated context and auto-restart them.
+    /// Saves a checkpoint and spawns a fresh session with the summary as prompt.
+    pub fn maybe_restart_saturated(
+        &mut self,
+        sessions: &[ClaudeSession],
+        lifecycle: &crate::config::LifecycleConfig,
+        is_idle: bool,
+    ) -> Vec<(u32, String)> {
+        if !lifecycle.auto_restart {
+            return Vec::new();
+        }
+        if lifecycle.restart_only_when_idle && !is_idle {
+            return Vec::new();
+        }
+
+        let threshold = lifecycle.restart_threshold_pct / 100.0;
+        let mut actions = Vec::new();
+
+        for session in sessions {
+            if self.restarted_pids.contains(&session.pid) {
+                continue;
+            }
+            if session.context_max == 0 {
+                continue;
+            }
+            let pct = session.context_tokens as f64 / session.context_max as f64;
+            if pct < threshold {
+                continue;
+            }
+            // Don't restart if actively waiting for tool approval
+            if session.status == SessionStatus::NeedsInput {
+                continue;
+            }
+
+            // Build summary for checkpoint
+            let ctx =
+                context::build_context(session, &[session.clone()], self.config.max_context_tokens);
+            let summary = format!(
+                "Continue the work from a previous session that hit context limits.\n\
+                 Project: {}\nModel: {}\nCost so far: ${:.2}\n\n\
+                 Recent context:\n{}",
+                session.display_name(),
+                session.model,
+                session.cost_usd,
+                &ctx.recent_transcript,
+            );
+
+            // Save checkpoint
+            if let Err(e) = save_checkpoint(&session.session_id, session, &summary) {
+                crate::logger::log("BRAIN", &format!("Checkpoint save failed: {e}"));
+            }
+
+            // Spawn fresh session
+            match crate::terminals::launch_session(&session.cwd, Some(&summary), None) {
+                Ok(msg) => {
+                    self.restarted_pids.insert(session.pid);
+                    actions.push((
+                        session.pid,
+                        format!(
+                            "Lifecycle: restarted {} (context at {:.0}%) → {msg}",
+                            session.display_name(),
+                            pct * 100.0,
+                        ),
+                    ));
+                }
+                Err(e) => {
+                    actions.push((
+                        session.pid,
+                        format!(
+                            "Lifecycle: restart failed for {}: {e}",
+                            session.display_name()
+                        ),
+                    ));
+                }
+            }
+        }
+
+        actions
+    }
+
     /// Clear pending suggestions for PIDs that are no longer in NeedsInput/WaitingInput.
     pub fn cleanup(&mut self, sessions: &[ClaudeSession]) {
         let active_pids: HashSet<u32> = sessions.iter().map(|s| s.pid).collect();
@@ -644,6 +727,40 @@ fn extract_file_path(input: &str) -> Option<String> {
     None
 }
 
+fn save_checkpoint(session_id: &str, session: &ClaudeSession, summary: &str) -> Result<(), String> {
+    let home = std::env::var("HOME").map_err(|e| format!("HOME not set: {e}"))?;
+    let dir = std::path::PathBuf::from(home)
+        .join(".claudectl")
+        .join("brain")
+        .join("checkpoints");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir failed: {e}"))?;
+
+    let path = dir.join(format!("{session_id}.md"));
+    let content = format!(
+        "# Session Checkpoint\n\n\
+         - Session: {}\n\
+         - Project: {}\n\
+         - Model: {}\n\
+         - Cost: ${:.2}\n\
+         - Context: {}/{}  ({:.0}%)\n\n\
+         ## Summary\n\n{}\n",
+        session_id,
+        session.display_name(),
+        session.model,
+        session.cost_usd,
+        session.context_tokens,
+        session.context_max,
+        if session.context_max > 0 {
+            session.context_tokens as f64 / session.context_max as f64 * 100.0
+        } else {
+            0.0
+        },
+        summary,
+    );
+    std::fs::write(&path, content).map_err(|e| format!("write failed: {e}"))?;
+    Ok(())
+}
+
 fn suggestion_to_rule_match(suggestion: &BrainSuggestion) -> RuleMatch {
     RuleMatch {
         rule_name: format!(
@@ -814,6 +931,84 @@ mod tests {
     #[test]
     fn extract_file_path_none_for_plain_text() {
         assert_eq!(extract_file_path("hello world"), None);
+    }
+
+    #[test]
+    fn lifecycle_below_threshold_no_restart() {
+        let config = crate::config::LifecycleConfig {
+            auto_restart: true,
+            restart_threshold_pct: 90.0,
+            restart_only_when_idle: false,
+        };
+        let mut engine = BrainEngine::new(make_config());
+        let mut s = make_session(100, SessionStatus::Processing);
+        s.context_tokens = 50_000;
+        s.context_max = 200_000;
+
+        let actions = engine.maybe_restart_saturated(&[s], &config, true);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn lifecycle_above_threshold_flags_restart() {
+        let config = crate::config::LifecycleConfig {
+            auto_restart: true,
+            restart_threshold_pct: 90.0,
+            restart_only_when_idle: false,
+        };
+        let mut engine = BrainEngine::new(make_config());
+        let mut s = make_session(100, SessionStatus::Processing);
+        s.context_tokens = 190_000;
+        s.context_max = 200_000;
+
+        let actions = engine.maybe_restart_saturated(&[s], &config, true);
+        assert!(!actions.is_empty());
+        assert!(actions[0].1.contains("Lifecycle:"));
+    }
+
+    #[test]
+    fn lifecycle_no_restart_loop() {
+        let config = crate::config::LifecycleConfig {
+            auto_restart: true,
+            restart_threshold_pct: 90.0,
+            restart_only_when_idle: false,
+        };
+        let mut engine = BrainEngine::new(make_config());
+        engine.restarted_pids.insert(100);
+        let mut s = make_session(100, SessionStatus::Processing);
+        s.context_tokens = 190_000;
+        s.context_max = 200_000;
+
+        let actions = engine.maybe_restart_saturated(&[s], &config, true);
+        assert!(actions.is_empty(), "Should skip already-restarted PID");
+    }
+
+    #[test]
+    fn lifecycle_respects_idle_only() {
+        let config = crate::config::LifecycleConfig {
+            auto_restart: true,
+            restart_threshold_pct: 90.0,
+            restart_only_when_idle: true,
+        };
+        let mut engine = BrainEngine::new(make_config());
+        let mut s = make_session(100, SessionStatus::Processing);
+        s.context_tokens = 190_000;
+        s.context_max = 200_000;
+
+        let actions = engine.maybe_restart_saturated(&[s], &config, false);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn lifecycle_disabled_no_restart() {
+        let config = crate::config::LifecycleConfig::default();
+        let mut engine = BrainEngine::new(make_config());
+        let mut s = make_session(100, SessionStatus::Processing);
+        s.context_tokens = 190_000;
+        s.context_max = 200_000;
+
+        let actions = engine.maybe_restart_saturated(&[s], &config, true);
+        assert!(actions.is_empty());
     }
 
     #[test]

--- a/src/brain/engine.rs
+++ b/src/brain/engine.rs
@@ -453,8 +453,11 @@ impl BrainEngine {
             }
 
             // Build summary for checkpoint
-            let ctx =
-                context::build_context(session, &[session.clone()], self.config.max_context_tokens);
+            let ctx = context::build_context(
+                session,
+                std::slice::from_ref(session),
+                self.config.max_context_tokens,
+            );
             let summary = format!(
                 "Continue the work from a previous session that hit context limits.\n\
                  Project: {}\nModel: {}\nCost so far: ${:.2}\n\n\

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,7 @@ pub struct Config {
     pub file_conflicts: bool, // Detect file-level conflicts across sessions
     pub auto_deny_file_conflicts: bool, // Auto-deny writes to conflicting files
     pub brain: Option<BrainConfig>,
+    pub lifecycle: LifecycleConfig,
     pub agents: Vec<AgentConfig>,
 }
 
@@ -111,6 +112,24 @@ impl Default for BrainConfig {
     }
 }
 
+/// Configuration for session lifecycle management (auto-restart on context saturation).
+#[derive(Debug, Clone)]
+pub struct LifecycleConfig {
+    pub auto_restart: bool,
+    pub restart_threshold_pct: f64,
+    pub restart_only_when_idle: bool,
+}
+
+impl Default for LifecycleConfig {
+    fn default() -> Self {
+        Self {
+            auto_restart: false,
+            restart_threshold_pct: 90.0,
+            restart_only_when_idle: true,
+        }
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -132,6 +151,7 @@ impl Default for Config {
             file_conflicts: true,
             auto_deny_file_conflicts: false,
             brain: None,
+            lifecycle: LifecycleConfig::default(),
             agents: Vec::new(),
         }
     }
@@ -158,7 +178,15 @@ struct RawConfig {
     file_conflicts: Option<bool>,
     auto_deny_file_conflicts: Option<bool>,
     brain: Option<BrainConfig>,
+    lifecycle: Option<RawLifecycleConfig>,
     agents: Vec<AgentConfig>,
+}
+
+#[derive(Debug, Default)]
+struct RawLifecycleConfig {
+    auto_restart: Option<bool>,
+    restart_threshold_pct: Option<f64>,
+    restart_only_when_idle: Option<bool>,
 }
 
 impl Config {
@@ -270,6 +298,17 @@ impl Config {
         }
         if let Some(brain) = raw.brain {
             self.brain = Some(brain);
+        }
+        if let Some(lc) = raw.lifecycle {
+            if let Some(v) = lc.auto_restart {
+                self.lifecycle.auto_restart = v;
+            }
+            if let Some(v) = lc.restart_threshold_pct {
+                self.lifecycle.restart_threshold_pct = v;
+            }
+            if let Some(v) = lc.restart_only_when_idle {
+                self.lifecycle.restart_only_when_idle = v;
+            }
         }
         for agent in raw.agents {
             if let Some(pos) = self.agents.iter().position(|a| a.name == agent.name) {
@@ -690,6 +729,17 @@ fn parse_config_file(path: &PathBuf) -> Option<RawConfig> {
                         }
                     }
                     "message" => rule.message = Some(unquote(value)),
+                    _ => {}
+                }
+            }
+            ("lifecycle", key) => {
+                let lc = raw
+                    .lifecycle
+                    .get_or_insert_with(RawLifecycleConfig::default);
+                match key {
+                    "auto_restart" => lc.auto_restart = parse_bool(value),
+                    "restart_threshold_pct" => lc.restart_threshold_pct = value.parse().ok(),
+                    "restart_only_when_idle" => lc.restart_only_when_idle = parse_bool(value),
                     _ => {}
                 }
             }


### PR DESCRIPTION
## Summary
- Adds `[lifecycle]` config section for auto-restart on context saturation
- Brain detects sessions above threshold and checkpoints their state to `~/.claudectl/brain/checkpoints/`
- Spawns fresh session with summarized context to continue work
- Tracks restarted PIDs to prevent restart loops
- Configurable threshold (default 90%) and idle-only mode

Closes #147

## Test plan
- [x] Sessions below threshold not restarted
- [x] Sessions above threshold trigger restart attempt
- [x] No restart loop (restarted PIDs tracked)
- [x] `restart_only_when_idle` respected
- [x] Disabled by default (`auto_restart = false`)
- [x] `cargo test` passes
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)