### PR TITLE
feat: add Ctrl+b TUI keybinding to toggle brain on/off

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 description = "Auto-pilot for Claude Code — a local model watches every session and decides what to approve"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The brain observes all your sessions and makes real-time decisions:
 ollama pull gemma4:e4b && ollama serve    # One-time setup
 claudectl --brain                         # Advisory mode (default)
 claudectl --brain --auto-run              # Auto mode: brain executes without asking
-claudectl --mode auto                     # Or toggle mid-session
+claudectl --mode auto                     # Or toggle mid-session (Ctrl+b in TUI)
 ```
 
 Works with any OpenAI-compatible endpoint: [ollama](https://ollama.com), [llama.cpp](https://github.com/ggerganov/llama.cpp), [vLLM](https://github.com/vllm-project/vllm), [LM Studio](https://lmstudio.ai).
@@ -128,7 +128,7 @@ Integrates the brain directly into Claude Code sessions — no TUI required.
 | Component | What it does |
 |-----------|-------------|
 | **Brain gate hook** | Queries the brain before every Bash/Write/Edit call |
-| `/brain on\|off\|auto` | Toggle brain mode mid-session |
+| `/brain on\|off\|auto` | Toggle brain mode mid-session (or `Ctrl+b` in TUI) |
 | `/sessions` | Show all active sessions with status, cost, health |
 | `/spend` | Cost breakdown by project and time window |
 | `/brain-stats` | Brain learning metrics and accuracy |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1720,6 +1720,11 @@ impl App {
                 self.cancel_pending_auto_approve();
                 self.handle_approve();
             }
+            (KeyCode::Char('b'), KeyModifiers::CONTROL) => {
+                self.cancel_pending_kill();
+                self.cancel_pending_auto_approve();
+                self.toggle_brain_gate();
+            }
             (KeyCode::Char('b'), _) => {
                 self.cancel_pending_kill();
                 self.cancel_pending_auto_approve();
@@ -2095,6 +2100,36 @@ impl App {
         } else {
             self.status_msg = "No brain suggestion pending for this session".into();
         }
+    }
+
+    fn toggle_brain_gate(&mut self) {
+        let current = crate::brain::read_gate_mode();
+        let next = match current.as_str() {
+            "on" => "off",
+            "off" => "on",
+            "auto" => "off",
+            _ => "on",
+        };
+
+        let path = crate::brain::gate_mode_path();
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+
+        if next == "on" {
+            // "on" is the default — remove the file so absence = on
+            let _ = std::fs::remove_file(&path);
+        } else {
+            let _ = std::fs::write(&path, next);
+        }
+
+        let description = match next {
+            "on" => "active — evaluating tool calls",
+            "off" => "disabled — normal permission flow",
+            _ => unreachable!(),
+        };
+        self.status_msg = format!("Brain: {description}");
+        crate::logger::log("BRAIN", &format!("Gate mode toggled: {current} → {next}"));
     }
 
     fn toggle_session_recording(&mut self) {

--- a/src/brain/mod.rs
+++ b/src/brain/mod.rs
@@ -14,3 +14,19 @@ pub mod preferences;
 pub mod prompts;
 pub mod retrieval;
 pub mod risk;
+
+use std::path::PathBuf;
+
+/// Path to the brain gate mode file (`~/.claudectl/brain/gate-mode`).
+pub fn gate_mode_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    PathBuf::from(home).join(".claudectl").join("brain").join("gate-mode")
+}
+
+/// Read the current brain gate mode from disk. Returns `"on"` if no file exists.
+pub fn read_gate_mode() -> String {
+    let path = gate_mode_path();
+    std::fs::read_to_string(&path)
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|_| "on".into())
+}

--- a/src/brain/mod.rs
+++ b/src/brain/mod.rs
@@ -20,7 +20,10 @@ use std::path::PathBuf;
 /// Path to the brain gate mode file (`~/.claudectl/brain/gate-mode`).
 pub fn gate_mode_path() -> PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-    PathBuf::from(home).join(".claudectl").join("brain").join("gate-mode")
+    PathBuf::from(home)
+        .join(".claudectl")
+        .join("brain")
+        .join("gate-mode")
 }
 
 /// Read the current brain gate mode from disk. Returns `"on"` if no file exists.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1006,19 +1006,12 @@ pub(crate) fn format_session(fmt: &str, s: &session::ClaudeSession) -> String {
 
 /// Path to the brain gate mode state file.
 pub(crate) fn brain_gate_mode_path() -> std::path::PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-    std::path::PathBuf::from(home)
-        .join(".claudectl")
-        .join("brain")
-        .join("gate-mode")
+    claudectl::brain::gate_mode_path()
 }
 
 /// Read the current brain gate mode from disk. Returns "on" if no file exists.
 pub(crate) fn read_brain_gate_mode() -> String {
-    let path = brain_gate_mode_path();
-    std::fs::read_to_string(&path)
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|_| "on".into())
+    claudectl::brain::read_gate_mode()
 }
 
 /// Set the brain gate mode (on/off/auto) and print confirmation.

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -95,6 +95,10 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
             Span::raw("  Record session highlight reel (toggle)"),
         ]),
         Line::from(vec![
+            Span::styled("  Ctrl+b         ", Style::default().fg(t.highlight_key)),
+            Span::raw("  Toggle brain on/off"),
+        ]),
+        Line::from(vec![
             Span::styled("  g              ", Style::default().fg(t.highlight_key)),
             Span::raw("  Toggle grouped view by project"),
         ]),

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -121,6 +121,18 @@ pub fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
                 Style::default().fg(t.header).add_modifier(Modifier::BOLD),
             ));
             frame.render_widget(msg, area);
+        } else {
+            let gate = crate::brain::read_gate_mode();
+            let (label, color) = match gate.as_str() {
+                "off" => ("Brain: off", t.text_muted),
+                "auto" => ("Brain: auto", t.header),
+                _ => ("Brain: on", t.success),
+            };
+            let msg = Paragraph::new(Span::styled(
+                format!(" {label}  (Ctrl+b toggle)"),
+                Style::default().fg(color),
+            ));
+            frame.render_widget(msg, area);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `Ctrl+b` keybinding in the TUI to toggle brain gate mode between on and off
- Shows current brain gate status (on/off/auto) in the status bar when brain engine is active with no pending suggestions
- Moves gate mode helpers to `brain::mod` so they're accessible from both lib and bin crates

## Test plan
- [ ] Launch TUI with `--brain`, verify status bar shows "Brain: on (Ctrl+b toggle)"
- [ ] Press `Ctrl+b`, verify status message shows "Brain: disabled" and status bar updates to "Brain: off"
- [ ] Press `Ctrl+b` again, verify it toggles back to on
- [ ] Verify `b`/`B` keys still work for accept/reject brain suggestions
- [ ] Press `?` to verify Ctrl+b appears in help overlay
- [ ] Run `cargo test` — all 315 tests pass
- [ ] Run `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)