### PR TITLE
fix: resolve 'No transcript' for active sessions with valid JSONL on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.29.2] - 2026-04-18
+
+### Fixed
+- Active sessions showing "No transcript" when JSONL files exist on disk. `cwd_to_slug` now strips trailing slashes before encoding, and a new fallback scan searches all project directories by session ID when the slug-based lookup fails. (#161)
+
+### Added
+- `--doctor` now includes a "Transcript Discovery" section that shows each active session's cwd, computed slug, and resolved JSONL path (or the exact paths tried when resolution fails).
+- Debug-level logging at the transcript discovery step, showing which paths were tried and whether the fallback scan was used.
+
 ## [0.29.1] - 2026-04-17
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.29.1"
+version = "0.29.2"
 edition = "2024"
 description = "Auto-pilot for Claude Code — a local model watches every session and decides what to approve"
 license = "MIT"

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -69,7 +69,7 @@ pub fn resolve_jsonl_paths(sessions: &mut [ClaudeSession]) {
         let slug = cwd_to_slug(&session.cwd);
         let project_dir = projects_dir().join(&slug);
 
-        // Priority 1: Try the session's own ID
+        // Priority 1: Try the session's own ID in the expected project dir
         let own_path = project_dir.join(format!("{}.jsonl", session.session_id));
         if own_path.exists() {
             session.jsonl_path = Some(own_path);
@@ -85,9 +85,58 @@ pub fn resolve_jsonl_paths(sessions: &mut [ClaudeSession]) {
             }
         }
 
-        // Priority 3: Fall back to most recently modified .jsonl
-        session.jsonl_path = find_latest_jsonl(&project_dir);
+        // Priority 3: Fall back to most recently modified .jsonl in the project dir
+        if let Some(latest) = find_latest_jsonl(&project_dir) {
+            session.jsonl_path = Some(latest);
+            continue;
+        }
+
+        // Priority 4: Search ALL project directories for a JSONL matching the session ID.
+        // This handles cwd encoding mismatches between claudectl and Claude Code
+        // (e.g., symlink resolution, path normalization differences).
+        if let Some(found) = search_all_projects_for_session(&session.session_id) {
+            crate::logger::log(
+                "DEBUG",
+                &format!(
+                    "session {}: slug mismatch — found JSONL via project scan: {}",
+                    session.session_id,
+                    found.display()
+                ),
+            );
+            session.jsonl_path = Some(found);
+            continue;
+        }
+
+        crate::logger::log(
+            "DEBUG",
+            &format!(
+                "session {}: no JSONL found (slug={}, project_dir_exists={})",
+                session.session_id,
+                slug,
+                project_dir.exists()
+            ),
+        );
     }
+}
+
+/// Search all directories under ~/.claude/projects/ for a JSONL file matching the session ID.
+/// This is a fallback when the cwd-based slug doesn't match the actual directory on disk.
+fn search_all_projects_for_session(session_id: &str) -> Option<PathBuf> {
+    let filename = format!("{session_id}.jsonl");
+    let base = projects_dir();
+    let entries = fs::read_dir(&base).ok()?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let candidate = path.join(&filename);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 /// Extract the UUID from a --resume argument in command args.
@@ -212,7 +261,11 @@ pub fn resolve_worktree_ids(sessions: &mut [ClaudeSession]) {
 }
 
 fn cwd_to_slug(cwd: &str) -> String {
-    cwd.replace('/', "-")
+    let trimmed = cwd.trim_end_matches('/');
+    if trimmed.is_empty() {
+        return "-".to_string();
+    }
+    trimmed.replace('/', "-")
 }
 
 /// Remove session JSON files for dead PIDs whose files are older than 24 hours.
@@ -266,4 +319,47 @@ fn cleanup_stale_sessions(dir: &std::path::Path) {
 
 fn pid_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slug_basic_path() {
+        assert_eq!(cwd_to_slug("/Users/foo/bar"), "-Users-foo-bar");
+    }
+
+    #[test]
+    fn slug_trailing_slash() {
+        // Must strip trailing slash — otherwise slug ends with "-" and won't match disk
+        assert_eq!(
+            cwd_to_slug("/Users/foo/bar/"),
+            "-Users-foo-bar",
+            "trailing slash must be stripped before slugifying"
+        );
+    }
+
+    #[test]
+    fn slug_multiple_trailing_slashes() {
+        assert_eq!(cwd_to_slug("/Users/foo/bar///"), "-Users-foo-bar");
+    }
+
+    #[test]
+    fn slug_with_hyphens_in_name() {
+        assert_eq!(
+            cwd_to_slug("/Users/dev/data-platform-answers"),
+            "-Users-dev-data-platform-answers"
+        );
+    }
+
+    #[test]
+    fn slug_root() {
+        assert_eq!(cwd_to_slug("/"), "-");
+    }
+
+    #[test]
+    fn slug_single_component() {
+        assert_eq!(cwd_to_slug("/tmp"), "-tmp");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -532,9 +532,98 @@ fn launch_session(cwd: &str, prompt: Option<&str>, resume: Option<&str>) -> io::
     }
 }
 
+fn print_doctor_transcripts() {
+    println!();
+    println!("Transcript Discovery");
+
+    let sessions_dir = discovery::projects_dir().parent().unwrap().join("sessions");
+    let projects_dir = discovery::projects_dir();
+
+    // Check sessions directory
+    let sessions_exists = sessions_dir.exists();
+    println!(
+        "  [{}] sessions dir: {}",
+        if sessions_exists { "ok" } else { "!!" },
+        sessions_dir.display()
+    );
+
+    // Check projects directory
+    let projects_exists = projects_dir.exists();
+    println!(
+        "  [{}] projects dir: {}",
+        if projects_exists { "ok" } else { "!!" },
+        projects_dir.display()
+    );
+
+    if !sessions_exists {
+        println!("      No session pointer files found — Claude Code may not have run yet");
+        return;
+    }
+
+    // Scan sessions and attempt resolution
+    let mut sessions = discovery::scan_sessions();
+    if sessions.is_empty() {
+        println!("  [--] no session pointer files found");
+        return;
+    }
+
+    process::fetch_and_enrich(&mut sessions);
+    let alive: Vec<_> = sessions
+        .iter()
+        .filter(|s| s.status != session::SessionStatus::Finished)
+        .collect();
+
+    if alive.is_empty() {
+        println!("  [--] no active Claude Code sessions");
+        return;
+    }
+
+    // Resolve JSONL paths for alive sessions
+    let mut alive_sessions: Vec<_> = alive.into_iter().cloned().collect();
+    for s in &mut alive_sessions {
+        discovery::resolve_jsonl_paths(std::slice::from_mut(s));
+    }
+
+    for s in &alive_sessions {
+        let found = s.jsonl_path.is_some();
+        let slug = s.cwd.trim_end_matches('/').replace('/', "-");
+        let expected_dir = projects_dir.join(&slug);
+
+        println!(
+            "  [{}] PID {} ({})",
+            if found { "ok" } else { "!!" },
+            s.pid,
+            s.project_name
+        );
+        println!("      cwd:  {}", s.cwd);
+        println!("      slug: {slug}");
+        if let Some(ref path) = s.jsonl_path {
+            println!("      jsonl: {}", path.display());
+        } else {
+            println!(
+                "      expected dir: {} (exists={})",
+                expected_dir.display(),
+                expected_dir.exists()
+            );
+            let expected_file = expected_dir.join(format!("{}.jsonl", s.session_id));
+            println!(
+                "      expected file: {} (exists={})",
+                expected_file.display(),
+                expected_file.exists()
+            );
+            println!(
+                "      fix: check that Claude Code's project directory slug matches the cwd encoding above"
+            );
+        }
+    }
+}
+
 fn print_doctor() -> io::Result<()> {
     let report = terminals::doctor_report();
     println!("{}", terminals::format_doctor_report(&report));
+
+    // Transcript discovery diagnostics
+    print_doctor_transcripts();
 
     // Brain diagnostics
     let cfg = config::Config::load();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -928,3 +928,150 @@ fn recorder_cast_file_creation() {
 
     let _ = std::fs::remove_file(&output_path);
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// Transcript Discovery Tests (Issue #161)
+//
+// These tests mutate the HOME env var so projects_dir() resolves to a temp dir.
+// A mutex serializes them to prevent concurrent HOME changes across threads.
+// ────────────────────────────────────────────────────────────────────────────
+
+use std::sync::Mutex;
+static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+/// Helper: build a fake ~/.claude layout in a temp dir and run resolve_jsonl_paths.
+/// Holds HOME_LOCK for the duration.
+fn resolve_with_layout(
+    cwd: &str,
+    session_id: &str,
+    slug_on_disk: &str,
+) -> (ClaudeSession, tempfile::TempDir) {
+    let _guard = HOME_LOCK.lock().unwrap();
+
+    let home = tempfile::tempdir().unwrap();
+    let original_home = std::env::var("HOME").ok();
+    unsafe { std::env::set_var("HOME", home.path()) };
+
+    let project_dir = home.path().join(".claude/projects").join(slug_on_disk);
+    std::fs::create_dir_all(&project_dir).unwrap();
+    let jsonl_content = r#"{"type":"assistant","message":{"model":"claude-opus-4-6","stop_reason":"end_turn","usage":{"input_tokens":1,"cache_creation_input_tokens":523,"cache_read_input_tokens":79425,"output_tokens":937}}}"#;
+    std::fs::write(
+        project_dir.join(format!("{session_id}.jsonl")),
+        jsonl_content,
+    )
+    .unwrap();
+
+    let raw = RawSession {
+        pid: 86131,
+        session_id: session_id.to_string(),
+        cwd: cwd.to_string(),
+        started_at: 1776421121745,
+    };
+    let mut session = ClaudeSession::from_raw(raw);
+    discovery::resolve_jsonl_paths(std::slice::from_mut(&mut session));
+
+    // Restore HOME
+    if let Some(h) = original_home {
+        unsafe { std::env::set_var("HOME", h) };
+    }
+
+    (session, home)
+}
+
+#[test]
+fn resolve_jsonl_standard_cwd() {
+    let (s, _home) = resolve_with_layout(
+        "/Users/testuser/Repos/data-platform-answers",
+        "db55eb53-8ff0-45b7-9f8f-0d5dfa51e701",
+        "-Users-testuser-Repos-data-platform-answers",
+    );
+    assert!(
+        s.jsonl_path.is_some(),
+        "should find JSONL for standard cwd (no trailing slash)"
+    );
+}
+
+#[test]
+fn resolve_jsonl_trailing_slash_cwd() {
+    let (s, _home) = resolve_with_layout(
+        "/Users/testuser/Repos/data-platform-answers/",
+        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "-Users-testuser-Repos-data-platform-answers",
+    );
+    assert!(
+        s.jsonl_path.is_some(),
+        "should find JSONL even when cwd has trailing slash"
+    );
+}
+
+#[test]
+fn resolve_jsonl_cwd_with_hyphens() {
+    let (s, _home) = resolve_with_layout(
+        "/Users/dev/my-cool-project",
+        "11111111-2222-3333-4444-555555555555",
+        "-Users-dev-my-cool-project",
+    );
+    assert!(
+        s.jsonl_path.is_some(),
+        "should find JSONL when cwd contains hyphens"
+    );
+}
+
+#[test]
+fn resolve_jsonl_encoding_mismatch_fallback() {
+    let _guard = HOME_LOCK.lock().unwrap();
+
+    let home = tempfile::tempdir().unwrap();
+    let original_home = std::env::var("HOME").ok();
+    unsafe { std::env::set_var("HOME", home.path()) };
+
+    let session_id = "deadbeef-1234-5678-9abc-def012345678";
+    let cwd = "/Users/testuser/projects/webapp";
+
+    // JSONL under a slug that does NOT match cwd_to_slug(cwd)
+    let wrong_slug = "-some-other-encoding-of-the-cwd";
+    let project_dir = home.path().join(".claude/projects").join(wrong_slug);
+    std::fs::create_dir_all(&project_dir).unwrap();
+    std::fs::write(
+        project_dir.join(format!("{session_id}.jsonl")),
+        r#"{"type":"assistant","message":{"model":"claude-opus-4-6","stop_reason":"end_turn","usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}"#,
+    ).unwrap();
+
+    let raw = RawSession {
+        pid: 99999,
+        session_id: session_id.to_string(),
+        cwd: cwd.to_string(),
+        started_at: 0,
+    };
+    let mut session = ClaudeSession::from_raw(raw);
+    discovery::resolve_jsonl_paths(std::slice::from_mut(&mut session));
+
+    if let Some(h) = original_home {
+        unsafe { std::env::set_var("HOME", h) };
+    }
+
+    assert!(
+        session.jsonl_path.is_some(),
+        "should find JSONL via fallback scan when slug encoding differs"
+    );
+}
+
+#[test]
+fn resolve_jsonl_telemetry_available_after_resolution() {
+    let (mut s, _home) = resolve_with_layout(
+        "/Users/testuser/myproject",
+        "face0000-face-face-face-faceface0000",
+        "-Users-testuser-myproject",
+    );
+    assert!(s.jsonl_path.is_some(), "precondition: jsonl_path found");
+
+    monitor::update_tokens(&mut s);
+    assert_eq!(
+        s.telemetry_status,
+        TelemetryStatus::Available,
+        "telemetry should be Available after parsing JSONL, not {:?}",
+        s.telemetry_status
+    );
+    assert!(s.usage_metrics_available);
+    assert!(s.own_output_tokens > 0, "should have parsed output tokens");
+}


### PR DESCRIPTION
## Summary

Fixes #161 — active sessions showing `"No transcript"` when JSONL files and pointer files both exist on disk.

**Root cause:** `cwd_to_slug` did a naive `cwd.replace('/', "-")` with no path normalization. A trailing `/` in the cwd (e.g., `/Users/foo/bar/`) produced slug `-Users-foo-bar-` (trailing dash), which didn't match the actual project directory `-Users-foo-bar` on disk. Beyond that, there was zero resilience to any encoding drift between claudectl and Claude Code.

**Fixes:**
- **`cwd_to_slug`**: Strip trailing slashes before slugifying
- **Fallback scan**: When slug-based lookup fails, scan all `~/.claude/projects/*/` subdirectories for a JSONL matching the session ID — handles any encoding mismatch
- **`--doctor` diagnostics**: New "Transcript Discovery" section shows each active session's cwd, computed slug, and resolved JSONL path (or the exact paths tried when resolution fails)
- **Debug logging**: Logs when the fallback scan finds a mismatched slug, and when no JSONL is found at all

**Tests added:**
- 6 unit tests for `cwd_to_slug` (basic, trailing slash, multiple trailing slashes, hyphens, root, single component)
- 5 integration tests for `resolve_jsonl_paths` (standard cwd, trailing slash, hyphens, encoding mismatch fallback, end-to-end telemetry)

## Test plan
- [x] `cargo test` — 338 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: run `claudectl --doctor` with an active Claude Code session and verify the Transcript Discovery section shows the resolved JSONL path
- [ ] Manual: run `claudectl --list` with an active session and verify CTX%, COST, TOKENS columns show real values (not `n/a`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)