### PR TITLE
ci: auto-comment on issues when fix is released

### DIFF
--- a/.github/workflows/issue-release-notify.yml
+++ b/.github/workflows/issue-release-notify.yml
@@ -1,0 +1,59 @@
+name: Notify fixed issues
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  issues: write
+
+jobs:
+  notify:
+    name: Comment on fixed issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find and notify fixed issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          RELEASE_URL="${{ github.event.release.html_url }}"
+
+          # Find the previous tag
+          PREV_TAG=$(git tag --sort=-creatordate | grep -A1 "^${TAG}$" | tail -1)
+          if [ "$PREV_TAG" = "$TAG" ] || [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found, checking all commits"
+            PREV_TAG=$(git rev-list --max-parents=0 HEAD | head -1)
+          fi
+
+          echo "Scanning commits between $PREV_TAG and $TAG"
+
+          # Extract issue numbers from commit messages (Closes #N, Fixes #N, etc.)
+          ISSUES=$(git log "$PREV_TAG".."$TAG" --format="%s %b" \
+            | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+' \
+            | grep -oE '#[0-9]+' \
+            | sort -u \
+            | tr -d '#')
+
+          if [ -z "$ISSUES" ]; then
+            echo "No issues referenced in commits"
+            exit 0
+          fi
+
+          for ISSUE in $ISSUES; do
+            echo "Commenting on issue #$ISSUE"
+            gh issue comment "$ISSUE" --body "$(cat <<BODY
+          Fixed in [v${VERSION}](${RELEASE_URL}) — now available via:
+
+          \`\`\`
+          brew upgrade claudectl    # Homebrew
+          cargo install claudectl   # crates.io
+          \`\`\`
+          BODY
+            )"
+          done


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically comments on issues when the fix ships in a release.

**Trigger:** `release: published` (runs after the release workflow creates the GitHub Release)

**What it does:**
1. Finds the previous git tag
2. Scans all commit messages between previous and current tag for `Closes #N` / `Fixes #N` references
3. Comments on each referenced issue with the version number and install commands

**Example comment posted on an issue:**
> Fixed in [v0.29.3](https://github.com/...) — now available via:
> ```
> brew upgrade claudectl    # Homebrew
> cargo install claudectl   # crates.io
> ```

This replaces the manual step of going back and commenting on issues after each release.

## Test plan
- [x] YAML validates with `yaml.safe_load`
- [ ] Merge, tag a release, verify comment appears on a closed issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)