### PR TITLE
feat: Claude Code plugin with brain gate, init command, and mode toggle

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,39 @@
+## What's new
+
+<!-- 1-2 sentence hook: what's the headline user-facing win? -->
+
+## Highlights
+
+<!-- 3-5 bullet points, each starting with a verb. Focus on what users can DO now, not what changed internally. -->
+
+- **Feature**: ...
+- **Improved**: ...
+- **Fixed**: ...
+
+## Demo
+
+<!-- Optional: GIF, screenshot, or asciinema link showing the highlight in action -->
+
+## Install / Upgrade
+
+```bash
+brew upgrade claudectl                    # Homebrew
+cargo install claudectl                   # Cargo
+curl -fsSL https://raw.githubusercontent.com/mercurialsolo/claudectl/main/install.sh | sh
+```
+
+## Changelog
+
+<!-- Link to full diff: https://github.com/mercurialsolo/claudectl/compare/vX.Y.Z...vA.B.C -->
+
+<details>
+<summary>Full changelog</summary>
+
+- commit description
+- commit description
+
+</details>
+
+---
+
+Questions? [Start a Discussion](https://github.com/mercurialsolo/claudectl/discussions). Found a bug? [Open an issue](https://github.com/mercurialsolo/claudectl/issues/new).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,36 @@
 # claudectl
 
-Mission control for Claude Code — supervise, budget, orchestrate, and auto-pilot sessions with a local LLM brain.
+**Auto-pilot for Claude Code — supervise, budget, orchestrate, and auto-pilot sessions with a local LLM brain.**
+
+claudectl is the missing control plane for Claude Code. If you're building tools, agents, or workflows that interact with Claude Code sessions, claudectl provides the monitoring, orchestration, and automation layer.
+
+## What claudectl does
+
+- **Local LLM supervision** — A local model (ollama/llama.cpp/vLLM) watches every Claude Code session and decides what to approve, deny, or coordinate. No cloud API, no telemetry.
+- **Multi-session orchestration** — Run parallel sessions with dependency ordering, cross-session context routing, and file conflict detection.
+- **Health monitoring** — Cognitive rot detection, loop detection, stall detection, cost spike alerts, context saturation warnings.
+- **Spend control** — Per-session budgets, daily/weekly limits, auto-kill on overspend.
+- **Learning from corrections** — The brain learns from every approve/reject decision and adapts per-tool, per-project confidence thresholds.
+
+## Integration points
+
+- **JSONL transcripts** — claudectl reads `~/.claude/sessions/*.json` and `~/.claude/projects/*/*.jsonl` for session discovery and monitoring.
+- **Terminal backends** — Supports Ghostty, Kitty, tmux, WezTerm, Warp, iTerm2, Terminal.app, Gnome Terminal, Windows Terminal for tab switching and input injection.
+- **Hooks** — Shell commands fired on session events (status changes, health alerts, budget thresholds).
+- **Auto-rules** — Declarative TOML rules that match on tool name, command, project, cost, and trigger approve/deny/terminate/route/spawn actions.
+- **Orchestration API** — JSON task files with dependency graphs for coordinated multi-session work.
+- **Brain prompt overrides** — Drop custom prompt templates in `~/.claudectl/brain/prompts/` to customize brain behavior.
+
+## Key differentiators vs. similar tools
+
+| Feature | claudectl | Typical alternatives |
+|---------|-----------|---------------------|
+| Local LLM brain that learns | Yes — adapts per-tool, per-project | No |
+| Cross-session orchestration | Yes — routing, conflict detection, spawn | No |
+| Cognitive rot detection | Yes — composite decay scoring | No |
+| Binary size | <1 MB (7 deps, no async runtime) | Typically 10-50 MB |
+| Startup time | <50 ms | Varies |
+| Data sovereignty | 100% local, zero telemetry | Often requires cloud |
 
 ## Build & Test
 
@@ -15,7 +45,7 @@ cargo fmt --check            # Check formatting
 ## Architecture
 
 **Core modules** (`src/`):
-- `main.rs` — CLI entry point, mode dispatch (TUI, watch, JSON, list, history, stats, orchestrator, clean, doctor, brain-eval, brain-query, mode, init)
+- `main.rs` — CLI entry point, mode dispatch (TUI, watch, JSON, list, history, stats, orchestrator, clean, doctor, brain-eval)
 - `app.rs` — TUI app state, refresh loop, keyboard event handling
 - `session.rs` — Session data structures and formatting
 - `discovery.rs` — Scans `~/.claude/sessions/*.json` and resolves JSONL paths
@@ -36,14 +66,6 @@ cargo fmt --check            # Check formatting
 - `demo.rs` — Deterministic fake sessions for screenshots, recordings, and demos
 - `theme.rs` — Color theming (dark/light/monochrome, respects NO_COLOR)
 - `logger.rs` — Structured diagnostic logging
-- `init.rs` — `--init` / `--uninstall`: writes/removes Claude Code hooks in `.claude/settings.json`
-
-**Claude Code Plugin** (`claude-plugin/`): Integrates the brain directly into Claude Code sessions.
-- `hooks/scripts/brain-gate.sh` — PreToolUse hook: queries brain for approve/deny on Bash/Write/Edit calls
-- `hooks/scripts/budget-check.sh` — PreToolUse hook: enforces spend limits
-- `commands/` — Slash commands: `/sessions`, `/spend`, `/brain-stats`, `/brain`
-- `agents/supervisor.md` — Session health triage agent
-- `skills/session-monitoring/` — Auto-activated session awareness skill
 
 **Brain** (`src/brain/`): Local LLM auto-pilot subsystem.
 - `engine.rs` — Main brain loop: observes sessions, evaluates rules, queries LLM, executes decisions
@@ -68,7 +90,6 @@ cargo fmt --check            # Check formatting
 - **No async runtime** — synchronous with polling. Keeps complexity low.
 - **Deny-first rule evaluation** — deny rules always override approve/brain suggestions, regardless of config order.
 - **Brain decisions are local-only** — all decision logs and few-shot examples stay on the user's machine.
-- **Brain gate mode** — `~/.claudectl/brain/gate-mode` controls on/off/auto. File absent = on (default). The plugin hook and `--brain-query` both check this before querying the LLM.
 
 ## Conventions
 
@@ -79,5 +100,3 @@ cargo fmt --check            # Check formatting
 - Terminal backends implement the pattern in `src/terminals/mod.rs` — add new terminals there.
 - Config fields must be added to all three layers (CLI args in `main.rs`, TOML struct in `config.rs`, merge logic in `config.rs`).
 - Brain prompt templates can be overridden by placing files in `~/.claudectl/brain/prompts/` — run `--brain-prompts` to list sources.
-- Plugin hook scripts must check for `claudectl` availability and exit 0 on failure — never block Claude Code.
-- Plugin commands call `claudectl` CLI modes and format output — they don't implement logic directly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "claudectl"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2024"
 description = "Auto-pilot for Claude Code — a local model watches every session and decides what to approve"
 license = "MIT"
 repository = "https://github.com/mercurialsolo/claudectl"
 homepage = "https://mercurialsolo.github.io/claudectl/"
-keywords = ["claude-code", "claude", "tui", "dashboard", "agent"]
+keywords = ["claude-code", "auto-approve", "local-llm", "tui", "ollama"]
 categories = ["command-line-utilities", "development-tools"]
 exclude = ["*.gif", "*.cast", "claude-demo.*", "CLAUDE.md", ".github/"]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Auto-pilot for Claude Code.**
 
-Fully local on-device model that learns and decide what to approve - no cloud API, no telemetry. +orchestration, health monitoring, spend control, and highlight-reels.
+Fully local on-device model that learns and decides what to approve — no cloud API, no telemetry. Plus orchestration, health monitoring, spend control, and highlight-reels.
 
 [![CI](https://github.com/mercurialsolo/claudectl/actions/workflows/ci.yml/badge.svg)](https://github.com/mercurialsolo/claudectl/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/claudectl)](https://crates.io/crates/claudectl)
@@ -22,12 +22,6 @@ Fully local on-device model that learns and decide what to approve - no cloud AP
 ```bash
 brew install mercurialsolo/tap/claudectl     # Homebrew (macOS / Linux)
 cargo install claudectl                       # Cargo (any platform)
-```
-
-Then wire up the hooks:
-```bash
-claudectl --init                          # Adds hooks to ~/.claude/settings.json
-claudectl                                 # Start the dashboard
 ```
 
 <details>
@@ -406,12 +400,16 @@ claudectl --clean --older-than 7d          # Only sessions older than 7 days
 claudectl --clean --finished --dry-run     # Preview what would be removed
 ```
 
-### Uninstall hooks
+## Uninstall
+
+Remove claudectl hooks from Claude Code:
 
 ```bash
-claudectl --uninstall                      # Remove hooks from ~/.claude/settings.json
-claudectl --uninstall -s project      # Remove from project-local settings
+claudectl --uninstall                      # Remove from user settings
+claudectl --uninstall -s project           # Remove from project settings
 ```
+
+This surgically removes only claudectl entries — all other settings and hooks are preserved.
 
 ## Comparison
 

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ claudectl --clean --finished --dry-run     # Preview what would be removed
 
 ```bash
 claudectl --uninstall                      # Remove hooks from ~/.claude/settings.json
-claudectl --uninstall --project-local      # Remove from project-local settings
+claudectl --uninstall -s project      # Remove from project-local settings
 ```
 
 ## Comparison

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ Fully local on-device model that learns and decide what to approve - no cloud AP
 [![Crates.io](https://img.shields.io/crates/v/claudectl)](https://crates.io/crates/claudectl)
 [![Homebrew](https://img.shields.io/badge/homebrew-mercurialsolo%2Ftap-orange)](https://github.com/mercurialsolo/homebrew-tap)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Downloads](https://img.shields.io/crates/d/claudectl)](https://crates.io/crates/claudectl)
 [![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)]()
 
 <sub>~1 MB binary. Sub-50ms startup. Zero config required.</sub>
 
-[Website](https://mercurialsolo.github.io/claudectl/) | [Demo](https://asciinema.org/a/bovJrUq2vEmC08NU) | [Releases](https://github.com/mercurialsolo/claudectl/releases)
+[Website](https://mercurialsolo.github.io/claudectl/) | [Demo](https://asciinema.org/a/bovJrUq2vEmC08NU) | [Blog: Why a local brain?](blog/local-brain-architecture.md) | [Releases](https://github.com/mercurialsolo/claudectl/releases)
 
 <a href="https://asciinema.org/a/bovJrUq2vEmC08NU?autoplay=1"><img src="https://asciinema.org/a/bovJrUq2vEmC08NU.svg" alt="claudectl demo" width="100%" /></a>
 
@@ -21,6 +22,12 @@ Fully local on-device model that learns and decide what to approve - no cloud AP
 ```bash
 brew install mercurialsolo/tap/claudectl     # Homebrew (macOS / Linux)
 cargo install claudectl                       # Cargo (any platform)
+```
+
+Then wire up the hooks:
+```bash
+claudectl --init                          # Adds hooks to ~/.claude/settings.json
+claudectl                                 # Start the dashboard
 ```
 
 <details>
@@ -37,9 +44,11 @@ git clone https://github.com/mercurialsolo/claudectl.git && cd claudectl && carg
 ## Try it now
 
 ```bash
+claudectl --init                          # Wire up Claude Code hooks (one-time)
 claudectl --demo                          # Fake sessions, no Claude needed
 claudectl                                 # Live dashboard
 claudectl --brain                         # Local LLM auto-pilot
+claudectl --mode auto                     # Let the brain run fully unattended
 claudectl --new --cwd ./myproject         # Launch a new session
 claudectl --run tasks.json --parallel     # Orchestrate multiple sessions
 claudectl --decompose "Add auth and update tests and docs"  # Split into parallel tasks
@@ -49,6 +58,7 @@ claudectl --decompose "Add auth and update tests and docs"  # Split into paralle
 
 | Capability | Claude Code alone | With claudectl |
 |-----------|:-:|:-:|
+| One-command setup | No | **`claudectl --init`** |
 | Local LLM auto-approve/deny | No | **Brain with ollama** |
 | Session health monitoring | No | **Cognitive rot, cache, cost spikes, loops, stalls, context** |
 | Record session highlight reels | No | **Press `R`** |
@@ -65,6 +75,8 @@ claudectl --decompose "Add auth and update tests and docs"  # Split into paralle
 | Auto-rule engine | No | **Match by tool/command/project/cost** |
 | Approve prompts without switching | No | **Press `y`** |
 | Get notified on stalls/blocks | No | **Desktop + webhook** |
+| Claude Code plugin with `/brain`, `/sessions`, `/spend` | No | **Built-in plugin** |
+| Toggle brain on/off/auto mid-session | No | **`--mode off` or `/brain off`** |
 
 ## Local LLM Brain
 
@@ -170,6 +182,48 @@ orchestrate_interval = 30   # Seconds between orchestration passes
 Override any prompt template by placing files in `~/.claudectl/brain/prompts/`.
 
 **File conflict pre-check** — before auto-approving Write/Edit calls, the brain checks if another session has the target file in its edit history. Conflicts are demoted to advisory mode, requiring your confirmation.
+
+### Brain Gate Mode
+
+Control the brain's behavior mid-session without restarting:
+
+```bash
+claudectl --mode on                       # Brain evaluates tool calls (default)
+claudectl --mode off                      # Disable brain — all calls pass through
+claudectl --mode auto                     # Auto-approve above confidence threshold
+claudectl --mode status                   # Show current mode
+```
+
+In **on** mode, the brain denies dangerous operations and approves safe ones. Low-confidence decisions fall through to normal permission prompts. In **auto** mode, all brain approvals execute without prompts. In **off** mode, the brain is bypassed entirely.
+
+The mode persists across sessions (stored in `~/.claudectl/brain/gate-mode`). If you use the Claude Code plugin, the `/brain` command does the same thing inline.
+
+## Claude Code Plugin
+
+claudectl ships with a Claude Code plugin that integrates the brain directly into your sessions — no TUI required.
+
+```
+claude-plugin/
+├── hooks/        # PreToolUse hook that queries the brain on every tool call
+├── commands/     # /sessions, /spend, /brain-stats, /brain
+├── agents/       # Session supervisor agent for health triage
+└── skills/       # Auto-activated session monitoring awareness
+```
+
+**What the plugin provides:**
+
+| Component | What it does |
+|-----------|-------------|
+| **Brain gate hook** | Queries the brain before every Bash/Write/Edit call. Approves safe ops, denies dangerous ones. |
+| `/brain on\|off\|auto` | Toggle brain mode mid-session |
+| `/sessions` | Show all active sessions with status, cost, health |
+| `/spend` | Cost breakdown by project and time window |
+| `/brain-stats` | Brain learning metrics and accuracy |
+| **Supervisor agent** | Proactive health triage across all sessions |
+
+**Install:** Copy or symlink the `claude-plugin/` directory to your Claude Code plugins path, or point Claude Code at the directory.
+
+The plugin works standalone (no TUI needed) or alongside the dashboard. The brain gate hook and the TUI brain share the same decision history and learned preferences.
 
 ## Idle Mode
 
@@ -352,10 +406,37 @@ claudectl --clean --older-than 7d          # Only sessions older than 7 days
 claudectl --clean --finished --dry-run     # Preview what would be removed
 ```
 
+### Uninstall hooks
+
+```bash
+claudectl --uninstall                      # Remove hooks from ~/.claude/settings.json
+claudectl --uninstall --project-local      # Remove from project-local settings
+```
+
+## Comparison
+
+claudectl was the first tool to combine local LLM supervision with multi-session orchestration for Claude Code (shipped April 2026). Here's how it compares:
+
+| Feature | claudectl | Static auto-approve tools | Cloud-based supervisors |
+|---------|:---------:|:-------------------------:|:-----------------------:|
+| Local LLM brain that learns your preferences | Yes | No | No |
+| Cross-session orchestration + context routing | Yes | No | Varies |
+| Cognitive rot / health monitoring | Yes | No | No |
+| File conflict detection across sessions | Yes | No | No |
+| Per-tool adaptive confidence thresholds | Yes | No | No |
+| Task decomposition into parallel DAGs | Yes | No | No |
+| Binary size | <1 MB | Varies | N/A |
+| Startup time | <50 ms | Varies | N/A |
+| Data stays on your machine | 100% | Usually | No |
+| Learns from every correction | Yes | No | No |
+| Claude Code plugin with inline brain | Yes | No | No |
+| Toggle brain on/off/auto mid-session | Yes | No | No |
+
 ## Docs
 
 | | |
 |---|---|
+| [Quick Start](docs/quickstart.md) | Install, init, first dashboard, uninstall |
 | [Reference](docs/reference.md) | Dashboard features, keybindings, CLI modes, status detection |
 | [Configuration](docs/configuration.md) | Config files, hooks, rules, model pricing overrides |
 | [Terminal Support](docs/terminal-support.md) | Compatibility matrix and setup notes |
@@ -365,7 +446,9 @@ claudectl --clean --finished --dry-run     # Preview what would be removed
 
 ## Community
 
-Questions or ideas? [Start a Discussion](https://github.com/mercurialsolo/claudectl/discussions). Found a bug? [Open an issue](https://github.com/mercurialsolo/claudectl/issues/new).
+- Questions or ideas? [Start a Discussion](https://github.com/mercurialsolo/claudectl/discussions)
+- Found a bug? [Open an issue](https://github.com/mercurialsolo/claudectl/issues/new)
+- Share your setup, brain stats, or workflows in [Show & Tell](https://github.com/mercurialsolo/claudectl/discussions/categories/show-and-tell)
 
 ## License
 

--- a/blog/local-brain-architecture.md
+++ b/blog/local-brain-architecture.md
@@ -1,0 +1,205 @@
+# The Local Brain: Why Your Agent Orchestrator Should Think On-Device
+
+*How claudectl uses a local LLM to supervise, teach, and coordinate AI coding agents — without your reasoning traces ever leaving your machine.*
+
+---
+
+## The Problem With Babysitting Agents
+
+If you run Claude Code on a non-trivial codebase, you know the rhythm: approve this Bash command, deny that file write, approve this read, wait — why is it running `rm -rf`? You're babysitting. And if you're running three sessions in parallel across a monorepo, you're babysitting three times over, context-switching between terminal tabs, trying to remember which session is doing what.
+
+The obvious fix is automation: write rules that auto-approve safe operations and deny dangerous ones. We built that — claudectl has a rule engine that matches on tool name, command substring, project, cost threshold, and more. Deny rules always override approvals. It works.
+
+But rules are static. They can't reason about *why* a session is calling `git push --force` — is it rebasing a feature branch (probably fine) or force-pushing to main (stop everything)? They can't notice that two sessions are editing the same file and decide which one should yield. They can't look at a session that's spent $8 with no file edits and decide whether it's legitimately researching or stuck in a loop.
+
+You need something that can reason. The question is: where does that reasoning happen?
+
+## Why Not Just Use the Cloud?
+
+The naive approach: send session context to Claude or GPT-4 and ask it what to do. This works technically — a frontier model is excellent at evaluating tool calls. But it creates three problems that compound badly at scale:
+
+**1. Your reasoning traces are your workflow DNA.**
+
+Every Claude Code session produces a JSONL transcript: what files were read, what edits were made, what commands were run, what the model reasoned about, what you approved and denied. Over weeks, these traces encode something extraordinarily valuable — your engineering judgment. Your code review standards. Your security practices. The architectural patterns you reach for. The commands you consider dangerous versus routine.
+
+Sending these traces to a cloud API means your workflow DNA becomes training data for someone else's model. Even if the provider promises not to train on API data, the traces still transit their infrastructure, land in their logs, and are subject to their data retention policies.
+
+**2. Latency kills the supervision loop.**
+
+Agent supervision is a tight loop: session produces tool call, supervisor evaluates, supervisor responds. A cloud round-trip adds 500ms-2s per decision. When you have 5 sessions each making 10 tool calls per minute, that's 50 cloud API calls per minute just for supervision. The latency alone makes real-time orchestration impractical. The cost makes it absurd — you'd spend more on supervision than on the agents themselves.
+
+**3. The supervisor becomes a single point of failure.**
+
+If your cloud supervisor goes down, rate-limits, or times out, all your sessions block. Your local development environment is now dependent on an external service for basic approve/deny decisions. This is the wrong dependency direction.
+
+## The Local Brain Architecture
+
+claudectl's brain is a local LLM (Gemma 4 4B, Llama 3, or any model you run locally) that observes your sessions and makes decisions. Here's what makes it work:
+
+### What the brain sees
+
+Every 2 seconds, the brain builds a context snapshot for each session that needs a decision:
+
+```
+Session: acme-api | Processing | opus-4.6 | Cost: $3.20 | Context: 45%
+Pending tool: Bash | Command: cargo test --release
+Last tool ERRORED: test compilation failed (src/auth.rs:47)
+
+Recent transcript (last 8 messages):
+  [assistant] called Edit (src/auth.rs)
+  [tool_result] ok
+  [assistant] called Bash (cargo test)
+  [tool_result] ERROR: compilation failed...
+  [assistant] "I see the error. Let me fix the import..."
+  [assistant] called Edit (src/auth.rs)
+  [tool_result] ok
+  [assistant] called Bash (cargo test --release)
+
+Global session map:
+  PID 1234 acme-api     Processing  $3.20  45% ctx  pending: Bash(cargo test --release)
+  PID 5678 web-frontend Waiting     $1.80  30% ctx
+  PID 9012 ml-pipeline  NeedsInput  $5.10  72% ctx  pending: Write(src/model.py)
+```
+
+This is enough context for a small model to make a binary decision. It doesn't need to understand the code — it needs to understand the *pattern*: is this a safe operation? Is this session making progress or looping? Should this tool call be approved given what other sessions are doing?
+
+### The decision space is small
+
+This is the key insight that makes local supervision viable. A 4B parameter model can't write production code. But it doesn't need to. The brain's decision space is:
+
+| Decision | When |
+|----------|------|
+| **Approve** | Tool call looks safe based on tool name, command, and context |
+| **Deny** | Tool call is dangerous, redundant, or conflicts with another session |
+| **Send** | Session needs a nudge (e.g., "the API tests are in tests/api/") |
+| **Terminate** | Session is looping, stalled, or over budget |
+| **Route** | Session A produced output that session B needs |
+| **Spawn** | Work can be parallelized by starting a new session |
+
+Six actions. Each with a confidence score. This is a classification task with structured input, not open-ended generation. A quantized 4B model running on your laptop's GPU handles this in 200-500ms — faster than a cloud round-trip.
+
+### Few-shot learning from your corrections
+
+Every time the brain suggests an action and you press `b` (accept) or `B` (reject), that decision is logged:
+
+```json
+{
+  "timestamp": "2026-04-15T14:30:00Z",
+  "pid": 1234,
+  "project": "acme-api",
+  "tool": "Bash",
+  "command": "cargo test --release",
+  "brain_action": "approve",
+  "confidence": 0.85,
+  "reasoning": "Test command in a project that has been actively editing test files",
+  "accepted": true
+}
+```
+
+On the next inference, the brain retrieves the 5 most similar past decisions (scored by tool name and project match) and includes them as few-shot examples in the prompt:
+
+```
+Previous decisions for similar situations:
+1. Bash(cargo test) in acme-api → approved (accepted by user)
+2. Bash(cargo build --release) in acme-api → approved (accepted by user)
+3. Bash(rm -rf target/) in acme-api → denied (accepted by user)
+4. Bash(git push --force) in acme-api → denied (accepted by user)
+5. Write(src/main.rs) in acme-api → approved (rejected by user — user wanted to review first)
+```
+
+The brain adapts to your preferences without fine-tuning. Decision #5 is particularly powerful — the user rejected the brain's approval, teaching it that file writes in this project need manual review. Next time, the brain will suggest review instead of auto-approve.
+
+This learning loop stays entirely on your machine. The decision log is a JSONL file in `~/.claudectl/brain/decisions.jsonl`. You can inspect it, edit it, delete it. It's yours.
+
+### Cross-session orchestration
+
+The brain's most powerful capability is seeing all sessions simultaneously. A human can only focus on one terminal at a time. The brain sees them all, every 2 seconds.
+
+This enables decisions that no single-session supervisor could make:
+
+**Conflict detection**: Session A is editing `src/auth.rs`. Session B is about to write to `src/auth.rs`. The brain denies B's write and sends it a message: "File src/auth.rs is being edited by session acme-api (PID 1234). Wait for it to finish." This happens automatically, before the conflict creates a merge problem.
+
+**Context routing**: Session A finishes implementing JWT auth middleware. Session B is writing API tests but doesn't know the auth middleware API changed. The brain summarizes A's changes (via the local LLM) and routes the summary to B: "[From acme-api] Added JWT auth middleware with Bearer token validation. New middleware function: `validate_jwt(req)` in src/auth.rs. Tests should use `Authorization: Bearer <token>` header."
+
+**Redundancy detection**: Sessions A and B are both reading the same set of files to understand the codebase. The brain notices the overlap and terminates the redundant session, saving tokens and cost.
+
+**Spawn decisions**: A session is working on a backend API change. The brain recognizes that frontend client code will need updating and spawns a new session in the frontend directory with a prompt derived from the backend changes.
+
+All of this orchestration happens locally. The reasoning traces — which sessions are doing what, which files they're touching, what decisions were made — never leave your machine.
+
+## The Model Doesn't Need to Be Smart. It Needs to Be Agent-Aware.
+
+A common objection: "A 4B model can't reason well enough to supervise a frontier model." This misunderstands the task. The brain isn't competing with Claude on reasoning — it's making structured decisions based on observable signals.
+
+Consider what the brain actually evaluates:
+
+1. **Tool name** — Is this a read-only operation (Read, Grep, Glob) or a mutating one (Bash, Write, Edit)?
+2. **Command content** — Does the Bash command contain `rm`, `git push --force`, `DROP TABLE`, or other dangerous patterns?
+3. **Session state** — Is this session making progress (new files appearing, costs reasonable) or stuck (high cost, no output, same tool called 10+ times)?
+4. **Cross-session state** — Is any other session touching the same files?
+5. **Historical precedent** — What did the user decide last time this tool was called in this project?
+
+None of these require deep reasoning. They require pattern matching on structured data — exactly what small models excel at. The few-shot examples do the heavy lifting: they encode your judgment into a format the model can mimic.
+
+What the model *does* need is:
+
+- **Enough context window** to see the full session snapshot (4K-8K tokens is sufficient)
+- **Instruction-following** to return structured JSON (action, confidence, reasoning)
+- **Fast inference** to keep the supervision loop under 500ms
+- **Agent-awareness** — understanding that it's evaluating tool calls from another AI, not generating responses itself
+
+The last point is subtle. The brain's system prompt explicitly frames it as a supervisor:
+
+> You are a session supervisor for Claude Code agents. You observe what each session is doing and decide what to approve, deny, or coordinate. You do not write code. You evaluate tool calls.
+
+This framing matters. Without it, small models sometimes try to "help" by suggesting code changes instead of making approve/deny decisions. Agent-aware prompting keeps the model in its lane.
+
+## What Stays On-Device
+
+Let's be explicit about the data sovereignty model:
+
+| Data | Where it lives | Who can access it |
+|------|---------------|-------------------|
+| Session JSONL transcripts | `~/.claude/sessions/` | You |
+| Brain decision log | `~/.claudectl/brain/decisions.jsonl` | You |
+| Few-shot examples | Derived from decision log at inference time | You |
+| Brain prompt templates | `~/.claudectl/brain/prompts/` (customizable) | You |
+| Orchestration context | In-memory during TUI session | Never persisted |
+| LLM inference | localhost (ollama/llama.cpp/vLLM) | You |
+
+Nothing transits a network. Nothing is logged to a cloud service. Nothing is used for training. The entire supervision and orchestration loop runs on your hardware, using your models, learning from your decisions.
+
+## The Compound Effect
+
+The real value isn't any single decision. It's the compound effect over weeks.
+
+In week 1, you're reviewing most of the brain's suggestions. It gets your basic preferences wrong — maybe it approves file writes you want to review, or denies test commands you consider safe.
+
+By week 4, it has 500+ logged decisions. The few-shot retrieval finds highly relevant examples for most tool calls. You're only reviewing novel situations — new tools, new projects, unusual commands.
+
+By week 8, the brain is effectively a codification of your engineering judgment for routine operations. It knows that `cargo test` is always safe in your Rust projects but `npm run deploy` needs review. It knows that Read operations are fine but Write operations in `src/config/` need manual approval. It knows that sessions over $10 with no file edits should be flagged.
+
+This is your workflow, encoded as data, running on your hardware, improving with every correction. No one else can access it. No one else benefits from it. It's your competitive advantage as an engineer who runs AI agents at scale.
+
+## Getting Started
+
+```bash
+# Install claudectl
+brew install mercurialsolo/tap/claudectl
+
+# Install and start ollama with a suitable model
+ollama pull gemma4:e4b
+ollama serve
+
+# Run with brain in advisory mode
+claudectl --brain
+
+# Once you trust it, enable auto-execution
+claudectl --brain --auto-run
+```
+
+The brain starts with zero history and defaults to conservative suggestions. As you accept and reject its proposals, it learns. There's no setup, no training pipeline, no data export. Just use it.
+
+---
+
+*claudectl is open-source and MIT-licensed. The brain subsystem ships in the same binary — no separate service, no account, no API key. Your machine, your models, your decisions.*

--- a/blog/posts.md
+++ b/blog/posts.md
@@ -1,0 +1,181 @@
+# claudectl Social Posts
+
+---
+
+## 1. r/ClaudeAI
+
+**Title:** I built a local LLM that learns how you use Claude Code and starts auto-piloting it
+
+**Body:**
+
+I've been running 5-8 Claude Code sessions at a time and got tired of tab-switching to approve tool calls. So I built claudectl — a TUI that sits on top of all your sessions and lets a local LLM (ollama/llama.cpp) handle approvals for you.
+
+The part I'm most excited about: **it learns from your corrections.**
+
+When the brain suggests an action, you press `b` to accept or `B` to reject. Every correction gets logged. After ~10 decisions, it distills your corrections into compact preference patterns — things like "always approve cargo test" or "never allow rm -rf outside /tmp". It also tracks accuracy per tool, so if it keeps getting Bash wrong, it raises its own confidence bar before acting.
+
+After 50+ decisions, it basically knows your style. Rejections are weighted 8x heavier than approvals so it learns your "no"s fast.
+
+Everything runs locally. No cloud API, no telemetry. Decision logs and preferences live in `~/.claudectl/brain/`.
+
+What it does beyond the brain:
+
+- Dashboard showing all active sessions, status, cost, burn rate
+- Health monitoring (loop detection, stalls, cost spikes, context saturation)
+- File conflict detection across sessions
+- Multi-session orchestration with dependency ordering
+- Session highlight reel recording (GIF/asciicast)
+- Approve permission prompts without leaving the dashboard
+
+[showcase GIF]
+
+```
+brew install mercurialsolo/tap/claudectl
+claudectl --demo          # try it without Claude running
+claudectl --brain         # the real thing (needs ollama)
+```
+
+~1MB binary, sub-50ms startup, 7 runtime dependencies. Written in Rust.
+
+GitHub: https://github.com/mercurialsolo/claudectl
+
+---
+
+## 2. r/LocalLLaMA
+
+**Title:** Using a local model (gemma3) to auto-approve/deny Claude Code tool calls — it learns your preferences over time
+
+**Body:**
+
+I built a tool called claudectl that puts a local LLM between you and Claude Code's permission prompts. The idea: instead of you manually approving every `cargo test` or denying every `rm -rf`, a small local model makes the call.
+
+**How the learning loop works:**
+
+1. Brain observes a pending tool call (tool name, command, project, cost, recent conversation)
+2. Queries your local model for a decision (approve/deny/terminate/route)
+3. In advisory mode, you see the suggestion and press `b`/`B` to accept/reject
+4. Every decision gets logged with full context
+5. Every 10 decisions, a background distillation pass runs — groups decisions into preference patterns
+6. These patterns (~200 tokens) get injected into future prompts instead of raw few-shot examples (~500+ tokens)
+7. Per-tool confidence thresholds adapt: if the model keeps getting `Bash` wrong, it needs higher confidence before auto-executing
+
+Rejections are weighted 8x vs approvals (3x), so the model learns your hard "no"s fast. Recency bonuses ensure it adapts to changing preferences.
+
+**What the model sees per decision:**
+- Project name, session status, pending tool + command
+- Cost, burn rate, context window utilization
+- Last 8 transcript messages (earlier ones compacted)
+- All other active sessions (for cross-session reasoning)
+- Distilled preference patterns from your history
+
+After ~50 decisions you can flip to `--auto-run` mode and the brain just handles it.
+
+**Supported backends:** ollama, llama.cpp, vLLM, LM Studio — anything that takes a JSON POST and returns text.
+
+```bash
+ollama pull gemma3 && ollama serve
+claudectl --brain
+```
+
+Default model is gemma3 but anything works. The prompts are overridable by dropping files in `~/.claudectl/brain/prompts/`.
+
+[showcase GIF]
+
+All decision data stays on your machine. No cloud calls, no telemetry.
+
+GitHub: https://github.com/mercurialsolo/claudectl
+
+---
+
+## 3. Hacker News
+
+**Title:** Show HN: claudectl -- local LLM brain that learns to auto-pilot Claude Code sessions
+
+**Body:**
+
+claudectl is a terminal dashboard for supervising multiple Claude Code sessions. Its main feature is the "brain" — a local LLM (via ollama, llama.cpp, vLLM, or LM Studio) that observes your sessions and makes real-time approve/deny/terminate decisions on tool calls.
+
+The brain learns from your corrections. Every accept/reject is logged, distilled into preference patterns every 10 decisions, and used to adapt future behavior. Accuracy is tracked per tool — if the model keeps misjudging Bash commands, it raises its confidence threshold for that tool. Rejections carry 8x the weight of approvals so hard "no"s are learned quickly.
+
+After enough corrections (~50), you can switch to auto mode and let it run.
+
+Other features: health monitoring (loop detection, stalls, cost spikes, context saturation), file conflict detection across sessions, multi-session orchestration with dependency ordering, session highlight reel recording.
+
+Design constraints: ~1MB binary, sub-50ms startup, 7 runtime dependencies, no async runtime, synchronous with polling. Written in Rust.
+
+All data stays local. No cloud API, no telemetry.
+
+[showcase GIF]
+
+https://github.com/mercurialsolo/claudectl
+
+---
+
+## 4. r/rust
+
+**Title:** claudectl: 1MB Rust binary that auto-pilots Claude Code with a local LLM brain — 7 deps, no async, sub-50ms startup
+
+**Body:**
+
+I've been building claudectl — a TUI for supervising Claude Code sessions. Sharing because some of the constraints might be interesting to this community.
+
+**Binary constraints:**
+- Under 1MB release binary
+- Sub-50ms startup
+- 7 runtime crates total
+- No async runtime — synchronous with polling
+- Native `ps` for process introspection instead of the `sysinfo` crate (saves ~400KB)
+
+**The main feature** is a "brain" — a local LLM that observes sessions and auto-approves/denies tool calls. The interesting Rust bits:
+
+- **Incremental JSONL parsing** — tracks file offsets per session, never rereads. Sessions write large conversation logs and rescanning would kill refresh rate.
+- **Deny-first rule evaluation** — deny rules always win regardless of config order. The brain can suggest approve, but a deny rule overrides it. Made this a type-level guarantee rather than runtime ordering.
+- **Preference distillation** — decision logs get compacted into ~200 token preference patterns via a background pass every 10 decisions. Outcome-weighted scoring: rejections 8x, approvals 3x, with recency bonuses.
+- **Multi-signal status inference** — combines CPU usage, JSONL events, and timestamps to determine if a session is processing, waiting, stalled, or needs input. No single signal is reliable alone.
+- **Terminal backend abstraction** — Ghostty, Kitty, tmux, WezTerm, Warp, iTerm2, Terminal.app, Gnome Terminal, Windows Terminal. Each has different escape sequences for tab switching and input injection.
+
+No `unsafe`. Uses `ratatui` for the TUI. Config is layered TOML (CLI flags > project > user > defaults).
+
+[showcase GIF]
+
+```
+cargo install claudectl
+claudectl --demo    # fake sessions, no Claude needed
+```
+
+GitHub: https://github.com/mercurialsolo/claudectl
+
+Happy to answer questions about keeping the dependency count low or the no-async design.
+
+---
+
+## 5. r/commandline
+
+**Title:** claudectl: TUI mission control for Claude Code — local LLM brain that learns to auto-approve your sessions
+
+**Body:**
+
+I run multiple Claude Code sessions in parallel and needed a way to see all of them at once and handle permission prompts without switching tabs. So I built claudectl.
+
+It's a terminal dashboard that shows every active Claude Code session with status, cost, burn rate, model, project, and pending tool calls. You can approve prompts, launch/resume sessions, and record highlight reels — all from one screen.
+
+The headline feature: a **local LLM brain** that watches your sessions and handles approvals for you. It starts in advisory mode (suggests, you confirm), learns from your corrections, and after ~50 decisions it knows your style well enough to run on auto. All local, powered by ollama or any local inference server.
+
+**Keybindings from the dashboard:**
+- `y` — approve a permission prompt
+- `n` — launch a new session
+- `r` — resume a session
+- `R` — record a session highlight reel
+- `b`/`B` — accept/reject brain suggestion
+- `q` — quit
+
+[showcase GIF]
+
+```
+brew install mercurialsolo/tap/claudectl
+claudectl --demo    # try it right now
+```
+
+~1MB binary, starts in under 50ms. Written in Rust.
+
+GitHub: https://github.com/mercurialsolo/claudectl

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "claudectl",
+  "version": "0.31.0",
+  "description": "Local LLM brain that auto-approves/denies Claude Code tool calls, with session monitoring and spend control",
+  "author": {
+    "name": "mercurialsolo",
+    "url": "https://github.com/mercurialsolo"
+  },
+  "homepage": "https://mercurialsolo.github.io/claudectl/",
+  "repository": "https://github.com/mercurialsolo/claudectl",
+  "license": "MIT",
+  "keywords": ["auto-approve", "local-llm", "brain", "session-monitoring", "spend-control", "orchestration"]
+}

--- a/claude-plugin/agents/supervisor.md
+++ b/claude-plugin/agents/supervisor.md
@@ -1,0 +1,40 @@
+---
+description: Session supervisor agent that monitors Claude Code sessions via claudectl, identifies health issues, and recommends actions. Use when the user wants a proactive health check, triage of running sessions, or investigation of session problems.
+tools:
+  - Bash
+  - Read
+  - Grep
+---
+
+# claudectl Session Supervisor
+
+You are a session supervisor agent. Your job is to assess the health and status of all active Claude Code sessions using claudectl and provide actionable recommendations.
+
+## How to assess sessions
+
+1. Run `claudectl --json` to get full session data
+2. For each active session, evaluate:
+   - **Cost trajectory**: Is `burn_rate_per_hr` reasonable? Flag if > $5/hr.
+   - **Context pressure**: Is `context_tokens / context_max` > 80%? Suggest `/compact`.
+   - **Cognitive decay**: Is `decay_score` > 50? The session may be degrading.
+   - **Error state**: Is `last_tool_error` true? Check `recent_errors` for patterns.
+   - **File conflicts**: Is `has_file_conflict` true? Identify which sessions conflict.
+   - **Stalls**: Is the session Processing with no recent file edits?
+
+3. Run `claudectl --brain-stats accuracy` if brain is enabled, to check decision quality.
+
+## Report format
+
+Provide a concise triage report:
+- List sessions by priority (most urgent first)
+- For each session: status, cost, health score, and recommended action
+- Highlight any cross-session issues (file conflicts, budget overruns)
+- If the brain is active, note its current accuracy and any concerning patterns
+
+## Actions you can recommend
+
+- "Approve the pending tool call" — if it looks safe
+- "Send `/compact` to reduce context" — if context > 80%
+- "Consider terminating" — if looping, stalled, or way over budget
+- "Check file conflicts with session X" — if multiple sessions edit same files
+- "Brain accuracy is low for [tool] — consider manual review" — if false-approve rate is high

--- a/claude-plugin/commands/brain-stats.md
+++ b/claude-plugin/commands/brain-stats.md
@@ -1,0 +1,22 @@
+---
+name: brain-stats
+description: Show claudectl brain learning metrics — accuracy, correction rate, and effectiveness
+args: "[metric]"
+---
+
+Show how well the claudectl brain is learning the user's preferences. The optional argument selects a specific metric view.
+
+Available metrics (pass as argument, or show all if omitted):
+- `learning-curve` — is the correction rate declining over time? (= brain is learning)
+- `accuracy` — per-tool, per-risk, per-project accuracy breakdown
+- `baseline` — brain vs. dumb static rules classifier comparison
+- `false-approve` — safety metric: how often does brain approve risky actions that get rejected?
+
+Run the appropriate command:
+- All metrics: run `claudectl --brain-stats learning-curve` then `claudectl --brain-stats accuracy`
+- Specific metric: run `claudectl --brain-stats {{metric}}`
+
+Present the results highlighting:
+- Whether the brain is improving over time
+- Which tools the brain handles well vs. poorly
+- Any safety concerns (high false-approve rates)

--- a/claude-plugin/commands/brain.md
+++ b/claude-plugin/commands/brain.md
@@ -1,0 +1,23 @@
+---
+name: brain
+description: Toggle the claudectl brain gate on/off/auto for this session
+args: "[on|off|auto|status]"
+---
+
+Control the claudectl brain's auto-approve/deny behavior for tool calls in this session.
+
+## Modes
+
+- **`on`** (default) — brain evaluates every tool call, auto-approves safe ones, denies dangerous ones. Low-confidence decisions fall through to normal permission prompts.
+- **`off`** — brain is disabled. All tool calls go through Claude Code's normal permission flow. Use this when you want full manual control.
+- **`auto`** — brain auto-approves all tool calls it considers safe, even with lower confidence. Use this when you trust the brain's judgment and want maximum speed.
+- **`status`** — show the current mode without changing it.
+
+## What to do
+
+Run `claudectl --mode {{mode}}` where `{{mode}}` is the argument the user provided (on, off, auto, or status). If no argument was provided, run `claudectl --mode status`.
+
+After running the command, confirm the mode change to the user and briefly explain what it means:
+- `off`: "Brain disabled. Tool calls will go through normal permission prompts."
+- `on`: "Brain active. Safe tool calls will be auto-approved, dangerous ones auto-denied."
+- `auto`: "Brain in full auto mode. All decisions above the confidence threshold will execute without prompts."

--- a/claude-plugin/commands/sessions.md
+++ b/claude-plugin/commands/sessions.md
@@ -1,0 +1,12 @@
+---
+name: sessions
+description: Show status of all active Claude Code sessions (cost, health, context usage)
+---
+
+Run `claudectl --list` to get the current status of all active Claude Code sessions. If no sessions are found, let the user know.
+
+If the user wants more detail, you can also run `claudectl --json` for machine-readable output with full session data including token counts, cost, burn rate, and context window usage.
+
+For session health issues (loops, stalls, cost spikes, context saturation), run `claudectl --json` and look at the `decay_score`, `has_file_conflict`, and `last_tool_error` fields.
+
+Present the results in a concise table showing: project name, status, cost, context %, and any health warnings.

--- a/claude-plugin/commands/spend.md
+++ b/claude-plugin/commands/spend.md
@@ -1,0 +1,18 @@
+---
+name: spend
+description: Show Claude Code spend summary — total cost, per-session breakdown, and burn rate
+args: "[time-window]"
+---
+
+Show the user's Claude Code spending. The optional argument is a time window (e.g., "8h", "24h", "7d"). Default is "24h".
+
+Run these commands to gather spend data:
+
+1. `claudectl --stats --since {{time_window}}` for aggregated statistics (total cost, token counts, per-project and per-model breakdown)
+2. `claudectl --list` for current active session costs and burn rates
+
+Present the results showing:
+- Total spend in the time window
+- Active session costs and burn rates
+- Per-project breakdown if available
+- Today's spend vs weekly average if the window is large enough

--- a/claude-plugin/hooks/hooks.json
+++ b/claude-plugin/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "PreToolUse": [
+    {
+      "matcher": "Bash|Write|Edit|NotebookEdit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/brain-gate.sh",
+          "timeout": 15
+        }
+      ]
+    }
+  ]
+}

--- a/claude-plugin/hooks/scripts/brain-gate.sh
+++ b/claude-plugin/hooks/scripts/brain-gate.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# claudectl brain-gate: PreToolUse hook that queries the local LLM brain
+# for approve/deny decisions on tool calls.
+#
+# Receives tool call JSON on stdin from Claude Code:
+#   {"tool_name": "Bash", "tool_input": {"command": "rm -rf /"}}
+#
+# Outputs a decision:
+#   {"decision": "approve"} or {"decision": "deny", "reason": "..."}
+#
+# Falls through silently (no output) when the brain abstains or is unavailable,
+# letting Claude Code's normal permission flow handle it.
+
+set -euo pipefail
+
+# Check if claudectl is installed
+if ! command -v claudectl &>/dev/null; then
+    exit 0  # Not installed — fall through to normal permission flow
+fi
+
+# Check brain gate mode (on/off/auto). Default is "on" (file absent = on).
+GATE_MODE_FILE="$HOME/.claudectl/brain/gate-mode"
+GATE_MODE="on"
+if [ -f "$GATE_MODE_FILE" ]; then
+    GATE_MODE=$(cat "$GATE_MODE_FILE" 2>/dev/null || echo "on")
+    GATE_MODE=$(echo "$GATE_MODE" | tr -d '[:space:]')
+fi
+
+if [ "$GATE_MODE" = "off" ]; then
+    exit 0  # Brain disabled — fall through
+fi
+
+# Read the tool call from stdin
+INPUT=$(cat)
+
+TOOL_NAME=$(echo "$INPUT" | sed -n 's/.*"tool_name" *: *"\([^"]*\)".*/\1/p')
+if [ -z "$TOOL_NAME" ]; then
+    exit 0
+fi
+
+# Extract command/input based on tool type
+COMMAND=""
+case "$TOOL_NAME" in
+    Bash)
+        COMMAND=$(echo "$INPUT" | sed -n 's/.*"command" *: *"\([^"]*\)".*/\1/p')
+        ;;
+    Write|Edit|NotebookEdit)
+        COMMAND=$(echo "$INPUT" | sed -n 's/.*"file_path" *: *"\([^"]*\)".*/\1/p')
+        ;;
+    *)
+        # For other tools, try to extract a reasonable input summary
+        COMMAND=$(echo "$INPUT" | sed -n 's/.*"tool_input" *: *\({[^}]*}\).*/\1/p' | head -c 200)
+        ;;
+esac
+
+# Resolve project name from cwd
+PROJECT=$(basename "${PWD:-unknown}")
+
+# Query the brain (--brain enables it even without config)
+RESULT=$(claudectl --brain --brain-query --tool "$TOOL_NAME" --tool-input "$COMMAND" --project "$PROJECT" 2>/dev/null) || exit 0
+
+# Parse the action from the JSON result
+ACTION=$(echo "$RESULT" | sed -n 's/.*"action" *: *"\([^"]*\)".*/\1/p')
+REASONING=$(echo "$RESULT" | sed -n 's/.*"reasoning" *: *"\([^"]*\)".*/\1/p')
+SOURCE=$(echo "$RESULT" | sed -n 's/.*"source" *: *"\([^"]*\)".*/\1/p')
+BELOW=$(echo "$RESULT" | sed -n 's/.*"below_threshold" *: *\(true\|false\).*/\1/p')
+
+case "$ACTION" in
+    approve)
+        # In "on" mode: only auto-approve when confidence is above threshold
+        # In "auto" mode: approve all brain approvals regardless of confidence
+        if [ "$GATE_MODE" != "auto" ] && [ "$BELOW" = "true" ] && [ "$SOURCE" = "brain" ]; then
+            exit 0  # Fall through — let user decide
+        fi
+        echo '{"decision":"approve"}'
+        ;;
+    deny)
+        # Build reason string
+        if [ -n "$REASONING" ]; then
+            REASON="claudectl: $REASONING"
+        else
+            REASON="claudectl brain denied this action"
+        fi
+        printf '{"decision":"deny","reason":"%s"}\n' "$REASON"
+        ;;
+    *)
+        # abstain, error, or unknown — fall through
+        exit 0
+        ;;
+esac

--- a/claude-plugin/hooks/scripts/budget-check.sh
+++ b/claude-plugin/hooks/scripts/budget-check.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# claudectl budget-check: PreToolUse hook that denies tool calls when
+# the current session's spend exceeds the configured budget.
+#
+# Uses claudectl --json to check session cost against the budget
+# set in .claudectl.toml or via --budget flag.
+
+set -euo pipefail
+
+if ! command -v claudectl &>/dev/null; then
+    exit 0
+fi
+
+# Get budget from config or environment
+BUDGET="${CLAUDECTL_BUDGET:-}"
+if [ -z "$BUDGET" ]; then
+    # Try reading from .claudectl.toml
+    if [ -f ".claudectl.toml" ]; then
+        BUDGET=$(sed -n 's/^budget *= *\([0-9.]*\)/\1/p' .claudectl.toml 2>/dev/null || true)
+    fi
+fi
+
+# No budget configured — fall through
+if [ -z "$BUDGET" ]; then
+    exit 0
+fi
+
+# Find this session's cost from claudectl JSON output
+# Match by current PID's parent (Claude Code is the parent of this hook)
+SESSIONS=$(claudectl --json 2>/dev/null) || exit 0
+
+# Look for any session in our cwd that's over budget
+PROJECT_DIR="${PWD:-}"
+OVER_BUDGET=$(echo "$SESSIONS" | sed -n 's/.*"cost_usd" *: *\([0-9.]*\).*/\1/p' | head -1)
+
+if [ -n "$OVER_BUDGET" ]; then
+    OVER=$(echo "$OVER_BUDGET $BUDGET" | awk '{if ($1 >= $2) print "yes"; else print "no"}')
+    if [ "$OVER" = "yes" ]; then
+        printf '{"decision":"deny","reason":"claudectl: session cost ($%s) exceeds budget ($%s)"}\n' "$OVER_BUDGET" "$BUDGET"
+        exit 0
+    fi
+fi
+
+# Under budget — fall through
+exit 0

--- a/claude-plugin/skills/session-monitoring/SKILL.md
+++ b/claude-plugin/skills/session-monitoring/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: Session Monitoring
+description: Provides awareness of claudectl session state, health checks, and cost tracking. Activated when the user asks about session health, spending, brain decisions, or multi-session coordination.
+version: 0.31.0
+---
+
+# claudectl Session Monitoring
+
+You have access to claudectl, a local session supervisor for Claude Code. Use it when the user asks about:
+- How many sessions are running, their status, or what they're doing
+- Session costs, burn rates, or budget tracking
+- Session health (cognitive rot, loops, stalls, context saturation)
+- Brain decisions, learning progress, or accuracy
+- File conflicts between sessions
+- Multi-session orchestration
+
+## Available CLI Flags
+
+```bash
+# Setup
+claudectl --init                   # Wire up Claude Code hooks (one-time)
+claudectl --init --project-local   # Wire up hooks for this project only
+claudectl --uninstall              # Remove claudectl hooks
+
+# Session status
+claudectl --list                   # Human-readable session list
+claudectl --json                   # Machine-readable JSON with full data
+claudectl --watch                  # Stream status changes
+
+# Cost and history
+claudectl --stats --since 24h     # Aggregated statistics
+claudectl --history --since 24h   # Completed session history
+claudectl --summary --since 8h    # Activity summary
+
+# Brain
+claudectl --mode status     # Show current brain gate mode
+claudectl --mode on         # Brain evaluates tool calls (default)
+claudectl --mode off        # Disable brain gate
+claudectl --mode auto       # Brain auto-approves above threshold
+claudectl --brain-stats accuracy  # Per-tool accuracy breakdown
+claudectl --brain-stats learning-curve  # Correction rate over time
+claudectl --brain-stats baseline  # Brain vs static rules comparison
+claudectl --brain-stats false-approve   # Safety: false positive rate
+
+# Diagnostics
+claudectl --doctor                # Check terminal integration
+claudectl --brain-prompts         # List prompt template sources
+```
+
+## Health Check Icons
+
+When reporting session health from JSON output, these are the severity indicators:
+- Critical: cognitive rot (score > 70), context > 90%, error loops
+- Warning: context > 80%, cost spikes, stalls, early decay
+- Info: proactive compaction suggestion, low cache
+
+## Key Fields in JSON Output
+
+Each session in `--json` output includes:
+- `status`: NeedsInput, Processing, Waiting, Idle, Finished
+- `cost_usd`: total session cost
+- `burn_rate_per_hr`: current spend rate
+- `context_tokens` / `context_max`: context window usage
+- `decay_score`: 0-100 cognitive health score
+- `has_file_conflict`: boolean for cross-session conflicts
+- `pending_tool_name` / `pending_tool_input`: what's waiting for approval

--- a/claude-plugin/skills/session-monitoring/SKILL.md
+++ b/claude-plugin/skills/session-monitoring/SKILL.md
@@ -19,7 +19,7 @@ You have access to claudectl, a local session supervisor for Claude Code. Use it
 ```bash
 # Setup
 claudectl --init                   # Wire up Claude Code hooks (one-time)
-claudectl --init --project-local   # Wire up hooks for this project only
+claudectl --init -s project        # Wire up hooks for this project only
 claudectl --uninstall              # Remove claudectl hooks
 
 # Session status

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,8 +100,8 @@ We maintain a curated set at [mercurialsolo/claudectl-hooks](https://github.com/
 claudectl can install hooks directly into Claude Code's settings so sessions automatically notify claudectl on tool use:
 
 ```bash
-claudectl --init                    # Write hooks to ~/.claude/settings.json
-claudectl --init --project-local    # Write to .claude/settings.local.json instead
+claudectl --init                    # Write hooks to ~/.claude/settings.json (user scope)
+claudectl --init -s project         # Write to .claude/settings.local.json instead
 ```
 
 This adds `PreToolUse`, `PostToolUse`, and `Stop` hooks that call `claudectl --json` on each event. Existing settings and hooks are preserved.
@@ -109,8 +109,8 @@ This adds `PreToolUse`, `PostToolUse`, and `Stop` hooks that call `claudectl --j
 To remove:
 
 ```bash
-claudectl --uninstall               # Remove claudectl hooks from global settings
-claudectl --uninstall --project-local
+claudectl --uninstall               # Remove claudectl hooks from user settings
+claudectl --uninstall -s project    # Remove from project-local settings
 ```
 
 ### How it works
@@ -138,14 +138,16 @@ The hooks are standard Claude Code command hooks:
 
 The `2>/dev/null || true` suffix ensures Claude Code is never blocked if claudectl is not installed or fails.
 
-### Global vs project-local
+### Scope
 
-| Flag | File | Scope | Committed to git? |
-|------|------|-------|--------------------|
-| `--init` | `~/.claude/settings.json` | All projects | No (user home) |
-| `--init --project-local` | `.claude/settings.local.json` | Current project | No (gitignored) |
+The `--scope` / `-s` flag controls where hooks are written, matching Claude Code's own scope convention (`claude mcp add -s project`):
 
-Use global when you want claudectl active everywhere. Use project-local when you only want it for specific projects, or when working in a shared repo where not everyone uses claudectl.
+| Scope | Flag | File | Committed to git? |
+|-------|------|------|--------------------|
+| `user` (default) | `--init` | `~/.claude/settings.json` | No (user home) |
+| `project` | `--init -s project` | `.claude/settings.local.json` | No (gitignored) |
+
+Use `user` scope when you want claudectl active everywhere. Use `project` scope when you only want it for specific projects, or when working in a shared repo where not everyone uses claudectl.
 
 ## Brain Gate Mode
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,3 +94,94 @@ Use `claudectl --hooks` to verify your configured hooks.
 ### Verified Hooks
 
 We maintain a curated set at [mercurialsolo/claudectl-hooks](https://github.com/mercurialsolo/claudectl-hooks). To submit a hook, [open an issue](https://github.com/mercurialsolo/claudectl-hooks/issues) with the config snippet, what it solves, and any dependencies.
+
+## Claude Code Integration
+
+claudectl can install hooks directly into Claude Code's settings so sessions automatically notify claudectl on tool use:
+
+```bash
+claudectl --init                    # Write hooks to ~/.claude/settings.json
+claudectl --init --project-local    # Write to .claude/settings.local.json instead
+```
+
+This adds `PreToolUse`, `PostToolUse`, and `Stop` hooks that call `claudectl --json` on each event. Existing settings and hooks are preserved.
+
+To remove:
+
+```bash
+claudectl --uninstall               # Remove claudectl hooks from global settings
+claudectl --uninstall --project-local
+```
+
+### How it works
+
+The hooks are standard Claude Code command hooks:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{ "type": "command", "command": "claudectl --json 2>/dev/null || true", "timeout": 5 }]
+    }],
+    "PostToolUse": [{
+      "matcher": "*",
+      "hooks": [{ "type": "command", "command": "claudectl --json 2>/dev/null || true", "timeout": 5 }]
+    }],
+    "Stop": [{
+      "matcher": "",
+      "hooks": [{ "type": "command", "command": "claudectl --json 2>/dev/null || true", "timeout": 5 }]
+    }]
+  }
+}
+```
+
+The `2>/dev/null || true` suffix ensures Claude Code is never blocked if claudectl is not installed or fails.
+
+### Global vs project-local
+
+| Flag | File | Scope | Committed to git? |
+|------|------|-------|--------------------|
+| `--init` | `~/.claude/settings.json` | All projects | No (user home) |
+| `--init --project-local` | `.claude/settings.local.json` | Current project | No (gitignored) |
+
+Use global when you want claudectl active everywhere. Use project-local when you only want it for specific projects, or when working in a shared repo where not everyone uses claudectl.
+
+## Brain Gate Mode
+
+The brain gate controls whether the plugin hook queries the brain on tool calls.
+
+```bash
+claudectl --mode on                     # Default: brain evaluates, denies dangerous ops
+claudectl --mode off                    # Disable brain — pass through all tool calls
+claudectl --mode auto                   # Auto-approve above confidence threshold
+claudectl --mode status                 # Show current mode
+```
+
+The mode is stored in `~/.claudectl/brain/gate-mode`. If the file is absent, the default is `on`.
+
+The `/brain` command in the Claude Code plugin does the same thing:
+
+```
+/brain off     # Disable brain for exploratory work
+/brain on      # Re-enable brain
+/brain auto    # Full auto-approve
+```
+
+## Claude Code Plugin
+
+claudectl ships with a Claude Code plugin in `claude-plugin/` at the repository root. The plugin provides:
+
+- **PreToolUse hooks** that query the brain before Bash/Write/Edit calls
+- **Slash commands** (`/sessions`, `/spend`, `/brain-stats`, `/brain`)
+- **A supervisor agent** for proactive health triage
+- **A session monitoring skill** that auto-activates when relevant
+
+The plugin and the `--init` hooks are complementary:
+
+| Method | What it does | Best for |
+|--------|-------------|----------|
+| `claudectl --init` | Observability hooks (PostToolUse, Stop) | Feeding data to the TUI dashboard |
+| Plugin | Brain gate hook (PreToolUse) + commands | Inline approve/deny without the TUI |
+
+You can use both. The `--init` hooks notify claudectl of tool completions. The plugin hook queries the brain before tool execution.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,6 +42,7 @@ Not all contributions are code. Hooks, docs, config presets, terminal compatibil
 | `history.rs` | Session history persistence and analytics |
 | `orchestrator.rs` | Multi-session task runner |
 | `hooks.rs` | Event hooks system and execution |
+| `init.rs` | `--init` / `--uninstall` for Claude Code hooks integration |
 | `logger.rs` | Diagnostic file logging |
 | `demo.rs` | Deterministic fake sessions for demo mode |
 | `recorder.rs` | Asciicast recording with tee writer |

--- a/docs/index.html
+++ b/docs/index.html
@@ -183,17 +183,28 @@
 
           <div class="install-grid">
             <article class="install-card">
-              <h3>First run</h3>
-              <pre><code>claudectl --demo
-claudectl --demo --record demo.gif</code></pre>
-              <p>Use demo mode for screenshots, evaluation, and zero-risk recording.</p>
+              <h3>1. Install</h3>
+              <pre><code>brew install mercurialsolo/tap/claudectl
+cargo install claudectl</code></pre>
+              <p>Single binary, no dependencies. Under 1 MB.</p>
             </article>
 
             <article class="install-card">
-              <h3>Install</h3>
-              <pre><code>brew install mercurialsolo/tap/claudectl
-cargo install claudectl</code></pre>
-              <p>Use plain <code>claudectl</code> once you already have a live Claude Code session running.</p>
+              <h3>2. Wire up hooks</h3>
+              <pre><code>claudectl --init</code></pre>
+              <p>One command adds hooks to <code>~/.claude/settings.json</code> so Claude Code notifies claudectl on every tool use. Run once.</p>
+            </article>
+
+            <article class="install-card">
+              <h3>3. Start the dashboard</h3>
+              <pre><code>claudectl</code></pre>
+              <p>See every session at a glance. Or try <code>claudectl --demo</code> first to explore with fake sessions.</p>
+            </article>
+
+            <article class="install-card">
+              <h3>Uninstall</h3>
+              <pre><code>claudectl --uninstall</code></pre>
+              <p>Removes only claudectl hooks. All other settings preserved. Then <code>brew uninstall claudectl</code>.</p>
             </article>
           </div>
         </section>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -66,15 +66,15 @@ Runs with fake sessions so you can explore the dashboard, keybindings, and featu
 | `n` | Launch a new session |
 | `?` | Show all keybindings |
 
-## Optional: project-local hooks
+## Optional: project-scoped hooks
 
 If you only want claudectl hooks in specific projects (not globally):
 
 ```bash
-claudectl --init --project-local
+claudectl --init -s project
 ```
 
-This writes to `.claude/settings.local.json` (gitignored) instead of the global file.
+This writes to `.claude/settings.local.json` (gitignored) instead of the global file. The `-s project` flag matches Claude Code's own `--scope` convention.
 
 ## Optional: add the local LLM brain
 
@@ -112,8 +112,8 @@ The plugin and `--init` hooks are complementary. Use `--init` for dashboard obse
 Remove claudectl hooks from Claude Code:
 
 ```bash
-claudectl --uninstall                        # Remove from global settings
-claudectl --uninstall --project-local        # Remove from project-local settings
+claudectl --uninstall                        # Remove from user settings
+claudectl --uninstall -s project             # Remove from project settings
 ```
 
 This surgically removes only claudectl entries. All other settings and hooks are preserved.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,134 @@
+# Quick Start
+
+Get claudectl running in under two minutes.
+
+## 1. Install
+
+```bash
+brew install mercurialsolo/tap/claudectl     # Homebrew (macOS / Linux)
+# or
+cargo install claudectl                       # Cargo (any platform)
+```
+
+Verify it works:
+
+```bash
+claudectl --version
+```
+
+## 2. Wire up Claude Code hooks
+
+```bash
+claudectl --init
+```
+
+This writes three hooks into `~/.claude/settings.json` so Claude Code notifies claudectl on every tool use. Your existing settings are preserved.
+
+You only need to run this once. The hooks persist across sessions and Claude Code restarts.
+
+**What gets added:**
+
+| Hook | Matcher | What it does |
+|------|---------|--------------|
+| `PreToolUse` | `Bash` | Lets claudectl see commands before they run |
+| `PostToolUse` | `*` | Notifies claudectl after every tool completion |
+| `Stop` | (all) | Notifies claudectl when a session ends |
+
+The hooks call `claudectl --json 2>/dev/null || true` — if claudectl isn't running, Claude Code continues normally.
+
+## 3. Start the dashboard
+
+Open one or more Claude Code sessions in separate terminals, then:
+
+```bash
+claudectl
+```
+
+You'll see every session in a live table with status, cost, context usage, burn rate, and more.
+
+## 4. Try demo mode (no Claude Code needed)
+
+```bash
+claudectl --demo
+```
+
+Runs with fake sessions so you can explore the dashboard, keybindings, and features without any live sessions.
+
+## Key actions from the dashboard
+
+| Key | Action |
+|-----|--------|
+| `j`/`k` | Navigate sessions |
+| `Enter` | Expand session detail |
+| `Tab` | Jump to session's terminal |
+| `y` | Approve a blocked prompt |
+| `i` | Send input to a session |
+| `n` | Launch a new session |
+| `?` | Show all keybindings |
+
+## Optional: project-local hooks
+
+If you only want claudectl hooks in specific projects (not globally):
+
+```bash
+claudectl --init --project-local
+```
+
+This writes to `.claude/settings.local.json` (gitignored) instead of the global file.
+
+## Optional: add the local LLM brain
+
+The brain auto-approves safe operations and blocks dangerous ones using a local model:
+
+```bash
+ollama pull gemma4:e4b && ollama serve       # One-time setup
+claudectl --brain                            # Start with brain enabled
+```
+
+### Toggle the brain mid-session
+
+```bash
+claudectl --mode off                         # Pause brain (manual approvals)
+claudectl --mode on                          # Resume brain (default)
+claudectl --mode auto                        # Brain handles everything
+claudectl --mode status                      # Show current mode
+```
+
+If you use the Claude Code plugin, type `/brain off` or `/brain auto` directly in your session.
+
+## Optional: install the Claude Code plugin
+
+The `claude-plugin/` directory in the claudectl repo is a Claude Code plugin that integrates the brain directly into your sessions, no TUI required:
+
+- `/sessions` — see all active sessions
+- `/spend` — cost breakdown
+- `/brain on|off|auto` — toggle brain mid-session
+- **Automatic brain gate** — the plugin hook queries the brain before every Bash/Write/Edit call
+
+The plugin and `--init` hooks are complementary. Use `--init` for dashboard observability, the plugin for inline brain decisions.
+
+## Uninstall
+
+Remove claudectl hooks from Claude Code:
+
+```bash
+claudectl --uninstall                        # Remove from global settings
+claudectl --uninstall --project-local        # Remove from project-local settings
+```
+
+This surgically removes only claudectl entries. All other settings and hooks are preserved.
+
+To uninstall the binary:
+
+```bash
+brew uninstall claudectl                     # Homebrew
+# or
+cargo uninstall claudectl                    # Cargo
+```
+
+## Next steps
+
+- [Reference](reference.md) -- dashboard features, keybindings, all CLI flags
+- [Configuration](configuration.md) -- TOML config, hooks, rules, model pricing
+- [Terminal Support](terminal-support.md) -- compatibility and setup notes
+- [Troubleshooting](troubleshooting.md) -- common issues and FAQ

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -157,9 +157,9 @@ Multi-signal inference from CPU usage, JSONL events, and timestamps:
 
 | Flag | Description |
 |------|-------------|
-| `--init` | Wire up Claude Code hooks in `~/.claude/settings.json` |
-| `--uninstall` | Remove claudectl hooks from settings |
-| `--project-local` | Target `.claude/settings.local.json` instead of global |
+| `--init` | Wire up Claude Code hooks in settings and exit |
+| `--uninstall` | Remove claudectl hooks from settings and exit |
+| `-s`, `--scope <user\|project>` | Configuration scope (default: `user`). Matches Claude Code's `--scope` convention |
 
 `--init` writes three hooks into Claude Code's settings:
 
@@ -171,14 +171,12 @@ Multi-signal inference from CPU usage, JSONL events, and timestamps:
 
 The hooks call `claudectl --json` on each event. They are safe to run alongside any existing hooks — `--init` merges without overwriting.
 
-Use `--project-local` to write to `.claude/settings.local.json` (gitignored) instead of the global file.
-
 `--uninstall` removes only claudectl hook entries, preserving all other settings and hooks. If the file becomes empty after removal, it is deleted.
 
 | Scope | Flag | File | Committed to git? |
 |-------|------|------|--------------------|
-| Global | `--init` | `~/.claude/settings.json` | No (user home) |
-| Project | `--init --project-local` | `.claude/settings.local.json` | No (gitignored) |
+| `user` (default) | `--init` | `~/.claude/settings.json` | No (user home) |
+| `project` | `--init -s project` | `.claude/settings.local.json` | No (gitignored) |
 
 ## Cost Tracking
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -65,6 +65,29 @@ claudectl --hooks                            # List configured hooks
 claudectl --clean --older-than 7d --dry-run  # Preview cleanup
 ```
 
+### Setup
+
+```bash
+claudectl --init                             # Wire up Claude Code hooks (global)
+claudectl --init --project-local             # Wire up hooks for this project only
+claudectl --uninstall                        # Remove claudectl hooks (global)
+claudectl --uninstall --project-local        # Remove hooks from project-local settings
+```
+
+`--init` writes three hooks into Claude Code's `~/.claude/settings.json`:
+
+| Hook | Matcher | Purpose |
+|------|---------|---------|
+| `PreToolUse` | `Bash` | Lets claudectl observe commands before execution |
+| `PostToolUse` | `*` | Notifies claudectl after every tool completion |
+| `Stop` | (all) | Notifies claudectl when a session ends |
+
+The hooks call `claudectl --json` on each event. They are safe to run alongside any existing hooks — `--init` merges without overwriting.
+
+Use `--project-local` to write to `.claude/settings.local.json` (gitignored) instead of the global file. This is useful when you want claudectl hooks only in specific projects.
+
+`--uninstall` removes only claudectl hook entries, preserving all other settings and hooks. If the file becomes empty after removal, it is deleted.
+
 ## Cost Tracking
 
 - Per-session USD estimates (Opus, Sonnet, Haiku model pricing)
@@ -87,6 +110,72 @@ claudectl reads Claude Code's local data — no API keys, no network access, no 
 - **`/tmp/claude-{uid}/{slug}/{sessionId}/tasks/`** — subagent task files
 
 Status inference combines multiple signals: `waiting_for_task` events, CPU usage thresholds, `stop_reason` fields, and message recency.
+
+### Brain Query
+
+Query the brain for a single tool-call decision without the TUI. Used by the Claude Code plugin hook, but also useful for scripting and testing:
+
+```bash
+claudectl --brain --brain-query --tool Bash --tool-input "rm -rf /tmp"
+claudectl --brain --brain-query --tool Write --tool-input "src/main.rs" --project myapp
+```
+
+Output is JSON:
+
+```json
+{"action":"deny","reasoning":"Destructive command","confidence":0.95,"source":"brain","below_threshold":false,"threshold":0.6}
+```
+
+The decision flow is: deny rules (instant) -> approve rules (instant) -> LLM query -> adaptive threshold check.
+
+If the brain is unreachable, returns `{"action":"abstain","source":"error"}` so callers are never blocked.
+
+### Brain Gate Mode
+
+Control whether the brain hook evaluates tool calls:
+
+```bash
+claudectl --mode on                    # Brain evaluates tool calls (default)
+claudectl --mode off                   # Disable brain — all calls pass through
+claudectl --mode auto                  # Brain auto-approves above threshold
+claudectl --mode status                # Show current mode
+```
+
+| Mode | Approves safe calls | Denies dangerous calls | Low-confidence calls |
+|------|:---:|:---:|:---:|
+| `on` | Yes | Yes | Fall through to user |
+| `auto` | Yes | Yes | Auto-approve |
+| `off` | No | No | Fall through to user |
+
+Mode is stored in `~/.claudectl/brain/gate-mode`. File absent = `on` (default).
+
+## Claude Code Plugin
+
+claudectl includes a Claude Code plugin in `claude-plugin/` that integrates the brain directly into sessions.
+
+### Plugin Components
+
+| Component | Type | What it does |
+|-----------|------|-------------|
+| `brain-gate.sh` | PreToolUse hook | Queries the brain before Bash/Write/Edit/NotebookEdit calls |
+| `budget-check.sh` | PreToolUse hook | Denies tool calls when session exceeds budget |
+| `/brain` | Command | Toggle brain mode: `/brain on`, `/brain off`, `/brain auto` |
+| `/sessions` | Command | Show all active sessions with status, cost, and health |
+| `/spend` | Command | Cost breakdown by project and time window |
+| `/brain-stats` | Command | Brain learning metrics and accuracy |
+| Supervisor | Agent | Proactive session health triage |
+| Session Monitoring | Skill | Auto-activated awareness of claudectl capabilities |
+
+### How the brain gate hook works
+
+1. Claude Code fires a PreToolUse event with the tool name and input
+2. The hook checks `~/.claudectl/brain/gate-mode` — if `off`, exits immediately
+3. Calls `claudectl --brain --brain-query --tool <name> --tool-input <input>`
+4. claudectl checks static deny/approve rules first (instant, no LLM)
+5. If no rule matches, queries the local LLM brain
+6. Returns `{"decision":"approve"}` or `{"decision":"deny","reason":"..."}` to Claude Code
+
+In `on` mode, low-confidence brain approvals fall through to normal permission prompts. In `auto` mode, all brain approvals execute.
 
 ## Security
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -50,31 +50,118 @@ Multi-signal inference from CPU usage, JSONL events, and timestamps:
 | `?` | Toggle help overlay |
 | `q`/`Esc` | Quit |
 
-## CLI Modes
+## CLI Reference
 
-```bash
-claudectl                                    # Interactive TUI dashboard
-claudectl --watch                            # Stream status changes (no TUI)
-claudectl --list                             # Print session table and exit
-claudectl --json                             # Machine-readable output
-claudectl --history --since 24h              # Past sessions with cost
-claudectl --stats --since 7d                 # Aggregated statistics
-claudectl --doctor                           # Diagnose terminal support
-claudectl --config                           # Show resolved configuration
-claudectl --hooks                            # List configured hooks
-claudectl --clean --older-than 7d --dry-run  # Preview cleanup
-```
+### Dashboard
+
+| Flag | Description |
+|------|-------------|
+| (no flags) | Interactive TUI dashboard |
+| `-i`, `--interval <ms>` | Refresh interval in milliseconds (default: 2000) |
+| `--theme <dark\|light\|none>` | Color theme. Respects `NO_COLOR` env var |
+| `--debug` | Show timing metrics in the footer |
+| `--demo` | Run with fake sessions for screenshots and demos |
+
+### Output Modes
+
+| Flag | Description |
+|------|-------------|
+| `-l`, `--list` | Print session table to stdout and exit |
+| `--json` | Print JSON array of sessions and exit |
+| `-w`, `--watch` | Stream status changes to stdout (no TUI) |
+| `--format <template>` | Custom format for `--watch`. Placeholders: `{pid}`, `{project}`, `{status}`, `{cost}`, `{context}` |
+| `--summary` | Show activity summary and exit |
+| `--since <duration>` | Time window for `--summary`, `--history`, `--stats` (e.g., "8h", "24h", "7d"). Default: 24h |
+
+### Filtering
+
+| Flag | Description |
+|------|-------------|
+| `--filter-status <status>` | Filter by status: NeedsInput, Processing, Waiting, Finished, etc. |
+| `--focus <filter>` | High-signal subset: `attention`, `over-budget`, `high-context`, `unknown-telemetry`, `conflict` |
+| `--search <text>` | Search project/model/session text |
+
+### Session Management
+
+| Flag | Description |
+|------|-------------|
+| `--new` | Launch a new Claude Code session |
+| `--cwd <path>` | Working directory for the new session (default: `.`) |
+| `--prompt <text>` | Prompt to send to the new session |
+| `--resume <session-id>` | Resume a previous session by ID |
+
+### Budget & Notifications
+
+| Flag | Description |
+|------|-------------|
+| `--budget <usd>` | Per-session budget in USD. Alert at 80%, optionally kill at 100% |
+| `--kill-on-budget` | Auto-kill sessions that exceed budget (requires `--budget`) |
+| `--notify` | Desktop notifications on NeedsInput transitions |
+| `--webhook <url>` | Webhook URL to POST JSON on status changes |
+| `--webhook-on <statuses>` | Only fire webhook on these transitions (comma-separated, e.g. "NeedsInput,Finished") |
+
+### Brain (Local LLM)
+
+| Flag | Description |
+|------|-------------|
+| `--brain` | Enable local LLM brain for session advisory |
+| `--auto-run` | Auto-execute brain suggestions without confirmation |
+| `--url <endpoint>` | LLM endpoint URL (maps to config `[brain] endpoint`) |
+| `--brain-model <name>` | Override brain model name (maps to config `[brain] model`) |
+| `--brain-eval` | Run brain eval scenarios against the LLM and report results |
+| `--brain-prompts` | List brain prompt templates and their source (built-in vs user override) |
+| `--brain-stats <metric>` | Brain statistics: `learning-curve`, `accuracy`, `baseline`, `false-approve` |
+| `--brain-query` | Query brain for a single tool-call decision (JSON output) |
+| `--tool <name>` | Tool name for `--brain-query` (e.g., "Bash", "Write") |
+| `--tool-input <input>` | Command or file path for `--brain-query` |
+| `--project <name>` | Project name for `--brain-query` (default: current directory name) |
+| `--mode <on\|off\|auto\|status>` | Set brain gate mode (see Brain Gate Mode below) |
+
+### Orchestration
+
+| Flag | Description |
+|------|-------------|
+| `--decompose <prompt>` | Analyze a prompt and suggest parallel sub-tasks (outputs JSON) |
+| `--run <file>` | Run tasks from a JSON file |
+| `--parallel` | Run independent tasks in parallel (used with `--run`) |
+
+### Recording
+
+| Flag | Description |
+|------|-------------|
+| `--record <path>` | Record the TUI as an asciicast v2 file (e.g., `--record demo.cast`) |
+| `--duration <secs>` | Auto-quit after N seconds (useful with `--demo --record`) |
+
+### Cleanup
+
+| Flag | Description |
+|------|-------------|
+| `--clean` | Clean up old session data (JSONL transcripts, session JSON files) |
+| `--older-than <duration>` | Only clean sessions older than this (e.g., "7d", "24h") |
+| `--finished` | Only clean sessions that have finished |
+| `--dry-run` | Show what would be removed without deleting |
+
+### History & Diagnostics
+
+| Flag | Description |
+|------|-------------|
+| `--history` | Show completed session history and exit |
+| `--stats` | Show aggregated session statistics and exit |
+| `--config` | Show resolved configuration and exit |
+| `--config-template` | Print annotated default config template to stdout |
+| `--hooks` | List configured event hooks and exit |
+| `--doctor` | Diagnose terminal integration and setup |
+| `--log <path>` | Write diagnostic logs to a file |
 
 ### Setup
 
-```bash
-claudectl --init                             # Wire up Claude Code hooks (global)
-claudectl --init --project-local             # Wire up hooks for this project only
-claudectl --uninstall                        # Remove claudectl hooks (global)
-claudectl --uninstall --project-local        # Remove hooks from project-local settings
-```
+| Flag | Description |
+|------|-------------|
+| `--init` | Wire up Claude Code hooks in `~/.claude/settings.json` |
+| `--uninstall` | Remove claudectl hooks from settings |
+| `--project-local` | Target `.claude/settings.local.json` instead of global |
 
-`--init` writes three hooks into Claude Code's `~/.claude/settings.json`:
+`--init` writes three hooks into Claude Code's settings:
 
 | Hook | Matcher | Purpose |
 |------|---------|---------|
@@ -84,9 +171,14 @@ claudectl --uninstall --project-local        # Remove hooks from project-local s
 
 The hooks call `claudectl --json` on each event. They are safe to run alongside any existing hooks — `--init` merges without overwriting.
 
-Use `--project-local` to write to `.claude/settings.local.json` (gitignored) instead of the global file. This is useful when you want claudectl hooks only in specific projects.
+Use `--project-local` to write to `.claude/settings.local.json` (gitignored) instead of the global file.
 
 `--uninstall` removes only claudectl hook entries, preserving all other settings and hooks. If the file becomes empty after removal, it is deleted.
+
+| Scope | Flag | File | Committed to git? |
+|-------|------|------|--------------------|
+| Global | `--init` | `~/.claude/settings.json` | No (user home) |
+| Project | `--init --project-local` | `.claude/settings.local.json` | No (gitignored) |
 
 ## Cost Tracking
 
@@ -187,4 +279,4 @@ claudectl runs entirely locally. It reads Claude Code's session files from disk 
 
 Webhook payloads contain session metadata (project name, cost, status). Review your webhook URL and event filters before enabling.
 
-The brain feature sends session context to a **local** LLM endpoint (default `localhost:11434`). No data leaves your machine unless you point `--brain-endpoint` at a remote server.
+The brain feature sends session context to a **local** LLM endpoint (default `localhost:11434`). No data leaves your machine unless you point `--url` at a remote server.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,7 @@
 
 ## No sessions found
 
+- Run `claudectl --init` if you haven't already -- this wires up the Claude Code hooks
 - Ensure Claude Code is running (`claude` in another terminal)
 - Check that `~/.claude/sessions/` contains `.json` files
 - Run `claudectl --log /tmp/claudectl.log` and check the log
@@ -25,10 +26,24 @@ claudectl reads token usage from JSONL logs. If the session just started, wait f
 
 Increase the poll interval: `claudectl --interval 3000` (default is 2000ms).
 
+## Brain not responding
+
+- Check the brain endpoint is running: `curl http://localhost:11434/api/tags`
+- Check brain gate mode: `claudectl --mode status` (if `off`, the brain is disabled)
+- Check the brain model is loaded: `ollama list`
+- Run `claudectl --doctor` for a full diagnostic
+
+## Plugin hook not firing
+
+- Verify the plugin is installed and enabled in Claude Code
+- Check that `claudectl` is on your PATH: `which claudectl`
+- Test the brain query manually: `claudectl --brain --brain-query --tool Bash --tool-input "echo hi"`
+- Check brain gate mode: `claudectl --mode status`
+
 ## FAQ
 
 **Does claudectl modify Claude Code or its files?**
-No. It is read-only. The only writes are to its own history file and log file.
+Only `--init` and `--uninstall` write to `.claude/settings.json` (to add/remove hooks). Everything else is read-only. The only other writes are to claudectl's own history and log files.
 
 **Does it need an API key?**
 No. It reads local files on disk. No network access required (unless you configure webhooks).

--- a/scripts/record-demos.sh
+++ b/scripts/record-demos.sh
@@ -106,10 +106,20 @@ case "$target" in
         record_gif "demo-overview" 12 "Live dashboard — status, cost, context at a glance"
         ;;&
 
+    social)
+        # 30-second showcase for social media (README, Twitter, etc.)
+        record_gif "demo-social" 30 "30s social media showcase — brain + health + orchestration"
+        echo ""
+        echo "Next steps for social sharing:"
+        echo "  1. Compress: gifsicle -O3 --lossy=80 $OUT_DIR/demo-social.gif -o $OUT_DIR/demo-social-opt.gif"
+        echo "  2. Add to README above the asciinema embed"
+        echo "  3. Upload to GitHub release assets for hotlinking"
+        ;;
+
     *)
-        if [ "$target" != "all" ] && [ "$target" != "hero" ] && [ "$target" != "health" ] && [ "$target" != "brain" ] && [ "$target" != "overview" ]; then
+        if [ "$target" != "all" ] && [ "$target" != "hero" ] && [ "$target" != "health" ] && [ "$target" != "brain" ] && [ "$target" != "overview" ] && [ "$target" != "social" ]; then
             echo "Unknown target: $target"
-            echo "Usage: $0 [all|hero|health|brain|overview]"
+            echo "Usage: $0 [all|hero|health|brain|overview|social]"
             exit 1
         fi
         ;;

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,599 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// The hooks we install into Claude Code's settings.json.
+///
+/// We use `PostToolUse` with a wildcard matcher so claudectl sees every tool
+/// completion, and `Stop` to catch session endings. The commands call
+/// `claudectl --json` which is a lightweight, non-TUI snapshot that the
+/// brain / hooks system can consume.
+///
+/// We also wire up `PreToolUse` for Bash commands so claudectl's rule engine
+/// can evaluate deny rules before execution.
+struct HookSpec {
+    event: &'static str,
+    matcher: &'static str,
+    command: &'static str,
+    timeout: u32,
+}
+
+const HOOKS: &[HookSpec] = &[
+    HookSpec {
+        event: "PreToolUse",
+        matcher: "Bash",
+        command: "claudectl --json 2>/dev/null || true",
+        timeout: 5,
+    },
+    HookSpec {
+        event: "PostToolUse",
+        matcher: "*",
+        command: "claudectl --json 2>/dev/null || true",
+        timeout: 5,
+    },
+    HookSpec {
+        event: "Stop",
+        matcher: "",
+        command: "claudectl --json 2>/dev/null || true",
+        timeout: 5,
+    },
+];
+
+fn settings_path(project: bool) -> PathBuf {
+    if project {
+        PathBuf::from(".claude/settings.local.json")
+    } else {
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/tmp"));
+        home.join(".claude/settings.json")
+    }
+}
+
+fn build_hooks_value() -> serde_json::Value {
+    let mut hooks_map = serde_json::Map::new();
+
+    for spec in HOOKS {
+        let hook_entry = serde_json::json!({
+            "type": "command",
+            "command": spec.command,
+            "timeout": spec.timeout,
+        });
+
+        let matcher_entry = serde_json::json!({
+            "matcher": spec.matcher,
+            "hooks": [hook_entry],
+        });
+
+        let array = hooks_map
+            .entry(spec.event)
+            .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+        if let serde_json::Value::Array(arr) = array {
+            arr.push(matcher_entry);
+        }
+    }
+
+    serde_json::Value::Object(hooks_map)
+}
+
+/// Check if claudectl hooks are already present in existing settings.
+fn has_claudectl_hooks(existing: &serde_json::Value) -> bool {
+    if let Some(hooks) = existing.get("hooks") {
+        if let Some(obj) = hooks.as_object() {
+            for (_event, matchers) in obj {
+                if let Some(arr) = matchers.as_array() {
+                    for matcher_entry in arr {
+                        if let Some(inner_hooks) = matcher_entry.get("hooks") {
+                            if let Some(inner_arr) = inner_hooks.as_array() {
+                                for hook in inner_arr {
+                                    if let Some(cmd) = hook.get("command") {
+                                        if let Some(s) = cmd.as_str() {
+                                            if s.contains("claudectl") {
+                                                return true;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Merge claudectl hooks into existing settings, preserving all other keys
+/// and any non-claudectl hooks already defined.
+fn merge_hooks(existing: &mut serde_json::Value) {
+    let new_hooks = build_hooks_value();
+
+    let hooks_obj = existing
+        .as_object_mut()
+        .expect("settings must be an object")
+        .entry("hooks")
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+
+    if let (Some(target), Some(source)) = (hooks_obj.as_object_mut(), new_hooks.as_object()) {
+        for (event, new_matchers) in source {
+            let event_arr = target
+                .entry(event)
+                .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+            if let (Some(arr), Some(new_arr)) = (event_arr.as_array_mut(), new_matchers.as_array())
+            {
+                for new_matcher in new_arr {
+                    arr.push(new_matcher.clone());
+                }
+            }
+        }
+    }
+}
+
+/// Remove claudectl hooks from a matcher entry's inner hooks array.
+/// Returns true if any hooks remain after filtering.
+fn filter_claudectl_hooks(matcher_entry: &mut serde_json::Value) -> bool {
+    if let Some(inner_hooks) = matcher_entry.get_mut("hooks") {
+        if let Some(arr) = inner_hooks.as_array_mut() {
+            arr.retain(|hook| {
+                hook.get("command")
+                    .and_then(|c| c.as_str())
+                    .is_none_or(|s| !s.contains("claudectl"))
+            });
+            return !arr.is_empty();
+        }
+    }
+    true
+}
+
+/// Remove all claudectl hook entries from settings, preserving everything else.
+/// Returns the number of hook entries removed.
+fn remove_claudectl_hooks(settings: &mut serde_json::Value) -> usize {
+    let mut removed = 0;
+
+    let Some(hooks) = settings.get_mut("hooks") else {
+        return 0;
+    };
+    let Some(hooks_obj) = hooks.as_object_mut() else {
+        return 0;
+    };
+
+    // For each event, filter out matcher entries that contain claudectl commands
+    let mut empty_events = Vec::new();
+    for (event, matchers) in hooks_obj.iter_mut() {
+        if let Some(arr) = matchers.as_array_mut() {
+            let before = arr.len();
+            arr.retain_mut(filter_claudectl_hooks);
+            removed += before - arr.len();
+            if arr.is_empty() {
+                empty_events.push(event.clone());
+            }
+        }
+    }
+
+    // Remove event keys that are now empty
+    for event in empty_events {
+        hooks_obj.remove(&event);
+    }
+
+    // Remove the hooks key entirely if it's now empty
+    if hooks_obj.is_empty() {
+        if let Some(obj) = settings.as_object_mut() {
+            obj.remove("hooks");
+        }
+    }
+
+    removed
+}
+
+/// Run the uninit command: remove claudectl hooks from settings.json.
+pub fn run_uninit(project: bool) -> io::Result<()> {
+    let path = settings_path(project);
+
+    if !path.exists() {
+        println!(
+            "No settings file at {} — nothing to remove.",
+            path.display()
+        );
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string(&path)?;
+    let mut settings = match serde_json::from_str::<serde_json::Value>(&content) {
+        Ok(v) if v.is_object() => v,
+        _ => {
+            eprintln!(
+                "Error: {} is not valid JSON — refusing to modify.",
+                path.display()
+            );
+            std::process::exit(1);
+        }
+    };
+
+    if !has_claudectl_hooks(&settings) {
+        println!(
+            "No claudectl hooks found in {} — nothing to remove.",
+            path.display()
+        );
+        return Ok(());
+    }
+
+    let removed = remove_claudectl_hooks(&mut settings);
+
+    // If the settings object is now empty (only had hooks), remove the file
+    let is_empty = settings.as_object().is_some_and(|obj| obj.is_empty());
+
+    if is_empty {
+        std::fs::remove_file(&path)?;
+        println!(
+            "Removed {removed} claudectl hook(s) — {} was empty and has been deleted.",
+            path.display()
+        );
+    } else {
+        let json = serde_json::to_string_pretty(&settings)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        std::fs::write(&path, format!("{json}\n"))?;
+        println!(
+            "Removed {removed} claudectl hook(s) from {}",
+            path.display()
+        );
+    }
+
+    Ok(())
+}
+
+/// Run the init command: write Claude Code hooks into settings.json.
+pub fn run_init(project: bool) -> io::Result<()> {
+    let path = settings_path(project);
+
+    // Read existing settings or start fresh
+    let mut settings = if path.exists() {
+        let content = std::fs::read_to_string(&path)?;
+        match serde_json::from_str::<serde_json::Value>(&content) {
+            Ok(v) if v.is_object() => v,
+            Ok(_) => {
+                eprintln!(
+                    "Error: {} exists but is not a JSON object — refusing to overwrite.",
+                    path.display()
+                );
+                std::process::exit(1);
+            }
+            Err(e) => {
+                eprintln!(
+                    "Error: {} contains invalid JSON: {} — refusing to overwrite.",
+                    path.display(),
+                    e
+                );
+                std::process::exit(1);
+            }
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    // Check for existing claudectl hooks
+    if has_claudectl_hooks(&settings) {
+        println!("claudectl hooks already configured in {}", path.display());
+        println!("To re-initialize, run `claudectl init --remove` first.");
+        return Ok(());
+    }
+
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // Merge and write
+    merge_hooks(&mut settings);
+    let json = serde_json::to_string_pretty(&settings)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    std::fs::write(&path, format!("{json}\n"))?;
+
+    print_success(&path);
+
+    Ok(())
+}
+
+fn print_success(path: &Path) {
+    println!("Initialized claudectl hooks in {}", path.display());
+    println!();
+    println!("Hooks installed:");
+    println!("  PreToolUse (Bash)  — lets claudectl observe commands before execution");
+    println!("  PostToolUse (*)    — notifies claudectl after every tool completion");
+    println!("  Stop               — notifies claudectl when a session ends");
+    println!();
+    println!("Claude Code will now notify claudectl on each tool use.");
+    println!("Run `claudectl` to start the dashboard.");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_hooks_value() {
+        let hooks = build_hooks_value();
+        let obj = hooks.as_object().unwrap();
+
+        // Should have entries for PreToolUse, PostToolUse, and Stop
+        assert!(obj.contains_key("PreToolUse"));
+        assert!(obj.contains_key("PostToolUse"));
+        assert!(obj.contains_key("Stop"));
+
+        // Each event should have an array of matcher entries
+        for (_event, matchers) in obj {
+            let arr = matchers.as_array().unwrap();
+            assert!(!arr.is_empty());
+            for entry in arr {
+                assert!(entry.get("matcher").is_some());
+                assert!(entry.get("hooks").is_some());
+                let inner = entry["hooks"].as_array().unwrap();
+                assert_eq!(inner[0]["type"], "command");
+                assert!(inner[0]["command"].as_str().unwrap().contains("claudectl"));
+            }
+        }
+    }
+
+    #[test]
+    fn test_has_claudectl_hooks_empty() {
+        let settings = serde_json::json!({});
+        assert!(!has_claudectl_hooks(&settings));
+    }
+
+    #[test]
+    fn test_has_claudectl_hooks_present() {
+        let settings = serde_json::json!({
+            "hooks": {
+                "PostToolUse": [{
+                    "matcher": "*",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "claudectl --json 2>/dev/null || true",
+                        "timeout": 5
+                    }]
+                }]
+            }
+        });
+        assert!(has_claudectl_hooks(&settings));
+    }
+
+    #[test]
+    fn test_has_claudectl_hooks_other_hooks_only() {
+        let settings = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "echo hello",
+                        "timeout": 5
+                    }]
+                }]
+            }
+        });
+        assert!(!has_claudectl_hooks(&settings));
+    }
+
+    #[test]
+    fn test_merge_hooks_empty() {
+        let mut settings = serde_json::json!({});
+        merge_hooks(&mut settings);
+
+        assert!(settings.get("hooks").is_some());
+        let hooks = settings["hooks"].as_object().unwrap();
+        assert!(hooks.contains_key("PreToolUse"));
+        assert!(hooks.contains_key("PostToolUse"));
+        assert!(hooks.contains_key("Stop"));
+    }
+
+    #[test]
+    fn test_merge_hooks_preserves_existing() {
+        let mut settings = serde_json::json!({
+            "allowedTools": ["Bash", "Read"],
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Write",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "echo validate-write",
+                        "timeout": 10
+                    }]
+                }]
+            }
+        });
+
+        merge_hooks(&mut settings);
+
+        // Existing allowedTools preserved
+        assert_eq!(
+            settings["allowedTools"],
+            serde_json::json!(["Bash", "Read"])
+        );
+
+        // Existing PreToolUse Write hook preserved
+        let pre = settings["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(pre.len(), 2); // original Write + new Bash
+        assert_eq!(pre[0]["matcher"], "Write");
+        assert_eq!(pre[1]["matcher"], "Bash");
+
+        // New hooks added
+        assert!(settings["hooks"]["PostToolUse"].is_array());
+        assert!(settings["hooks"]["Stop"].is_array());
+    }
+
+    #[test]
+    fn test_run_init_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_file = dir.path().join(".claude/settings.local.json");
+
+        // Temporarily override HOME so settings_path uses our temp dir
+        // We test the file-writing logic directly instead
+        let parent = settings_file.parent().unwrap();
+        std::fs::create_dir_all(parent).unwrap();
+
+        let mut settings = serde_json::json!({});
+        merge_hooks(&mut settings);
+
+        let json = serde_json::to_string_pretty(&settings).unwrap();
+        std::fs::write(&settings_file, format!("{json}\n")).unwrap();
+
+        // Verify the file was created and is valid JSON
+        let content = std::fs::read_to_string(&settings_file).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(parsed.get("hooks").is_some());
+        assert!(has_claudectl_hooks(&parsed));
+    }
+
+    #[test]
+    fn test_settings_path_global() {
+        let path = settings_path(false);
+        let path_str = path.to_string_lossy();
+        assert!(path_str.ends_with(".claude/settings.json"));
+    }
+
+    #[test]
+    fn test_settings_path_project() {
+        let path = settings_path(true);
+        assert_eq!(path, PathBuf::from(".claude/settings.local.json"));
+    }
+
+    #[test]
+    fn test_remove_claudectl_hooks_all() {
+        let mut settings = serde_json::json!({});
+        merge_hooks(&mut settings);
+        assert!(has_claudectl_hooks(&settings));
+
+        let removed = remove_claudectl_hooks(&mut settings);
+        assert_eq!(removed, 3); // PreToolUse, PostToolUse, Stop
+        assert!(!has_claudectl_hooks(&settings));
+        // hooks key removed entirely when empty
+        assert!(settings.get("hooks").is_none());
+    }
+
+    #[test]
+    fn test_remove_claudectl_hooks_preserves_others() {
+        let mut settings = serde_json::json!({
+            "allowedTools": ["Bash"],
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Write",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "echo validate-write",
+                            "timeout": 10
+                        }]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "claudectl --json 2>/dev/null || true",
+                            "timeout": 5
+                        }]
+                    }
+                ],
+                "PostToolUse": [{
+                    "matcher": "*",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "claudectl --json 2>/dev/null || true",
+                        "timeout": 5
+                    }]
+                }]
+            }
+        });
+
+        let removed = remove_claudectl_hooks(&mut settings);
+        assert_eq!(removed, 2); // Bash from PreToolUse + PostToolUse entry
+
+        // Write hook in PreToolUse preserved
+        let pre = settings["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(pre.len(), 1);
+        assert_eq!(pre[0]["matcher"], "Write");
+
+        // PostToolUse event removed entirely (was only claudectl)
+        assert!(settings["hooks"].get("PostToolUse").is_none());
+
+        // allowedTools untouched
+        assert_eq!(settings["allowedTools"], serde_json::json!(["Bash"]));
+    }
+
+    #[test]
+    fn test_remove_claudectl_hooks_noop_when_absent() {
+        let mut settings = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "echo hello",
+                        "timeout": 5
+                    }]
+                }]
+            }
+        });
+
+        let removed = remove_claudectl_hooks(&mut settings);
+        assert_eq!(removed, 0);
+        // Original hook still present
+        assert!(settings["hooks"]["PreToolUse"].as_array().unwrap().len() == 1);
+    }
+
+    #[test]
+    fn test_remove_then_no_hooks_key() {
+        // Settings that only had claudectl hooks — hooks key should be removed entirely
+        let mut settings = serde_json::json!({ "permissions": {} });
+        merge_hooks(&mut settings);
+        remove_claudectl_hooks(&mut settings);
+
+        assert!(settings.get("hooks").is_none());
+        // Other keys preserved
+        assert!(settings.get("permissions").is_some());
+    }
+
+    #[test]
+    fn test_init_uninit_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings_file = dir.path().join("settings.json");
+
+        // Start with existing settings
+        let original = serde_json::json!({
+            "allowedTools": ["Read", "Glob"],
+            "hooks": {
+                "SessionStart": [{
+                    "matcher": "*",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "echo started",
+                        "timeout": 5
+                    }]
+                }]
+            }
+        });
+        let json = serde_json::to_string_pretty(&original).unwrap();
+        std::fs::write(&settings_file, &json).unwrap();
+
+        // Init: merge claudectl hooks in
+        let content = std::fs::read_to_string(&settings_file).unwrap();
+        let mut settings: serde_json::Value = serde_json::from_str(&content).unwrap();
+        merge_hooks(&mut settings);
+        let json = serde_json::to_string_pretty(&settings).unwrap();
+        std::fs::write(&settings_file, &json).unwrap();
+        assert!(has_claudectl_hooks(&settings));
+
+        // Uninit: remove claudectl hooks
+        let content = std::fs::read_to_string(&settings_file).unwrap();
+        let mut settings: serde_json::Value = serde_json::from_str(&content).unwrap();
+        remove_claudectl_hooks(&mut settings);
+
+        // Back to original state
+        assert!(!has_claudectl_hooks(&settings));
+        assert_eq!(
+            settings["allowedTools"],
+            serde_json::json!(["Read", "Glob"])
+        );
+        let session_start = settings["hooks"]["SessionStart"].as_array().unwrap();
+        assert_eq!(session_start.len(), 1);
+        assert_eq!(session_start[0]["hooks"][0]["command"], "echo started");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod discovery;
 pub mod health;
 pub mod history;
 pub mod hooks;
