### PR TITLE
feat: add star prompt after first successful run and --demo

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -252,7 +252,38 @@ struct Cli {
 
 fn main() -> io::Result<()> {
     let cli = Cli::parse();
+    let is_demo = cli.demo;
+    let result = run_main(cli);
+    if result.is_ok() {
+        maybe_print_star_prompt(is_demo);
+    }
+    result
+}
 
+fn maybe_print_star_prompt(is_demo: bool) {
+    let marker = std::env::var_os("HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+        .join(".claudectl/.star-prompted");
+
+    let first_run = !marker.exists();
+
+    if is_demo || first_run {
+        eprintln!();
+        eprintln!(
+            "\u{2b50} If claudectl is useful, star it: https://github.com/mercurialsolo/claudectl"
+        );
+
+        if first_run {
+            if let Some(parent) = marker.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let _ = std::fs::write(&marker, "");
+        }
+    }
+}
+
+fn run_main(cli: Cli) -> io::Result<()> {
     // Initialize diagnostic logger if --log is set
     if let Some(ref log_path) = cli.log {
         if let Err(e) = logger::init(log_path) {


### PR DESCRIPTION
## Summary

- After the first successful run or `--demo`, prints a one-liner to stderr:
  ```
  ⭐ If claudectl is useful, star it: https://github.com/mercurialsolo/claudectl
  ```
- Uses a marker file at `~/.claudectl/.star-prompted` — prompt only appears once
- Prints to stderr so JSON/machine-readable stdout output is unaffected
- Refactors `main()` → `main()` + `run_main()` for a single exit point

## Test plan

- [ ] `rm -f ~/.claudectl/.star-prompted && cargo run -- --list` → star prompt appears
- [ ] Run again → star prompt does NOT appear
- [ ] `cargo run -- --demo --list` → star prompt always appears
- [ ] `cargo run -- --json` → star prompt on stderr, JSON on stdout unaffected
- [ ] `cargo test` — all tests pass
- [ ] `cargo clippy -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)