### PR TITLE
feat: dynamic task decomposition for large prompts

### DIFF
--- a/src/brain/client.rs
+++ b/src/brain/client.rs
@@ -70,6 +70,93 @@ pub fn infer(config: &BrainConfig, prompt: &str) -> Result<BrainSuggestion, Stri
     }
 }
 
+/// Result of a task decomposition analysis.
+#[derive(Debug, Clone)]
+pub struct DecompositionResult {
+    pub decomposable: bool,
+    pub reasoning: String,
+    pub tasks: Vec<DecomposedTask>,
+}
+
+/// A single sub-task from decomposition.
+#[derive(Debug, Clone)]
+pub struct DecomposedTask {
+    pub name: String,
+    pub prompt: String,
+    pub depends_on: Vec<String>,
+}
+
+/// Analyze a prompt and determine if it can be split into parallel sub-tasks.
+pub fn decompose_prompt(
+    config: &BrainConfig,
+    prompt: &str,
+    cwd: &str,
+    max_tasks: usize,
+) -> Result<DecompositionResult, String> {
+    let template = super::prompts::load(super::prompts::DECOMPOSITION);
+    let expanded = super::prompts::expand(
+        &template,
+        &[
+            ("prompt", prompt),
+            ("cwd", cwd),
+            ("max_tasks", &max_tasks.to_string()),
+        ],
+    );
+
+    let response = call_llm(config, &expanded)?;
+    parse_decomposition_json(&response)
+}
+
+/// Parse the decomposition JSON response.
+pub fn parse_decomposition_json(text: &str) -> Result<DecompositionResult, String> {
+    let json: serde_json::Value = serde_json::from_str(text.trim())
+        .map_err(|e| format!("invalid decomposition JSON: {e}"))?;
+
+    let decomposable = json
+        .get("decomposable")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let reasoning = json
+        .get("reasoning")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let tasks = if decomposable {
+        json.get("tasks")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| {
+                        Some(DecomposedTask {
+                            name: t.get("name")?.as_str()?.to_string(),
+                            prompt: t.get("prompt")?.as_str()?.to_string(),
+                            depends_on: t
+                                .get("depends_on")
+                                .and_then(|v| v.as_array())
+                                .map(|deps| {
+                                    deps.iter()
+                                        .filter_map(|d| d.as_str().map(|s| s.to_string()))
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    Ok(DecompositionResult {
+        decomposable,
+        reasoning,
+        tasks,
+    })
+}
+
 /// Detect if the endpoint is OpenAI-compatible based on URL path.
 fn is_openai_compatible(endpoint: &str) -> bool {
     endpoint.contains("/v1/chat") || endpoint.contains("/v1/completions")
@@ -354,5 +441,37 @@ mod tests {
         ));
         assert!(is_openai_compatible("http://host/v1/completions"));
         assert!(!is_openai_compatible("http://localhost:11434/api/generate"));
+    }
+
+    #[test]
+    fn parse_decomposition_decomposable() {
+        let json = r#"{"decomposable": true, "reasoning": "two independent modules", "tasks": [{"name": "task-a", "prompt": "update module A", "depends_on": []}, {"name": "task-b", "prompt": "update module B", "depends_on": []}]}"#;
+        let result = parse_decomposition_json(json).unwrap();
+        assert!(result.decomposable);
+        assert_eq!(result.tasks.len(), 2);
+        assert_eq!(result.tasks[0].name, "task-a");
+        assert_eq!(result.tasks[1].name, "task-b");
+        assert!(result.tasks[0].depends_on.is_empty());
+    }
+
+    #[test]
+    fn parse_decomposition_not_decomposable() {
+        let json = r#"{"decomposable": false, "reasoning": "task is atomic", "tasks": []}"#;
+        let result = parse_decomposition_json(json).unwrap();
+        assert!(!result.decomposable);
+        assert!(result.tasks.is_empty());
+        assert!(result.reasoning.contains("atomic"));
+    }
+
+    #[test]
+    fn parse_decomposition_with_dependencies() {
+        let json = r#"{"decomposable": true, "reasoning": "pipeline", "tasks": [{"name": "analyze", "prompt": "analyze code", "depends_on": []}, {"name": "fix", "prompt": "fix issues", "depends_on": ["analyze"]}]}"#;
+        let result = parse_decomposition_json(json).unwrap();
+        assert_eq!(result.tasks[1].depends_on, vec!["analyze"]);
+    }
+
+    #[test]
+    fn parse_decomposition_invalid_json() {
+        assert!(parse_decomposition_json("not json").is_err());
     }
 }

--- a/src/brain/prompts.rs
+++ b/src/brain/prompts.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 pub const ADVISORY: &str = "advisory";
 pub const ORCHESTRATION: &str = "orchestration";
 pub const SUMMARIZE: &str = "summarize";
+pub const DECOMPOSITION: &str = "decomposition";
 
 /// Load a prompt template by name. Checks user overrides first, falls back to built-in.
 pub fn load(name: &str) -> String {
@@ -50,6 +51,7 @@ fn builtin(name: &str) -> &'static str {
         ADVISORY => ADVISORY_PROMPT,
         ORCHESTRATION => ORCHESTRATION_PROMPT,
         SUMMARIZE => SUMMARIZE_PROMPT,
+        DECOMPOSITION => DECOMPOSITION_PROMPT,
         _ => {
             "Respond with JSON: {\"action\": \"deny\", \"reasoning\": \"unknown prompt\", \"confidence\": 0.0}"
         }
@@ -58,7 +60,7 @@ fn builtin(name: &str) -> &'static str {
 
 /// List all available prompt names and their source (builtin vs user override).
 pub fn list_prompts() -> Vec<(String, String)> {
-    let names = [ADVISORY, ORCHESTRATION, SUMMARIZE];
+    let names = [ADVISORY, ORCHESTRATION, SUMMARIZE, DECOMPOSITION];
     names
         .iter()
         .map(|name| {
@@ -102,6 +104,23 @@ Analyze all sessions and decide if any cross-session action should be taken:
 Consider: Are sessions doing redundant work? Could work be parallelized? Is a session stuck? Has one session produced output another needs?
 
 Respond with JSON: {"action": "spawn"|"route"|"terminate"|"deny", "target_pid": <pid if route>, "spawn_prompt": "...", "spawn_cwd": ".", "reasoning": "...", "confidence": 0.0-1.0}"#;
+
+const DECOMPOSITION_PROMPT: &str = r#"Analyze this task prompt and determine if it can be split into independent parallel sub-tasks.
+
+Task prompt:
+{{prompt}}
+
+Working directory: {{cwd}}
+
+Rules:
+- Only split if parts are truly independent (can run in parallel without file conflicts)
+- Each sub-task must be self-contained with a clear, actionable prompt
+- Keep the number of sub-tasks between 2 and {{max_tasks}}
+- If the task is already focused/atomic, set decomposable to false
+- Name each sub-task with a short slug (lowercase, hyphens)
+
+Respond with JSON:
+{"decomposable": true/false, "reasoning": "why or why not", "tasks": [{"name": "short-name", "prompt": "full prompt text", "depends_on": ["other-task-name"]}]}"#;
 
 const SUMMARIZE_PROMPT: &str = r#"Summarize this output from session '{{source_project}}' for another Claude Code session working on: {{target_task}}
 
@@ -159,10 +178,11 @@ mod tests {
     #[test]
     fn list_prompts_returns_all() {
         let prompts = list_prompts();
-        assert_eq!(prompts.len(), 3);
+        assert_eq!(prompts.len(), 4);
         assert!(prompts.iter().any(|(n, _)| n == ADVISORY));
         assert!(prompts.iter().any(|(n, _)| n == ORCHESTRATION));
         assert!(prompts.iter().any(|(n, _)| n == SUMMARIZE));
+        assert!(prompts.iter().any(|(n, _)| n == DECOMPOSITION));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,10 @@ struct Cli {
     brain_stats: Option<String>,
 
     // ── Orchestration ──────────────────────────────────────────────────
+    /// Analyze a prompt and suggest parallel sub-tasks (outputs TaskFile JSON)
+    #[arg(long, help_heading = "Orchestration")]
+    decompose: Option<String>,
+
     /// Run tasks from a JSON file (e.g., claudectl --run tasks.json)
     #[arg(long, help_heading = "Orchestration")]
     run: Option<String>,
@@ -358,6 +362,38 @@ fn main() -> io::Result<()> {
 
     if let Some(ref subcommand) = cli.brain_stats {
         brain::metrics::dispatch(subcommand);
+        return Ok(());
+    }
+
+    if let Some(ref prompt) = cli.decompose {
+        let brain_cfg = cfg.brain.clone().unwrap_or_default();
+        if prompt.len() < 200 {
+            println!(
+                "Prompt is short ({} chars) — decomposition works best with larger, multi-part prompts.",
+                prompt.len()
+            );
+        }
+        let cwd = std::env::current_dir()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| ".".into());
+        let max_tasks = brain_cfg.max_sessions.min(6);
+        eprintln!("Analyzing prompt for decomposition...");
+        match brain::client::decompose_prompt(&brain_cfg, prompt, &cwd, max_tasks) {
+            Ok(result) => {
+                if result.decomposable {
+                    let task_file = orchestrator::decomposition_to_task_file(result.tasks, &cwd);
+                    let json = serde_json::to_string_pretty(&task_file)
+                        .unwrap_or_else(|e| format!("JSON error: {e}"));
+                    println!("{json}");
+                } else {
+                    println!("Not decomposable: {}", result.reasoning);
+                }
+            }
+            Err(e) => {
+                eprintln!("Decomposition failed: {e}");
+                std::process::exit(1);
+            }
+        }
         return Ok(());
     }
 

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 /// A task definition from the tasks file.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct TaskDef {
     pub name: String,
@@ -29,7 +29,7 @@ pub struct TaskDef {
 }
 
 /// Task file containing a list of tasks.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TaskFile {
     pub tasks: Vec<TaskDef>,
@@ -163,6 +163,27 @@ struct TaskReport {
     latest_stderr_log: Option<String>,
     recent_output: Vec<String>,
     attempts: Vec<AttemptArtifact>,
+}
+
+/// Convert decomposed tasks into a TaskFile compatible with the orchestrator.
+pub fn decomposition_to_task_file(
+    tasks: Vec<crate::brain::client::DecomposedTask>,
+    cwd: &str,
+) -> TaskFile {
+    TaskFile {
+        tasks: tasks
+            .into_iter()
+            .map(|t| TaskDef {
+                name: t.name,
+                cwd: Some(cwd.to_string()),
+                prompt: t.prompt,
+                depends_on: t.depends_on,
+                resume: None,
+                retries: None,
+            })
+            .collect(),
+        retries: None,
+    }
 }
 
 /// Load tasks from a JSON file.
@@ -1443,5 +1464,34 @@ mod tests {
         let outputs = HashMap::new();
         let err = expand_prompt_templates("{{a.stderr}}", &outputs).unwrap_err();
         assert!(err.to_string().contains("unsupported"));
+    }
+
+    #[test]
+    fn test_decomposition_to_task_file() {
+        let tasks = vec![
+            crate::brain::client::DecomposedTask {
+                name: "analyze".into(),
+                prompt: "analyze code".into(),
+                depends_on: vec![],
+            },
+            crate::brain::client::DecomposedTask {
+                name: "fix".into(),
+                prompt: "fix issues".into(),
+                depends_on: vec!["analyze".into()],
+            },
+        ];
+        let task_file = decomposition_to_task_file(tasks, "/tmp/proj");
+        assert_eq!(task_file.tasks.len(), 2);
+        assert_eq!(task_file.tasks[0].name, "analyze");
+        assert_eq!(task_file.tasks[0].cwd, Some("/tmp/proj".into()));
+        assert_eq!(task_file.tasks[1].depends_on, vec!["analyze"]);
+        // Validate the resulting task file is valid
+        assert!(validate_task_file(&task_file).is_ok());
+    }
+
+    #[test]
+    fn test_decomposition_empty_tasks() {
+        let task_file = decomposition_to_task_file(vec![], "/tmp");
+        assert!(task_file.tasks.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Adds brain-powered prompt decomposition via local LLM
- New `--decompose` CLI flag analyzes prompts and outputs parallel sub-task DAGs
- Output is orchestrator-compatible `TaskFile` JSON (pipe to `--run`)
- New `DECOMPOSITION` prompt template (user-overridable)
- `DecompositionResult` and `parse_decomposition_json` in client.rs
- `decomposition_to_task_file` conversion in orchestrator.rs
- `TaskDef` and `TaskFile` now implement `Serialize`

Closes #149

## Test plan
- [x] Decomposition JSON parsing (decomposable, not decomposable, with deps)
- [x] Invalid JSON error handling
- [x] Conversion to TaskFile with correct dependencies
- [x] Generated TaskFile passes validation
- [x] Empty task list handled
- [x] Prompt template list updated (4 templates)
- [x] `cargo test` passes (230 tests)
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)