### PR TITLE
fix: detect kitty terminal on Linux via native env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to claudectl are documented here.
 ### Fixed
 - Kitty terminal not detected on Linux — `detect_terminal()` now checks `KITTY_WINDOW_ID` and `TERM=xterm-kitty` env vars before falling back to `TERM_PROGRAM`. Kitty on Linux doesn't set `TERM_PROGRAM`. (#160)
 - Added native env var detection for WezTerm (`WEZTERM_EXECUTABLE`) and Ghostty (`GHOSTTY_RESOURCES_DIR`) as fallbacks when `TERM_PROGRAM` is not set.
+- "No TTY associated with this session" error when pressing Tab in kitty — the blanket TTY guard now only applies to terminals that match by TTY name (tmux, WezTerm, iTerm2, Terminal.app). Kitty, Ghostty, and Warp use PID/cwd-based IPC and don't need a TTY. (#160)
 
 ## [0.29.2] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.29.3] - 2026-04-18
+
+### Fixed
+- Kitty terminal not detected on Linux — `detect_terminal()` now checks `KITTY_WINDOW_ID` and `TERM=xterm-kitty` env vars before falling back to `TERM_PROGRAM`. Kitty on Linux doesn't set `TERM_PROGRAM`. (#160)
+- Added native env var detection for WezTerm (`WEZTERM_EXECUTABLE`) and Ghostty (`GHOSTTY_RESOURCES_DIR`) as fallbacks when `TERM_PROGRAM` is not set.
+
 ## [0.29.2] - 2026-04-18
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.29.2"
+version = "0.29.3"
 edition = "2024"
 description = "Auto-pilot for Claude Code — a local model watches every session and decides what to approve"
 license = "MIT"

--- a/src/terminals/mod.rs
+++ b/src/terminals/mod.rs
@@ -291,6 +291,12 @@ pub fn detect_terminal() -> Terminal {
         return Terminal::WindowsTerm;
     }
 
