### PR TITLE
feat: time-to-correct analysis with suggested_at timestamps

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -972,6 +972,7 @@ impl App {
                             message: s.pending_tool_input.clone(),
                             reasoning: "Safe build command, no side effects".into(),
                             confidence: 0.92,
+                            suggested_at: 0,
                         },
                     );
                 }
@@ -988,6 +989,7 @@ impl App {
                             message: s.pending_tool_input.clone(),
                             reasoning: "Destructive operation, needs manual review".into(),
                             confidence: 0.87,
+                            suggested_at: 0,
                         },
                     );
                 }

--- a/src/brain/client.rs
+++ b/src/brain/client.rs
@@ -12,6 +12,9 @@ pub struct BrainSuggestion {
     pub message: Option<String>,
     pub reasoning: String,
     pub confidence: f64,
+    /// Epoch seconds when this suggestion was created.
+    /// Used by time-to-correct analysis to measure user reaction latency.
+    pub suggested_at: u64,
 }
 
 /// Call the local LLM endpoint via curl and parse the response.
@@ -352,7 +355,15 @@ pub fn parse_suggestion_json(text: &str) -> Result<BrainSuggestion, String> {
         message,
         reasoning,
         confidence: confidence.clamp(0.0, 1.0),
+        suggested_at: epoch_secs(),
     })
+}
+
+fn epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 #[cfg(test)]

--- a/src/brain/decisions.rs
+++ b/src/brain/decisions.rs
@@ -55,6 +55,9 @@ pub struct DecisionRecord {
     /// Whether this was a session or orchestration decision.
     /// Defaults to Session for backwards compatibility with old records.
     pub decision_type: DecisionType,
+    /// Epoch seconds when the brain suggestion was created.
+    /// None for old records or observations. Used by time-to-correct analysis.
+    pub suggested_at: Option<u64>,
 }
 
 /// Outcome of a decision, backfilled during distillation by looking at
@@ -234,6 +237,7 @@ pub fn log_decision(
         "brain_reasoning": suggestion.reasoning,
         "user_action": user_action,
         "decision_type": decision_type.label(),
+        "suggested_at": suggestion.suggested_at,
     });
     if let Some(s) = session {
         record["context"] = snapshot_context(s);
@@ -1686,6 +1690,8 @@ pub fn read_all_decisions() -> Vec<DecisionRecord> {
                 context,
                 outcome: None, // Backfilled during distillation
                 decision_type,
+                // Backwards-compatible: old records won't have "suggested_at"
+                suggested_at: json.get("suggested_at").and_then(|v| v.as_u64()),
             })
         })
         .collect()
@@ -1730,6 +1736,7 @@ mod tests {
             message: None,
             reasoning: "safe command".into(),
             confidence: 0.95,
+            suggested_at: 0,
         }
     }
 
@@ -1811,6 +1818,7 @@ mod tests {
             context: None,
             outcome: None,
             decision_type: DecisionType::Session,
+            suggested_at: None,
         }
     }
 
@@ -1833,6 +1841,7 @@ mod tests {
             context: None,
             outcome: None,
             decision_type: DecisionType::Session,
+            suggested_at: None,
         }
     }
 
@@ -1890,6 +1899,7 @@ mod tests {
             context: Some(ctx),
             outcome: None,
             decision_type: DecisionType::Session,
+            suggested_at: None,
         }
     }
 
@@ -1907,6 +1917,7 @@ mod tests {
             context: None,
             outcome: None,
             decision_type: DecisionType::Orchestration,
+            suggested_at: None,
         }
     }
 
@@ -2530,6 +2541,7 @@ mod tests {
                 context: Some(make_context(1.0, 50, false)),
                 outcome: None,
                 decision_type: DecisionType::Session,
+                suggested_at: None,
             },
             DecisionRecord {
                 timestamp: "2".into(),
@@ -2544,6 +2556,7 @@ mod tests {
                 context: Some(make_context(1.5, 55, true)),
                 outcome: None,
                 decision_type: DecisionType::Session,
+                suggested_at: None,
             },
         ];
 
@@ -2577,6 +2590,7 @@ mod tests {
                 context: Some(make_context(1.0, 50, true)),
                 outcome: None,
                 decision_type: DecisionType::Session,
+                suggested_at: None,
             });
         }
         // Then user denies
