### PR TITLE
feat: cognitive rot detection and monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.30.0] - 2026-04-18
+
+### Added
+- **Cognitive rot detection** — temporal health monitoring that detects session degradation over time, not just point-in-time snapshots (#165)
+  - Composite decay score (0-100) combining context saturation, error acceleration, token efficiency decline, and file re-read repetition
+  - `check_proactive_compaction` — suggests `/compact` at 50% context usage (research shows degradation begins at 40-50%), independent of existing 80/90% context thresholds
+  - `check_token_efficiency` — detects when a session spends increasingly more tokens per file edit vs its frozen baseline
+  - `check_error_acceleration` — detects rising error rates over sliding windows vs a frozen baseline
+  - `check_repetition` — detects files being re-read repeatedly without intervening edits (agent confusion signal)
+  - `check_cognitive_decay` — composite check with severity-ranked icons: `◐` early (30-59), `◉` significant (60-79), `⊘` severe (80-100)
+- **Cognitive Health section** in the detail panel showing decay score, efficiency vs baseline, error trend, repetition count, and context-aware mitigation suggestions
+- `decay_score` field in `--json` output for programmatic access
+- Brain context now includes decay score so the LLM factors cognitive health into its decisions
+- Four new configurable thresholds in `[health]`: `decay_compaction_pct`, `efficiency_critical_factor`, `error_accel_factor`, `repetition_threshold`
+- Demo mode showcases cognitive decay indicators on the ml-pipeline session
+
 ## [0.29.3] - 2026-04-18
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.29.3"
+version = "0.30.0"
 edition = "2024"
 description = "Auto-pilot for Claude Code — a local model watches every session and decides what to approve"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ claudectl --decompose "Add auth and update tests and docs"  # Split into paralle
 | Capability | Claude Code alone | With claudectl |
 |-----------|:-:|:-:|
 | Local LLM auto-approve/deny | No | **Brain with ollama** |
-| Session health monitoring | No | **Cache, cost spikes, loops, stalls, context** |
+| Session health monitoring | No | **Cognitive rot, cache, cost spikes, loops, stalls, context** |
 | Record session highlight reels | No | **Press `R`** |
 | Orchestrate multi-session workflows | No | **Dependency-ordered tasks** |
 | Launch/resume sessions | Separate terminal | **Press `n` or `--new`** |
@@ -245,11 +245,15 @@ The decomposition prompt template is user-overridable via `~/.claudectl/brain/pr
 
 claudectl continuously checks each session for problems and surfaces them with severity-ranked icons in the dashboard:
 
+- **Cognitive rot detection** — composite 0-100 decay score that tracks degradation over time: token efficiency decline, error acceleration, file re-read repetition, and context pressure. Icons: `◐` early, `◉` significant, `⊘` severe
+- **Proactive compaction** — suggests `/compact` at 50% context (research shows degradation starts at 40-50%), before the existing 80/90% thresholds fire
 - **Cache health** — detects low cache hit ratios that can silently multiply costs
 - **Cost spikes** — flags when burn rate exceeds the session average
 - **Loop detection** — catches tools failing repeatedly in retry loops
 - **Stall detection** — sessions spending money but producing no file edits
 - **Context saturation** — warns when a session approaches its context window limit
+
+The detail panel shows a **Cognitive Health** section with decay score, efficiency vs baseline, error trend, repetition count, and actionable mitigation suggestions.
 
 Health issues appear as icons in the session table and as a summary in the status bar. No configuration needed.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -591,9 +591,11 @@ impl App {
             }
         }
 
-        // Record activity for sparkline
+        // Record activity for sparkline and cache decay score
         for session in &mut sessions {
             session.record_activity();
+            session.decay_score =
+                crate::health::compute_decay_score(session, &self.health_thresholds);
         }
 
         // Track when sessions first appear as Finished, remove after 30s

--- a/src/brain/context.rs
+++ b/src/brain/context.rs
@@ -82,6 +82,10 @@ fn format_session_summary(session: &ClaudeSession) -> String {
         }
     }
 
+    if session.decay_score > 0 {
+        summary.push_str(&format!(" | Decay: {}/100", session.decay_score));
+    }
+
     if session.last_tool_error {
         if let Some(ref msg) = session.last_error_message {
             let truncated = session::truncate_str(msg, 100);

--- a/src/brain/decisions.rs
+++ b/src/brain/decisions.rs
@@ -2340,6 +2340,16 @@ mod tests {
                 tool_name: "Bash".into(),
                 message: "exit code 1".into(),
             }],
+            total_tokens_at_edit_count: 0,
+            edit_event_count: 0,
+            baseline_tokens_per_edit: None,
+            error_counts_per_window: vec![],
+            current_window_errors: 0,
+            window_tick_counter: 0,
+            baseline_error_rate: None,
+            file_reads_since_edit: HashMap::new(),
+            total_error_count: 0,
+            decay_score: 0,
         };
 
         let ctx = snapshot_context(&session);

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,10 @@ pub struct HealthThresholds {
     pub stall_min_minutes: u64,  // Min minutes with no edits to trigger stall (default 10)
     pub context_critical_pct: f64, // Context usage above this = critical (default 90%)
     pub context_warning_pct: f64, // Context usage above this = warning (default 80%)
+    pub decay_compaction_pct: f64, // Context % to suggest proactive compaction (default 50%)
+    pub efficiency_critical_factor: f64, // Tokens-per-edit ratio vs baseline to trigger (default 2.0)
+    pub error_accel_factor: f64,         // Error rate ratio vs baseline to trigger (default 2.0)
+    pub repetition_threshold: u32,       // File re-read count without edit to trigger (default 3)
 }
 
 impl Default for HealthThresholds {
@@ -61,6 +65,10 @@ impl Default for HealthThresholds {
             stall_min_minutes: 10,
             context_critical_pct: 90.0,
             context_warning_pct: 80.0,
+            decay_compaction_pct: 50.0,
+            efficiency_critical_factor: 2.0,
+            error_accel_factor: 2.0,
+            repetition_threshold: 3,
         }
     }
 }
@@ -78,6 +86,10 @@ struct RawHealthThresholds {
     stall_min_minutes: Option<u64>,
     context_critical_pct: Option<f64>,
     context_warning_pct: Option<f64>,
+    decay_compaction_pct: Option<f64>,
+    efficiency_critical_factor: Option<f64>,
+    error_accel_factor: Option<f64>,
+    repetition_threshold: Option<u32>,
 }
 
 /// Configuration for the optional local LLM brain.
@@ -320,6 +332,18 @@ impl Config {
             if let Some(v) = h.context_warning_pct {
                 self.health.context_warning_pct = v;
             }
+            if let Some(v) = h.decay_compaction_pct {
+                self.health.decay_compaction_pct = v;
+            }
+            if let Some(v) = h.efficiency_critical_factor {
+                self.health.efficiency_critical_factor = v;
+            }
+            if let Some(v) = h.error_accel_factor {
+                self.health.error_accel_factor = v;
+            }
+            if let Some(v) = h.repetition_threshold {
+                self.health.repetition_threshold = v;
+            }
         }
         if let Some(v) = raw.file_conflicts {
             self.file_conflicts = v;
@@ -463,6 +487,13 @@ impl Config {
             "  context:  critical >{:.0}%, warning >{:.0}%",
             self.health.context_critical_pct, self.health.context_warning_pct,
         );
+        println!(
+            "  decay:    compact >{:.0}%, efficiency >{:.1}x, errors >{:.1}x, repeats >{}",
+            self.health.decay_compaction_pct,
+            self.health.efficiency_critical_factor,
+            self.health.error_accel_factor,
+            self.health.repetition_threshold,
+        );
         if self.model_overrides.is_empty() {
             println!("  model_overrides: none");
         } else {
@@ -569,6 +600,12 @@ impl Config {
 # Context saturation thresholds (percentage, 0-100)
 # context_critical_pct = 90.0
 # context_warning_pct = 80.0
+
+# Cognitive decay detection
+# decay_compaction_pct = 50.0         # Context % to suggest proactive /compact
+# efficiency_critical_factor = 2.0    # Tokens-per-edit ratio vs baseline to trigger
+# error_accel_factor = 2.0            # Error rate ratio vs baseline to trigger
+# repetition_threshold = 3            # File re-reads without edit to trigger
 
 # ── Model Pricing Overrides ─────────────────────────────────────────
 # Override built-in pricing for specific models.
@@ -737,6 +774,12 @@ fn parse_config_file(path: &PathBuf) -> Option<RawConfig> {
                     "stall_min_minutes" => h.stall_min_minutes = value.parse().ok(),
                     "context_critical_pct" => h.context_critical_pct = value.parse().ok(),
                     "context_warning_pct" => h.context_warning_pct = value.parse().ok(),
+                    "decay_compaction_pct" => h.decay_compaction_pct = value.parse().ok(),
+                    "efficiency_critical_factor" => {
+                        h.efficiency_critical_factor = value.parse().ok()
+                    }
+                    "error_accel_factor" => h.error_accel_factor = value.parse().ok(),
+                    "repetition_threshold" => h.repetition_threshold = value.parse().ok(),
                     _ => {}
                 }
             }

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -284,6 +284,16 @@ pub fn generate_sessions(tick: u32) -> Vec<ClaudeSession> {
                 s.burn_rate_per_hr = avg_rate * 6.0;
             }
 
+            // Session 3 (ml-pipeline): Cognitive decay — high context + declining efficiency
+            if i == 3 && tick > 8 {
+                s.baseline_tokens_per_edit = Some(5000.0);
+                s.edit_event_count = 12;
+                s.total_tokens_at_edit_count = 12 * 12_000; // ~12k per edit vs 5k baseline
+                s.error_counts_per_window = vec![0, 1, 1, 2, 3, 4];
+                s.baseline_error_rate = Some(0.7); // average of first 3 windows
+                s.file_reads_since_edit.insert("src/pipeline.rs".into(), 4);
+            }
+
             // Session 4 (ml-pipeline worktree): Loop detection → 🔄
             if i == 4 && tick > 5 {
                 s.last_tool_error = true;

--- a/src/health.rs
+++ b/src/health.rs
@@ -37,6 +37,21 @@ pub fn check_session(session: &ClaudeSession, t: &HealthThresholds) -> Vec<Healt
     if let Some(c) = check_context_saturation(session, t) {
         checks.push(c);
     }
+    if let Some(c) = check_cognitive_decay(session, t) {
+        checks.push(c);
+    }
+    if let Some(c) = check_proactive_compaction(session, t) {
+        checks.push(c);
+    }
+    if let Some(c) = check_token_efficiency(session, t) {
+        checks.push(c);
+    }
+    if let Some(c) = check_error_acceleration(session, t) {
+        checks.push(c);
+    }
+    if let Some(c) = check_repetition(session, t) {
+        checks.push(c);
+    }
 
     // Sort: Critical first, then Warning, then Info
     checks.sort_by_key(|c| match c.severity {
@@ -269,6 +284,213 @@ fn check_context_saturation(session: &ClaudeSession, t: &HealthThresholds) -> Op
     }
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// Cognitive decay checks
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Compute a composite cognitive decay score (0-100) from multiple signals.
+pub fn compute_decay_score(session: &ClaudeSession, _t: &HealthThresholds) -> u32 {
+    let mut score: f64 = 0.0;
+
+    // Context contribution: 0-40 points (linear from 40% to 100%)
+    let ctx_pct = session.context_percent();
+    if ctx_pct > 40.0 {
+        score += ((ctx_pct - 40.0) / 60.0) * 40.0;
+    }
+
+    // Error acceleration contribution: 0-25 points
+    if let Some(baseline) = session.baseline_error_rate {
+        if baseline > 0.0 && session.error_counts_per_window.len() >= 2 {
+            let recent_count = session.error_counts_per_window.len().min(3);
+            let recent: f64 = session
+                .error_counts_per_window
+                .iter()
+                .rev()
+                .take(recent_count)
+                .sum::<u32>() as f64
+                / recent_count as f64;
+            let ratio = recent / baseline;
+            score += (ratio - 1.0).clamp(0.0, 1.0) * 25.0;
+        }
+    }
+
+    // Token efficiency contribution: 0-20 points
+    if let Some(baseline) = session.baseline_tokens_per_edit {
+        if baseline > 0.0 && session.edit_event_count > 5 {
+            let current =
+                session.total_tokens_at_edit_count as f64 / session.edit_event_count as f64;
+            let ratio = current / baseline;
+            score += (ratio - 1.0).clamp(0.0, 1.0) * 20.0;
+        }
+    }
+
+    // Repetition contribution: 0-15 points
+    let max_rereads = session
+        .file_reads_since_edit
+        .values()
+        .copied()
+        .max()
+        .unwrap_or(0);
+    if max_rereads >= 2 {
+        score += ((max_rereads as f64 - 1.0) / 4.0).min(1.0) * 15.0;
+    }
+
+    (score.round() as u32).min(100)
+}
+
+/// Composite cognitive decay check — wraps the decay score into a HealthCheck.
+fn check_cognitive_decay(session: &ClaudeSession, t: &HealthThresholds) -> Option<HealthCheck> {
+    let score = compute_decay_score(session, t);
+    if score >= 80 {
+        Some(HealthCheck {
+            icon: "⊘",
+            name: "severe decay",
+            severity: Severity::Critical,
+            message: format!(
+                "Decay score {}/100 — session is severely compromised. Restart with fresh context.",
+                score,
+            ),
+        })
+    } else if score >= 60 {
+        Some(HealthCheck {
+            icon: "◉",
+            name: "significant decay",
+            severity: Severity::Warning,
+            message: format!(
+                "Decay score {}/100 — consider restarting. Generate a state transfer summary first.",
+                score,
+            ),
+        })
+    } else if score >= 30 {
+        Some(HealthCheck {
+            icon: "◐",
+            name: "early decay",
+            severity: Severity::Info,
+            message: format!(
+                "Decay score {}/100 — consider /compact with preservation notes.",
+                score,
+            ),
+        })
+    } else {
+        None
+    }
+}
+
+/// Suggest proactive compaction at moderate context usage (before degradation starts).
+fn check_proactive_compaction(
+    session: &ClaudeSession,
+    t: &HealthThresholds,
+) -> Option<HealthCheck> {
+    if session.context_max == 0 {
+        return None;
+    }
+
+    let pct = session.context_percent();
+    if pct > t.decay_compaction_pct && pct <= t.context_warning_pct {
+        Some(HealthCheck {
+            icon: "📋",
+            name: "consider compact",
+            severity: Severity::Info,
+            message: format!(
+                "Context at {:.0}% — research shows degradation begins here. Consider /compact.",
+                pct,
+            ),
+        })
+    } else {
+        None
+    }
+}
+
+/// Detect token efficiency degradation — spending more tokens per file edit over time.
+fn check_token_efficiency(session: &ClaudeSession, t: &HealthThresholds) -> Option<HealthCheck> {
+    let baseline = session.baseline_tokens_per_edit?;
+    if baseline < 100.0 || session.edit_event_count < 8 {
+        return None;
+    }
+
+    let current = session.total_tokens_at_edit_count as f64 / session.edit_event_count as f64;
+    let ratio = current / baseline;
+
+    if ratio > t.efficiency_critical_factor {
+        Some(HealthCheck {
+            icon: "📉",
+            name: "low efficiency",
+            severity: Severity::Warning,
+            message: format!(
+                "Tokens per edit is {:.1}x baseline — agent is working harder for less output.",
+                ratio,
+            ),
+        })
+    } else {
+        None
+    }
+}
+
+/// Detect error rate acceleration — errors are increasing over time.
+fn check_error_acceleration(session: &ClaudeSession, t: &HealthThresholds) -> Option<HealthCheck> {
+    let baseline = session.baseline_error_rate?;
+    if baseline <= 0.0 || session.error_counts_per_window.len() < 4 {
+        return None;
+    }
+
+    let recent_count = session.error_counts_per_window.len().min(3);
+    let recent: f64 = session
+        .error_counts_per_window
+        .iter()
+        .rev()
+        .take(recent_count)
+        .sum::<u32>() as f64
+        / recent_count as f64;
+    let ratio = recent / baseline;
+
+    if ratio > t.error_accel_factor {
+        Some(HealthCheck {
+            icon: "⚠",
+            name: "error acceleration",
+            severity: Severity::Warning,
+            message: format!(
+                "Error rate is {:.1}x baseline — agent may be stuck or confused.",
+                ratio,
+            ),
+        })
+    } else {
+        None
+    }
+}
+
+/// Detect file re-reads without intervening edits — possible confusion or looping.
+fn check_repetition(session: &ClaudeSession, t: &HealthThresholds) -> Option<HealthCheck> {
+    let max_rereads = session
+        .file_reads_since_edit
+        .values()
+        .copied()
+        .max()
+        .unwrap_or(0);
+
+    if max_rereads >= t.repetition_threshold {
+        let file = session
+            .file_reads_since_edit
+            .iter()
+            .max_by_key(|(_, v)| *v)
+            .map(|(k, _)| {
+                // Show just filename
+                k.rsplit('/').next().unwrap_or(k)
+            })
+            .unwrap_or("?");
+        Some(HealthCheck {
+            icon: "🔁",
+            name: "repetition",
+            severity: Severity::Warning,
+            message: format!(
+                "{} read {} times without editing — agent may be looping.",
+                file, max_rereads,
+            ),
+        })
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -447,5 +669,140 @@ mod tests {
                 .iter()
                 .any(|c| c.name == "context full" && c.severity == Severity::Critical)
         );
+    }
+
+    // ── Cognitive decay tests ────────────────────────────────────────
+
+    #[test]
+    fn proactive_compaction_fires_at_50pct() {
+        let mut s = make_session();
+        s.context_tokens = 110_000;
+        s.context_max = 200_000; // 55%
+        s.usage_metrics_available = true;
+        let check = check_proactive_compaction(&s, &defaults());
+        assert!(check.is_some());
+        let c = check.unwrap();
+        assert_eq!(c.name, "consider compact");
+        assert_eq!(c.severity, Severity::Info);
+    }
+
+    #[test]
+    fn proactive_compaction_silent_below_threshold() {
+        let mut s = make_session();
+        s.context_tokens = 70_000;
+        s.context_max = 200_000; // 35%
+        assert!(check_proactive_compaction(&s, &defaults()).is_none());
+    }
+
+    #[test]
+    fn token_efficiency_detects_degradation() {
+        let mut s = make_session();
+        s.baseline_tokens_per_edit = Some(1000.0);
+        s.edit_event_count = 10;
+        s.total_tokens_at_edit_count = 25_000; // 2500 per edit = 2.5x baseline
+        let check = check_token_efficiency(&s, &defaults());
+        assert!(check.is_some());
+        let c = check.unwrap();
+        assert_eq!(c.name, "low efficiency");
+        assert_eq!(c.severity, Severity::Warning);
+    }
+
+    #[test]
+    fn token_efficiency_silent_when_healthy() {
+        let mut s = make_session();
+        s.baseline_tokens_per_edit = Some(1000.0);
+        s.edit_event_count = 10;
+        s.total_tokens_at_edit_count = 12_000; // 1200 per edit = 1.2x baseline
+        assert!(check_token_efficiency(&s, &defaults()).is_none());
+    }
+
+    #[test]
+    fn error_acceleration_detects_increase() {
+        let mut s = make_session();
+        s.baseline_error_rate = Some(1.0);
+        s.error_counts_per_window = vec![1, 1, 1, 2, 3, 4]; // rising
+        let check = check_error_acceleration(&s, &defaults());
+        assert!(check.is_some());
+        let c = check.unwrap();
+        assert_eq!(c.name, "error acceleration");
+        assert_eq!(c.severity, Severity::Warning);
+    }
+
+    #[test]
+    fn error_acceleration_silent_when_stable() {
+        let mut s = make_session();
+        s.baseline_error_rate = Some(1.0);
+        s.error_counts_per_window = vec![1, 1, 1, 1]; // stable
+        assert!(check_error_acceleration(&s, &defaults()).is_none());
+    }
+
+    #[test]
+    fn repetition_detects_rereads() {
+        let mut s = make_session();
+        s.file_reads_since_edit
+            .insert("/tmp/test/src/main.rs".into(), 4);
+        let check = check_repetition(&s, &defaults());
+        assert!(check.is_some());
+        let c = check.unwrap();
+        assert_eq!(c.name, "repetition");
+        assert_eq!(c.severity, Severity::Warning);
+        assert!(c.message.contains("main.rs"));
+    }
+
+    #[test]
+    fn repetition_silent_below_threshold() {
+        let mut s = make_session();
+        s.file_reads_since_edit.insert("/tmp/test/foo.rs".into(), 2);
+        assert!(check_repetition(&s, &defaults()).is_none());
+    }
+
+    #[test]
+    fn decay_score_zero_for_fresh_session() {
+        let s = make_session();
+        assert_eq!(compute_decay_score(&s, &defaults()), 0);
+    }
+
+    #[test]
+    fn decay_score_context_only_contribution() {
+        let mut s = make_session();
+        s.context_tokens = 140_000;
+        s.context_max = 200_000; // 70%
+        s.usage_metrics_available = true;
+        let score = compute_decay_score(&s, &defaults());
+        // 70% context: (70-40)/60 * 40 = 20 points
+        assert_eq!(score, 20);
+    }
+
+    #[test]
+    fn decay_score_high_for_saturated_session() {
+        let mut s = make_session();
+        s.context_tokens = 180_000;
+        s.context_max = 200_000; // 90% → 33 context points
+        s.usage_metrics_available = true;
+        s.baseline_error_rate = Some(1.0);
+        s.error_counts_per_window = vec![1, 1, 1, 3, 4, 5]; // accelerating
+        s.file_reads_since_edit
+            .insert("/tmp/test/main.rs".into(), 5); // repetition
+        let score = compute_decay_score(&s, &defaults());
+        assert!(score >= 60, "expected >= 60, got {score}");
+    }
+
+    #[test]
+    fn cognitive_decay_check_critical_at_80() {
+        let mut s = make_session();
+        s.context_tokens = 200_000;
+        s.context_max = 200_000; // 100% → 40 context points
+        s.usage_metrics_available = true;
+        s.baseline_tokens_per_edit = Some(1000.0);
+        s.edit_event_count = 10;
+        s.total_tokens_at_edit_count = 20_000; // 2x baseline → 20 efficiency points
+        s.baseline_error_rate = Some(1.0);
+        s.error_counts_per_window = vec![1, 1, 1, 3, 4, 5]; // → 25 error points
+        let check = check_cognitive_decay(&s, &defaults());
+        assert!(check.is_some());
+        let c = check.unwrap();
+        assert_eq!(c.name, "severe decay");
+        assert_eq!(c.severity, Severity::Critical);
+        assert!(c.icon == "⊘");
     }
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -181,6 +181,8 @@ pub fn update_tokens(session: &mut ClaudeSession) {
                                         } => {
                                             session.last_tool_error = *is_error;
                                             if *is_error {
+                                                session.total_error_count += 1;
+                                                session.current_window_errors += 1;
                                                 let truncated = if content.len() > 256 {
                                                     format!(
                                                         "{}...",
@@ -423,6 +425,27 @@ fn record_tool_usage(tool_name: &str, input: &Value, session: &mut ClaudeSession
     if matches!(tool_name, "Edit" | "Write" | "NotebookEdit") {
         if let Some(path) = input.get("file_path").and_then(|p| p.as_str()) {
             *session.files_modified.entry(path.to_string()).or_insert(0) += 1;
+            // Reset file-read tracker for this path (it was just edited)
+            session.file_reads_since_edit.remove(path);
+        }
+        // Track token efficiency: cumulative tokens at each edit event
+        let total_tokens = session.total_input_tokens + session.total_output_tokens;
+        session.total_tokens_at_edit_count += total_tokens;
+        session.edit_event_count += 1;
+        // Freeze baseline tokens-per-edit after first 5 edits
+        if session.baseline_tokens_per_edit.is_none() && session.edit_event_count >= 5 {
+            session.baseline_tokens_per_edit =
+                Some(session.total_tokens_at_edit_count as f64 / session.edit_event_count as f64);
+        }
+    }
+
+    // Track file reads for repetition detection
+    if matches!(tool_name, "Read" | "Grep" | "Glob") {
+        if let Some(path) = input.get("file_path").and_then(|p| p.as_str()) {
+            *session
+                .file_reads_since_edit
+                .entry(path.to_string())
+                .or_insert(0) += 1;
         }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -147,6 +147,27 @@ pub struct ClaudeSession {
     pub last_tool_error: bool,
     pub last_error_message: Option<String>,
     pub recent_errors: Vec<ErrorEntry>, // Last 5 errors (ring buffer)
+    // ── Cognitive health tracking ────────────────────────────────────
+    /// Cumulative tokens at each Edit/Write event (for efficiency trending).
+    pub total_tokens_at_edit_count: u64,
+    /// Number of Edit/Write events (for averaging tokens-per-edit).
+    pub edit_event_count: u32,
+    /// Baseline tokens-per-edit, frozen after first 5 edits.
+    pub baseline_tokens_per_edit: Option<f64>,
+    /// Error count ring buffer: one entry per window (~10s each).
+    pub error_counts_per_window: Vec<u32>, // max 10 entries
+    /// Accumulator for current error window.
+    pub current_window_errors: u32,
+    /// Ticks since last window flush.
+    pub window_tick_counter: u32,
+    /// Baseline error rate (errors per window), frozen after 3 windows.
+    pub baseline_error_rate: Option<f64>,
+    /// File reads since last edit: path -> read count. Reset when file is edited.
+    pub file_reads_since_edit: HashMap<String, u32>,
+    /// All-time error count.
+    pub total_error_count: u32,
+    /// Cached composite decay score (0-100), recomputed each tick.
+    pub decay_score: u32,
 }
 
 /// A captured tool error with context.
@@ -326,6 +347,16 @@ impl ClaudeSession {
             last_tool_error: false,
             last_error_message: None,
             recent_errors: Vec::new(),
+            total_tokens_at_edit_count: 0,
+            edit_event_count: 0,
+            baseline_tokens_per_edit: None,
+            error_counts_per_window: Vec::new(),
+            current_window_errors: 0,
+            window_tick_counter: 0,
+            baseline_error_rate: None,
+            file_reads_since_edit: HashMap::new(),
+            total_error_count: 0,
+            decay_score: 0,
         }
     }
 
@@ -343,6 +374,24 @@ impl ClaudeSession {
         self.activity_history.push(level);
         if self.activity_history.len() > 15 {
             self.activity_history.remove(0);
+        }
+
+        // Flush error window every 5 ticks (~10s at default 2s interval)
+        self.window_tick_counter += 1;
+        if self.window_tick_counter >= 5 {
+            self.error_counts_per_window
+                .push(self.current_window_errors);
+            if self.error_counts_per_window.len() > 10 {
+                self.error_counts_per_window.remove(0);
+            }
+            // Freeze baseline error rate after 3 windows
+            if self.baseline_error_rate.is_none() && self.error_counts_per_window.len() >= 3 {
+                let sum: u32 = self.error_counts_per_window.iter().sum();
+                self.baseline_error_rate =
+                    Some(sum as f64 / self.error_counts_per_window.len() as f64);
+            }
+            self.current_window_errors = 0;
+            self.window_tick_counter = 0;
         }
     }
 
@@ -623,6 +672,7 @@ impl ClaudeSession {
                     },
                 })
             }).collect::<Vec<_>>(),
+            "decay_score": if self.usage_metrics_available { serde_json::json!(self.decay_score) } else { serde_json::Value::Null },
             "last_error": self.last_error_message,
             "recent_errors": self.recent_errors.iter().map(|e| {
                 serde_json::json!({
@@ -798,5 +848,44 @@ mod tests {
         assert_eq!(rows[0].display_label(), "completed (2)");
         assert_eq!(rows[0].count, 2);
         assert_eq!(rows[0].format_tokens(), "20.0k/2.0k");
+    }
+
+    // ── Cognitive health tracking tests ──────────────────────────────
+
+    #[test]
+    fn error_window_flush() {
+        let mut s = make_session();
+        s.current_window_errors = 3;
+        // Call record_activity 5 times to trigger one window flush
+        for _ in 0..5 {
+            s.record_activity();
+        }
+        assert_eq!(s.error_counts_per_window.len(), 1);
+        assert_eq!(s.error_counts_per_window[0], 3);
+        assert_eq!(s.current_window_errors, 0);
+        assert_eq!(s.window_tick_counter, 0);
+    }
+
+    #[test]
+    fn baseline_error_rate_freezes() {
+        let mut s = make_session();
+        // Simulate 3 windows of errors
+        for errors in [2, 3, 4] {
+            s.current_window_errors = errors;
+            for _ in 0..5 {
+                s.record_activity();
+            }
+        }
+        assert_eq!(s.error_counts_per_window.len(), 3);
+        let baseline = s.baseline_error_rate.expect("baseline should be set");
+        // baseline = (2+3+4)/3 = 3.0
+        assert!((baseline - 3.0).abs() < 0.01);
+
+        // Add another window — baseline should NOT change
+        s.current_window_errors = 10;
+        for _ in 0..5 {
+            s.record_activity();
+        }
+        assert_eq!(s.baseline_error_rate.unwrap(), baseline);
     }
 }

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -92,11 +92,86 @@ pub fn render_detail_panel(frame: &mut Frame, area: Rect, session: &ClaudeSessio
         detail_line("  Total", &cost, t),
         detail_line("  Burn Rate", &burn_rate, t),
         detail_line("  Estimate", &estimate, t),
+    ];
+
+    // Cognitive Health section
+    if session.has_usage_metrics() && session.decay_score > 0 {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            " Cognitive Health",
+            Style::default().fg(t.header).add_modifier(Modifier::BOLD),
+        )));
+
+        let decay_label = match session.decay_score {
+            0..=29 => "healthy",
+            30..=59 => "early decay",
+            60..=79 => "significant decay",
+            _ => "severe decay",
+        };
+        lines.push(detail_line(
+            "  Decay Score",
+            &format!("{}/100 {}", session.decay_score, decay_label),
+            t,
+        ));
+        lines.push(detail_line(
+            "  Context",
+            &format!("{}%", session.context_percent() as u32),
+            t,
+        ));
+
+        if let Some(baseline) = session.baseline_tokens_per_edit {
+            if session.edit_event_count > 5 && baseline > 0.0 {
+                let current =
+                    session.total_tokens_at_edit_count as f64 / session.edit_event_count as f64;
+                let pct_change = ((current / baseline) - 1.0) * 100.0;
+                let arrow = if pct_change > 5.0 { "↓" } else { "→" };
+                lines.push(detail_line(
+                    "  Efficiency",
+                    &format!("{}{:.0}% vs baseline", arrow, pct_change.abs()),
+                    t,
+                ));
+            }
+        }
+
+        if session.error_counts_per_window.len() >= 2 {
+            let recent = session.error_counts_per_window.last().unwrap_or(&0);
+            let first = session.error_counts_per_window.first().unwrap_or(&0);
+            if recent > first {
+                lines.push(detail_line("  Error trend", "↑ accelerating", t));
+            }
+        }
+
+        let max_rereads = session
+            .file_reads_since_edit
+            .values()
+            .copied()
+            .max()
+            .unwrap_or(0);
+        if max_rereads >= 2 {
+            lines.push(detail_line(
+                "  Repetition",
+                &format!("{} file re-reads detected", max_rereads),
+                t,
+            ));
+        }
+
+        if session.decay_score >= 30 {
+            let suggestion = match session.decay_score {
+                30..=49 => "Consider /compact with preservation notes",
+                50..=69 => "Compact recommended — preserve architectural decisions",
+                70..=84 => "Restart recommended — generate state transfer first",
+                _ => "Session compromised — restart with fresh context",
+            };
+            lines.push(detail_line("  Suggestion", suggestion, t));
+        }
+    }
+
+    lines.extend([
         Line::from(""),
         detail_line("Command", &command, t),
         detail_line("JSONL", &jsonl, t),
         detail_line("Subagents", &subagents, t),
-    ];
+    ]);
 
     if !subagent_breakdown.is_empty() {
         lines.push(Line::from(""));


### PR DESCRIPTION
## Summary

- Adds temporal health monitoring that detects session degradation over time — composite 0-100 decay score from context pressure, error acceleration, token efficiency decline, and file re-read repetition
- 5 new health checks: `check_cognitive_decay` (composite), `check_proactive_compaction` (at 50% context), `check_token_efficiency`, `check_error_acceleration`, `check_repetition`
- Cognitive Health section in the detail panel with decay score, efficiency trend, error trend, repetition count, and mitigation suggestions
- Brain context now includes decay score for LLM-aware decision making
- 4 new configurable thresholds in `[health]` config section
- 13 new tests covering all decay checks and score computation

Closes #165

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — 288 lib + 62 integration + 8 unit tests pass
- [x] `cargo build --release` — compiles successfully
- [ ] `cargo run -- --demo` — verify decay indicators on ml-pipeline session (session 3)
- [ ] Manual: run with a long session to observe decay score progression

🤖 Generated with [Claude Code](https://claude.com/claude-code)