+    // Terminal-specific env vars that don't rely on TERM_PROGRAM.
+    // Some terminals (notably kitty on Linux) don't set TERM_PROGRAM at all.
+    if let Some(term) = detect_by_native_env() {
+        return term;
+    }
+
     match std::env::var("TERM_PROGRAM").as_deref() {
         Ok("ghostty") => Terminal::Ghostty,
         Ok("WarpTerminal") => Terminal::Warp,
@@ -301,6 +307,33 @@ pub fn detect_terminal() -> Terminal {
         Ok(other) => Terminal::Unknown(other.to_string()),
         Err(_) => Terminal::Unknown("unknown".to_string()),
     }
+}
+
+/// Detect terminal from native env vars that each terminal sets unconditionally,
+/// without relying on TERM_PROGRAM (which some terminals don't set on Linux).
+fn detect_by_native_env() -> Option<Terminal> {
+    // Kitty: KITTY_WINDOW_ID is set unconditionally per-window.
+    // TERM=xterm-kitty is also reliable but can be inherited by child shells.
+    if std::env::var_os("KITTY_WINDOW_ID").is_some() {
+        return Some(Terminal::Kitty);
+    }
+
+    // WezTerm: WEZTERM_EXECUTABLE is set on all platforms.
+    if std::env::var_os("WEZTERM_EXECUTABLE").is_some() {
+        return Some(Terminal::WezTerm);
+    }
+
+    // Ghostty: GHOSTTY_RESOURCES_DIR is set on all platforms.
+    if std::env::var_os("GHOSTTY_RESOURCES_DIR").is_some() {
+        return Some(Terminal::Ghostty);
+    }
+
+    // TERM=xterm-kitty as last resort (weaker signal — can be inherited through ssh/tmux)
+    if std::env::var("TERM").as_deref() == Ok("xterm-kitty") {
+        return Some(Terminal::Kitty);
+    }
+
+    None
 }
 
 fn ancestor_process_contains(needle: &str) -> bool {
@@ -1127,5 +1160,96 @@ mod tests {
     fn wsl_interop_check_reports_when_available() {
         let check = wsl_interop_check(true).unwrap();
         assert_eq!(check.name, "Windows Terminal interop");
+    }
+
+    // Native env var detection tests.
+    // These mutate env vars and must be serialized.
+    use std::sync::Mutex;
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Helper: clear all terminal-related env vars, run f(), then restore.
+    fn with_clean_env<F: FnOnce() -> R, R>(f: F) -> R {
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        let keys = [
+            "KITTY_WINDOW_ID",
+            "KITTY_PID",
+            "WEZTERM_EXECUTABLE",
+            "GHOSTTY_RESOURCES_DIR",
+            "TERM",
+            "TERM_PROGRAM",
+            "TMUX",
+            "GNOME_TERMINAL_SERVICE",
+            "GNOME_TERMINAL_SCREEN",
+            "WT_SESSION",
+        ];
+        let saved: Vec<(&str, Option<String>)> =
+            keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
+
+        for key in &keys {
+            unsafe { std::env::remove_var(key) };
+        }
+
+        let result = f();
+
+        for (key, val) in saved {
+            match val {
+                Some(v) => unsafe { std::env::set_var(key, v) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
+
+        result
+    }
+
+    #[test]
+    fn detect_kitty_via_kitty_window_id() {
+        with_clean_env(|| {
+            unsafe { std::env::set_var("KITTY_WINDOW_ID", "49") };
+            assert_eq!(detect_by_native_env(), Some(Terminal::Kitty));
+        });
+    }
+
+    #[test]
+    fn detect_kitty_via_term_xterm_kitty() {
+        with_clean_env(|| {
+            unsafe { std::env::set_var("TERM", "xterm-kitty") };
+            assert_eq!(detect_by_native_env(), Some(Terminal::Kitty));
+        });
+    }
+
+    #[test]
+    fn detect_wezterm_via_wezterm_executable() {
+        with_clean_env(|| {
+            unsafe { std::env::set_var("WEZTERM_EXECUTABLE", "/usr/bin/wezterm") };
+            assert_eq!(detect_by_native_env(), Some(Terminal::WezTerm));
+        });
+    }
+
+    #[test]
+    fn detect_ghostty_via_ghostty_resources_dir() {
+        with_clean_env(|| {
+            unsafe { std::env::set_var("GHOSTTY_RESOURCES_DIR", "/usr/share/ghostty") };
+            assert_eq!(detect_by_native_env(), Some(Terminal::Ghostty));
+        });
+    }
+
+    #[test]
+    fn detect_native_env_returns_none_when_clean() {
+        with_clean_env(|| {
+            assert_eq!(detect_by_native_env(), None);
+        });
+    }
+
+    #[test]
+    fn kitty_window_id_takes_priority_over_term_xterm_kitty() {
+        // Both set — KITTY_WINDOW_ID should match first (stronger signal)
+        with_clean_env(|| {
+            unsafe {
+                std::env::set_var("KITTY_WINDOW_ID", "1");
+                std::env::set_var("TERM", "xterm-kitty");
+            }
+            assert_eq!(detect_by_native_env(), Some(Terminal::Kitty));
+        });
     }
 }

--- a/src/terminals/mod.rs
+++ b/src/terminals/mod.rs
@@ -992,11 +992,17 @@ pub fn launch_session(
 }
 
 pub fn switch_to_terminal(session: &ClaudeSession) -> Result<(), String> {
-    if session.tty.is_empty() {
+    let terminal = detect_terminal();
+
+    // Only require a TTY for terminals that match sessions by TTY name.
+    // Kitty, Ghostty, and Warp use their own IPC (PID/cwd matching) and don't need it.
+    let needs_tty = matches!(
+        terminal,
+        Terminal::Tmux | Terminal::WezTerm | Terminal::Apple | Terminal::ITerm2
+    );
+    if needs_tty && session.tty.is_empty() {
         return Err("No TTY associated with this session".into());
     }
-
-    let terminal = detect_terminal();
     crate::logger::log(
         "DEBUG",
         &format!(


### PR DESCRIPTION
## Summary

Fixes #160 — two issues with kitty on Linux:

### 1. Terminal not detected (`Detected terminal: unknown`)

**Root cause:** `detect_terminal()` only recognized kitty via `TERM_PROGRAM=kitty`, but kitty on Linux doesn't set `TERM_PROGRAM`. It sets `KITTY_WINDOW_ID`, `KITTY_PID`, and `TERM=xterm-kitty` instead.

**Fix:** Added `detect_by_native_env()` that checks terminal-specific env vars **before** falling back to `TERM_PROGRAM`:

| Terminal | Env var checked | Notes |
|----------|----------------|-------|
| Kitty | `KITTY_WINDOW_ID` | Set unconditionally per-window |
| Kitty | `TERM=xterm-kitty` | Weaker fallback (can be inherited) |
| WezTerm | `WEZTERM_EXECUTABLE` | Set on all platforms |
| Ghostty | `GHOSTTY_RESOURCES_DIR` | Set on all platforms |

### 2. "No TTY associated with this session" on Tab ([comment](https://github.com/mercurialsolo/claudectl/issues/160#issuecomment-4268050510))

**Root cause:** `switch_to_terminal()` had a blanket `session.tty.is_empty()` guard for ALL terminals, but kitty uses PID-based IPC (`kitty @ focus-window --match pid:N`) and never reads TTY. On Linux, `ps -o tty=` reports `?` for GUI-launched processes.

**Fix:** TTY guard now only applies to terminals that actually match by TTY name (tmux, WezTerm, iTerm2, Terminal.app). Kitty, Ghostty, and Warp skip it.

## Test plan
- [x] `cargo test` — 344 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: on Linux with kitty, run `claudectl --doctor` → verify `Detected terminal: Kitty`
- [ ] Manual: press Tab on a session → verify it focuses the kitty tab (no TTY error)
- [ ] Manual: press y/i on a NeedsInput session → verify approve/input work

🤖 Generated with [Claude Code](https://claude.com/claude-code)