@@ -2593,6 +2607,7 @@ mod tests {
             context: Some(make_context(1.0, 50, false)),
             outcome: None,
             decision_type: DecisionType::Session,
+            suggested_at: None,
         });
         // Repeat the streak pattern to reach threshold of 2
         for _ in 0..4 {
@@ -2609,6 +2624,7 @@ mod tests {
                 context: Some(make_context(1.0, 50, true)),
                 outcome: None,
                 decision_type: DecisionType::Session,
+                suggested_at: None,
             });
         }
         decisions.push(DecisionRecord {
@@ -2624,6 +2640,7 @@ mod tests {
             context: Some(make_context(1.0, 50, false)),
             outcome: None,
             decision_type: DecisionType::Session,
+            suggested_at: None,
         });
 
         let patterns = detect_temporal_patterns(&decisions);

--- a/src/brain/engine.rs
+++ b/src/brain/engine.rs
@@ -821,6 +821,7 @@ mod tests {
             message: None,
             reasoning: "safe".into(),
             confidence: 0.95,
+            suggested_at: 0,
         };
         let rm = suggestion_to_rule_match(&suggestion);
         assert_eq!(rm.action, RuleAction::Approve);
@@ -837,6 +838,7 @@ mod tests {
                 message: None,
                 reasoning: "test".into(),
                 confidence: 0.9,
+                suggested_at: 0,
             },
         );
 
@@ -856,6 +858,7 @@ mod tests {
                 message: None,
                 reasoning: "test".into(),
                 confidence: 0.9,
+                suggested_at: 0,
             },
         );
 
@@ -1024,6 +1027,7 @@ mod tests {
                 message: None,
                 reasoning: "test".into(),
                 confidence: 0.9,
+                suggested_at: 0,
             },
         );
 

--- a/src/brain/insights.rs
+++ b/src/brain/insights.rs
@@ -881,6 +881,7 @@ mod tests {
             context: None,
             outcome: None,
             decision_type: DecisionType::Session,
+            suggested_at: None,
         }
     }
 