+pub mod init;
 pub mod launch;
 pub mod logger;
 pub mod models;

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,9 +281,9 @@ struct Cli {
     #[arg(long, help_heading = "Setup", conflicts_with = "init")]
     uninstall: bool,
 
-    /// Target .claude/settings.local.json (project-local) instead of ~/.claude/settings.json (global)
-    #[arg(long = "project-local", help_heading = "Setup")]
-    project_local: bool,
+    /// Configuration scope: user (global ~/.claude/settings.json) or project (.claude/settings.local.json)
+    #[arg(short, long, default_value = "user", help_heading = "Setup")]
+    scope: String,
 }
 
 fn main() -> io::Result<()> {
@@ -402,11 +402,13 @@ fn run_main(cli: Cli) -> io::Result<()> {
     }
 
     if cli.init {
-        return init::run_init(cli.project_local);
+        let project = cli.scope == "project";
+        return init::run_init(project);
     }
 
     if cli.uninstall {
-        return init::run_uninit(cli.project_local);
+        let project = cli.scope == "project";
+        return init::run_uninit(project);
     }
 
     if cli.brain_prompts {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod discovery;
 mod health;
 mod history;
 mod hooks;
+mod init;
 mod launch;
 mod logger;
 mod models;
@@ -181,6 +182,28 @@ struct Cli {
     #[arg(long, help_heading = "Brain (Local LLM)")]
     brain_stats: Option<String>,
 
+    /// Query the brain for a single tool-call decision and exit (JSON output).
+    /// Used by Claude Code plugin hooks for inline approve/deny.
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    brain_query: bool,
+
+    /// Tool name for --brain-query (e.g., "Bash", "Write", "Edit")
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    tool: Option<String>,
+
+    /// Command or input for --brain-query (e.g., "rm -rf /tmp")
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    tool_input: Option<String>,
+
+    /// Project name for --brain-query context (defaults to current directory name)
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    project: Option<String>,
+
+    /// Set brain gate mode: on (default), off (disable), auto (full auto-approve).
+    /// Controls whether the Claude Code plugin hook queries the brain.
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    mode: Option<String>,
+
     // ── Orchestration ──────────────────────────────────────────────────
     /// Analyze a prompt and suggest parallel sub-tasks (outputs TaskFile JSON)
     #[arg(long, help_heading = "Orchestration")]
@@ -248,6 +271,19 @@ struct Cli {
     /// Write diagnostic logs to a file (for debugging/bug reports)
     #[arg(long, help_heading = "History & Diagnostics")]
     log: Option<String>,
+
+    // ── Setup ─────────────────────────────────────────────────────────
+    /// Wire up Claude Code hooks in .claude/settings.json and exit
+    #[arg(long, help_heading = "Setup")]
+    init: bool,
+
+    /// Remove claudectl hooks from .claude/settings.json and exit
+    #[arg(long, help_heading = "Setup", conflicts_with = "init")]
+    uninstall: bool,
+
+    /// Target .claude/settings.local.json (project-local) instead of ~/.claude/settings.json (global)
+    #[arg(long = "project-local", help_heading = "Setup")]
+    project_local: bool,
 }
 
 fn main() -> io::Result<()> {
@@ -365,6 +401,14 @@ fn run_main(cli: Cli) -> io::Result<()> {
         return print_doctor();
     }
 
+    if cli.init {
+        return init::run_init(cli.project_local);
+    }
+
+    if cli.uninstall {
+        return init::run_uninit(cli.project_local);
+    }
+
     if cli.brain_prompts {
         println!("Brain Prompt Templates");
         println!("======================");
@@ -394,6 +438,14 @@ fn run_main(cli: Cli) -> io::Result<()> {
     if let Some(ref subcommand) = cli.brain_stats {
         brain::metrics::dispatch(subcommand);
         return Ok(());
+    }
+
+    if cli.brain_query {
+        return run_brain_query(&cfg, &cli);
+    }
+
+    if let Some(ref mode) = cli.mode {
+        return run_brain_mode(mode);
     }
 
     if let Some(ref prompt) = cli.decompose {
@@ -1396,6 +1448,236 @@ fn run_tui<W: io::Write>(
                     }
                 }
             }
+        }
+    }
+}
+
+/// Path to the brain gate mode state file.
+fn brain_gate_mode_path() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    std::path::PathBuf::from(home)
+        .join(".claudectl")
+        .join("brain")
+        .join("gate-mode")
+}
+
+/// Read the current brain gate mode from disk. Returns "on" if no file exists.
+fn read_brain_gate_mode() -> String {
+    let path = brain_gate_mode_path();
+    std::fs::read_to_string(&path)
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|_| "on".into())
+}
+
+/// Set the brain gate mode (on/off/auto) and print confirmation.
+fn run_brain_mode(mode: &str) -> io::Result<()> {
+    match mode {
+        "on" | "off" | "auto" => {}
+        "status" | "" => {
+            let current = read_brain_gate_mode();
+            println!("Brain gate mode: {current}");
+            println!();
+            println!("Modes:");
+            println!("  on   — brain evaluates tool calls, denies dangerous ones (default)");
+            println!("  off  — brain disabled, all tool calls pass through");
+            println!("  auto — brain auto-approves above confidence threshold");
+            return Ok(());
+        }
+        _ => {
+            eprintln!("Unknown brain mode: {mode}");
+            eprintln!("Valid modes: on, off, auto, status");
+            std::process::exit(1);
+        }
+    }
+
+    let path = brain_gate_mode_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    if mode == "on" {
+        // "on" is the default — remove the file so absence = on
+        let _ = std::fs::remove_file(&path);
+    } else {
+        std::fs::write(&path, mode)?;
+    }
+
+    let description = match mode {
+        "on" => "brain evaluates tool calls, denies dangerous ones",
+        "off" => "brain disabled — all tool calls pass through to normal permission flow",
+        "auto" => "brain auto-approves tool calls above confidence threshold",
+        _ => unreachable!(),
+    };
+
+    println!("Brain gate mode set to: {mode}");
+    println!("  {description}");
+    Ok(())
+}
+
+/// Standalone brain query: builds a minimal context from CLI args, calls the
+/// local LLM, and prints a JSON decision to stdout. Designed to be called
+/// by Claude Code plugin hooks (PreToolUse) for inline approve/deny.
+fn run_brain_query(cfg: &config::Config, cli: &Cli) -> io::Result<()> {
+    // Respect brain gate mode — if off, skip immediately
+    let gate_mode = read_brain_gate_mode();
+    if gate_mode == "off" {
+        let result = serde_json::json!({
+            "action": "abstain",
+            "reasoning": "Brain gate mode is off",
+            "confidence": 0.0,
+            "source": "gate",
+        });
+        println!("{}", serde_json::to_string(&result).unwrap());
+        return Ok(());
+    }
+
+    let brain_cfg = cfg.brain.clone().unwrap_or_default();
+
+    if !brain_cfg.enabled && !cli.brain {
+        eprintln!("Brain is not enabled. Use --brain or set brain.enabled = true in config.");
+        std::process::exit(1);
+    }
+
+    let tool_name = cli.tool.clone().unwrap_or_else(|| "unknown".into());
+    let command = cli.tool_input.clone().unwrap_or_default();
+    let project = cli.project.clone().unwrap_or_else(|| {
+        std::env::current_dir()
+            .ok()
+            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .unwrap_or_else(|| "unknown".into())
+    });
+
+    // Step 1: Check static deny rules first (instant, no LLM needed)
+    let auto_rules = cfg.rules.clone();
+    let deny_rules: Vec<_> = auto_rules
+        .iter()
+        .filter(|r| r.action == rules::RuleAction::Deny)
+        .cloned()
+        .collect();
+
+    // Build a minimal synthetic session for rule matching
+    let mut synthetic = session::ClaudeSession::from_raw(session::RawSession {
+        pid: std::process::id(),
+        session_id: "brain-query".into(),
+        cwd: std::env::current_dir()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| ".".into()),
+        started_at: 0,
+    });
+    synthetic.project_name = project.clone();
+    synthetic.status = session::SessionStatus::NeedsInput;
+    synthetic.pending_tool_name = Some(tool_name.clone());
+    synthetic.pending_tool_input = if command.is_empty() {
+        None
+    } else {
+        Some(command.clone())
+    };
+
+    // Check deny rules
+    if let Some(deny_match) = rules::evaluate(&deny_rules, &synthetic) {
+        let result = serde_json::json!({
+            "action": "deny",
+            "reasoning": format!("Deny rule '{}' matched", deny_match.rule_name),
+            "confidence": 1.0,
+            "source": "rule",
+        });
+        println!("{}", serde_json::to_string(&result).unwrap());
+        return Ok(());
+    }
+
+    // Step 2: Check approve rules
+    let approve_rules: Vec<_> = auto_rules
+        .iter()
+        .filter(|r| r.action == rules::RuleAction::Approve)
+        .cloned()
+        .collect();
+    if let Some(approve_match) = rules::evaluate(&approve_rules, &synthetic) {
+        let result = serde_json::json!({
+            "action": "approve",
+            "reasoning": format!("Approve rule '{}' matched", approve_match.rule_name),
+            "confidence": 1.0,
+            "source": "rule",
+        });
+        println!("{}", serde_json::to_string(&result).unwrap());
+        return Ok(());
+    }
+
+    // Step 3: Query the LLM brain
+    let tool_display = if command.is_empty() {
+        tool_name.clone()
+    } else {
+        format!("{tool_name}: {command}")
+    };
+
+    let session_summary = format!(
+        "Project: {project} | Status: Needs Input | Pending tool: {tool_name} | Command: {command}"
+    );
+
+    // Load distilled preferences
+    let pref_section = if let Some(prefs) = brain::decisions::load_preferences_for_project(&project)
+    {
+        let summary = brain::decisions::format_preference_summary(&prefs);
+        format!("\n\n## Learned Preferences\n{summary}")
+    } else {
+        String::new()
+    };
+
+    // Load few-shot examples
+    let few_shot_section = {
+        let similar = brain::decisions::retrieve_similar(
+            Some(&tool_name),
+            &project,
+            brain_cfg.few_shot_count.min(5),
+            Some(brain::decisions::DecisionType::Session),
+        );
+        if similar.is_empty() {
+            String::new()
+        } else {
+            let examples = brain::decisions::format_few_shot_examples(&similar);
+            format!("\n\n## Past Decisions\n{examples}")
+        }
+    };
+
+    let prompt = format!(
+        "You are a session supervisor deciding whether to approve or deny a tool call.\n\
+         \n## Session\n{session_summary}\
+         {pref_section}\
+         {few_shot_section}\n\
+         \n## Decision\n\
+         The session wants to run [{tool_display}]. \
+         Should this be approved or denied? \
+         Respond with JSON: {{\"action\": \"approve\"|\"deny\", \
+         \"message\": \"...\", \"reasoning\": \"...\", \"confidence\": 0.0-1.0}}"
+    );
+
+    match brain::client::infer(&brain_cfg, &prompt) {
+        Ok(suggestion) => {
+            // Check adaptive threshold
+            let threshold = brain::decisions::adaptive_threshold(Some(&tool_name)).unwrap_or(0.6);
+            let below_threshold = suggestion.confidence < threshold;
+
+            let result = serde_json::json!({
+                "action": suggestion.action.label(),
+                "reasoning": suggestion.reasoning,
+                "confidence": suggestion.confidence,
+                "message": suggestion.message,
+                "source": "brain",
+                "below_threshold": below_threshold,
+                "threshold": threshold,
+            });
+            println!("{}", serde_json::to_string(&result).unwrap());
+            Ok(())
+        }
+        Err(e) => {
+            // On brain failure, output abstain (don't block the user)
+            let result = serde_json::json!({
+                "action": "abstain",
+                "reasoning": format!("Brain query failed: {e}"),
+                "confidence": 0.0,
+                "source": "error",
+            });
+            println!("{}", serde_json::to_string(&result).unwrap());
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Claude Code plugin** (`claude-plugin/`) — integrates the brain directly into sessions via PreToolUse hooks. Includes `/sessions`, `/spend`, `/brain-stats`, `/brain` commands, a supervisor agent, and a session monitoring skill.
- **`--brain-query`** — standalone brain decision query (JSON output) for plugin hooks and scripting. Decision flow: deny rules → approve rules → LLM query → adaptive threshold.
- **`--mode on|off|auto`** — toggle brain gate mode mid-session. Stored in `~/.claudectl/brain/gate-mode`. Available as `/brain on|off|auto` in the plugin.
- **`--init` / `--uninstall`** — wire up or remove Claude Code hooks in `settings.json` with `--project-local` support.
- Version bump 0.30.0 → 0.31.0

## Test plan

- [x] `cargo build` compiles
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] All 674 tests pass
- [x] `claudectl --mode status/on/off/auto` works correctly
- [x] `claudectl --help` shows all new flags
- [ ] Manual: install plugin in Claude Code, verify `/brain`, `/sessions` commands work
- [ ] Manual: verify brain-gate hook fires on Bash/Write/Edit calls
- [ ] Manual: `claudectl --init` writes hooks to settings.json
- [ ] Manual: `claudectl --init --project-local` writes to .claude/settings.local.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)