--- a/src/brain/metrics.rs
+++ b/src/brain/metrics.rs
@@ -1448,6 +1448,160 @@ pub fn print_incidents() {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// #132: Time-to-correct analysis
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Print time-to-correct analysis — how quickly users respond to brain suggestions.
+pub fn print_time_to_correct() {
+    let decisions = read_all_decisions();
+    let total = decisions.len();
+
+    println!("Time-to-Correct Analysis");
+    println!("=========================");
+    println!();
+
+    if total < 5 {
+        println!("  Not enough decisions yet ({total}). Need at least 5.");
+        return;
+    }
+
+    // Find decisions with both suggested_at and ts (parsed as epoch secs)
+    let mut reaction_times: Vec<(usize, f64, bool)> = Vec::new(); // (index, seconds, is_correction)
+
+    for (idx, d) in decisions.iter().enumerate() {
+        let Some(suggested_at) = d.suggested_at else {
+            continue;
+        };
+        if suggested_at == 0 {
+            continue;
+        }
+
+        // Parse the ts field (could be epoch seconds as string or number)
+        let responded_at: u64 = d.timestamp.trim_matches('"').parse::<u64>().unwrap_or(0);
+        if responded_at == 0 || responded_at < suggested_at {
+            continue;
+        }
+
+        let reaction_secs = (responded_at - suggested_at) as f64;
+        // Cap at 5 minutes — anything longer is likely the user was away
+        if reaction_secs > 300.0 {
+            continue;
+        }
+
+        let is_correction = d.is_negative();
+        reaction_times.push((idx, reaction_secs, is_correction));
+    }
+
+    if reaction_times.is_empty() {
+        println!("  No reaction time data available yet.");
+        println!("  This requires brain suggestions with the suggested_at timestamp");
+        println!("  (available in decisions logged after v0.31.1).");
+        return;
+    }
+
+    // Categorize: fast (<2s), moderate (2-5s), deliberate (>5s)
+    let fast = reaction_times.iter().filter(|(_, t, _)| *t < 2.0).count();
+    let moderate = reaction_times
+        .iter()
+        .filter(|(_, t, _)| *t >= 2.0 && *t < 5.0)
+        .count();
+    let deliberate = reaction_times.iter().filter(|(_, t, _)| *t >= 5.0).count();
+    let total_reactions = reaction_times.len();
+
+    let avg_time: f64 =
+        reaction_times.iter().map(|(_, t, _)| t).sum::<f64>() / total_reactions as f64;
+
+    println!("  {} decisions with reaction time data", total_reactions);
+    println!("  Average reaction time: {:.1}s", avg_time);
+    println!();
+
+    // Distribution
+    println!("  Reaction speed:");
+    println!(
+        "    Fast (<2s):      {:>4} ({:.0}%)  — gut reaction",
+        fast,
+        fast as f64 / total_reactions as f64 * 100.0,
+    );
+    println!(
+        "    Moderate (2-5s): {:>4} ({:.0}%)  — quick review",
+        moderate,
+        moderate as f64 / total_reactions as f64 * 100.0,
+    );
+    println!(
+        "    Deliberate (>5s):{:>4} ({:.0}%)  — careful consideration",
+        deliberate,
+        deliberate as f64 / total_reactions as f64 * 100.0,
+    );
+    println!();
+
+    // Corrections vs accepts
+    let corrections: Vec<&(usize, f64, bool)> =
+        reaction_times.iter().filter(|(_, _, c)| *c).collect();
+    let accepts: Vec<&(usize, f64, bool)> = reaction_times.iter().filter(|(_, _, c)| !*c).collect();
+
+    if !corrections.is_empty() {
+        let avg_correction =
+            corrections.iter().map(|(_, t, _)| t).sum::<f64>() / corrections.len() as f64;
+        let avg_accept = if accepts.is_empty() {
+            0.0
+        } else {
+            accepts.iter().map(|(_, t, _)| t).sum::<f64>() / accepts.len() as f64
+        };
+
+        println!("  Corrections vs accepts:");
+        println!(
+            "    Avg correction time: {:.1}s ({} corrections)",
+            avg_correction,
+            corrections.len()
+        );
+        println!(
+            "    Avg accept time:     {:.1}s ({} accepts)",
+            avg_accept,
+            accepts.len()
+        );
+
+        if avg_correction > avg_accept + 1.0 {
+            println!(
+                "    Corrections take longer — user deliberates before overriding (good signal)"
+            );
+        } else if avg_accept > avg_correction + 1.0 {
+            println!("    Accepts take longer than corrections — possible rubber-stamping risk");
+        }
+    }
+
+    // Trend: compare first vs last half reaction times
+    if total_reactions >= 10 {
+        let mid = total_reactions / 2;
+        let early_avg: f64 =
+            reaction_times[..mid].iter().map(|(_, t, _)| t).sum::<f64>() / mid as f64;
+        let late_avg: f64 = reaction_times[mid..].iter().map(|(_, t, _)| t).sum::<f64>()
+            / (total_reactions - mid) as f64;
+
+        println!();
+        println!("  Trend:");
+        println!("    Early avg: {:.1}s", early_avg);
+        println!("    Recent avg: {:.1}s", late_avg);
+
+        let delta = late_avg - early_avg;
+        if delta.abs() > 0.5 {
+            if delta > 0.0 {
+                println!(
+                    "    Slowing down ({:+.1}s) — may indicate decision fatigue or more nuanced calls",
+                    delta
+                );
+            } else {
+                println!(
+                    "    Speeding up ({:+.1}s) — user developing sharper judgment",
+                    delta
+                );
+            }
+        } else {
+            println!("    Stable (within 0.5s)");
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // #170: Impact scorecard
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -1681,6 +1835,7 @@ pub fn dispatch(subcommand: &str) {
         "novel-rate" | "novel" => print_novel_rate(),
         "calibration" | "cal" => print_calibration(),
         "incidents" | "postmortem" => print_incidents(),
+        "time-to-correct" | "ttc" => print_time_to_correct(),
         "help" | "" => print_help(),
         _ => {
             eprintln!("Unknown brain-stats subcommand: '{subcommand}'");
@@ -1707,9 +1862,10 @@ fn print_help() {
     println!("  false-approve   False-approve rate on risky actions (safety)");
     println!("  false-deny      False-deny rate and friction cost");
     println!("  incidents       Post-mortem analysis of every false approval");
+    println!("  time-to-correct How quickly users respond to brain suggestions");
     println!("  help            Show this help");
     println!();
-    println!("Aliases: curve, acc, rules, fa, fd, dist, novel, cal, postmortem");
+    println!("Aliases: curve, acc, rules, fa, fd, dist, novel, cal, postmortem, ttc");
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1938,6 +2094,7 @@ mod tests {
             context: None,
             outcome: None,
             decision_type: DecisionType::Session,
+            suggested_at: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Adds `suggested_at` timestamp to brain suggestions, enabling measurement of how quickly users respond to brain decisions. This is the last remaining metrics sub-issue under #127.

### Changes

1. **`BrainSuggestion.suggested_at`** — new `u64` field (epoch seconds) set when the suggestion is created
2. **JSONL persistence** — `suggested_at` written to decision records, parsed back on read (backwards compatible)
3. **`--brain-stats time-to-correct`** — new subcommand analyzing reaction latency

### What it measures

```
Time-to-Correct Analysis
=========================

  142 decisions with reaction time data
  Average reaction time: 3.2s

  Reaction speed:
    Fast (<2s):        47 (33%)  — gut reaction
    Moderate (2-5s):   68 (48%)  — quick review
    Deliberate (>5s):  27 (19%)  — careful consideration

  Corrections vs accepts:
    Avg correction time: 4.8s (23 corrections)
    Avg accept time:     2.7s (119 accepts)
    Corrections take longer — user deliberates before overriding (good signal)

  Trend:
    Early avg: 3.8s
    Recent avg: 2.6s
    Speeding up (-1.2s) — user developing sharper judgment
```

Closes #132

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo test` — all 700 tests pass
- [x] Backwards compatible — old records without `suggested_at` are skipped gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)