### PR TITLE
feat: make hive a default feature, bump to v0.41.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2024"
 description = "Auto-pilot for Claude Code — a local model watches every session and decides what to approve"
 license = "MIT"
@@ -11,10 +11,10 @@ categories = ["command-line-utilities", "development-tools"]
 exclude = ["*.gif", "*.cast", "claude-demo.*", "CLAUDE.md", ".github/"]
 
 [features]
-default = []
+default = ["hive"]
 coord = ["rusqlite"]
 relay = []
-hive = ["relay"]
+hive = []
 
 [[bin]]
 name = "claudectl"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -140,6 +140,6 @@ cargo uninstall claudectl                    # Cargo
 
 - [Reference](reference.md) -- dashboard features, keybindings, all CLI flags
 - [Configuration](configuration.md) -- TOML config, hooks, rules, model pricing
-- [Relay & Hive Mind](relay.md) -- connect instances across machines, share learnings
+- [Relay & Hive Mind](relay.md) -- hive knowledge is built-in; add `--features relay` for cross-machine networking
 - [Terminal Support](terminal-support.md) -- compatibility and setup notes
 - [Troubleshooting](troubleshooting.md) -- common issues and FAQ

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -14,13 +14,15 @@ Every instance stays sovereign. Your local preferences always override peer know
 
 ## Quick Start: Connect Two Machines
 
-### Step 1: Enable the relay feature
+### Step 1: Install with relay feature
 
-Build claudectl with the relay feature:
+Hive (local knowledge) is included by default. For cross-machine networking, add the relay feature:
 
 ```bash
 cargo install claudectl --features relay
 ```
+
+Without relay, hive works locally — knowledge is distilled, archived, and used by the brain, but not synced to peers.
 
 ### Step 2: Generate an invite
 

--- a/src/brain/decisions.rs
+++ b/src/brain/decisions.rs
@@ -435,16 +435,19 @@ fn maybe_distill_background() {
                         min_tool_decisions: hive_cfg.export_min_tool_decisions,
                         ..Default::default()
                     };
-                    let peer_id = crate::relay::load_or_create_identity();
+                    #[cfg(feature = "relay")]
+                    let local_id = crate::relay::load_or_create_identity().0;
+                    #[cfg(not(feature = "relay"))]
+                    let local_id = crate::hive::local_identity();
                     let mut store = crate::hive::store::HiveStore::load();
                     let units = crate::hive::distiller::distill_to_knowledge_stable(
                         &prefs,
-                        peer_id.as_str(),
+                        &local_id,
                         None,
                         &thresholds,
                         &store,
                     );
-                    let count = units.len() as u32;
+                    let _count = units.len() as u32;
                     for unit in units {
                         store.insert(unit);
                     }
@@ -475,8 +478,9 @@ fn maybe_distill_background() {
                     let _ = store.save();
 
                     // Signal the relay to broadcast new knowledge to peers
-                    if count > 0 {
-                        crate::hive::signal_new_knowledge(count);
+                    #[cfg(feature = "relay")]
+                    if _count > 0 {
+                        crate::hive::signal_new_knowledge(_count);
                     }
                 }
             }

--- a/src/hive/cli.rs
+++ b/src/hive/cli.rs
@@ -72,26 +72,34 @@ fn cmd_status(json_mode: bool) -> io::Result<()> {
     // Count conflicts
     let conflict_count = conflict_line_count();
 
-    // Load gossip sync state
-    let local_id = crate::relay::load_or_create_identity();
-    let gossip = super::gossip::GossipEngine::new(local_id.as_str(), 5, 30);
-    let sync_states = gossip.all_sync_states();
+    // Load gossip sync state (only when relay is available)
+    #[cfg(feature = "relay")]
+    let relay_identity = Some(crate::relay::load_or_create_identity());
+    #[cfg(not(feature = "relay"))]
+    let relay_identity: Option<String> = None;
 
     if json_mode {
-        let output = serde_json::json!({
-            "identity": local_id.as_str(),
+        #[allow(unused_mut)]
+        let mut output = serde_json::json!({
             "total_units": all.len(),
             "max_units": hive_cfg.max_units,
             "sources": sources,
             "categories": by_category,
             "conflicts": conflict_count,
-            "sync_states": sync_states,
         });
+        #[cfg(feature = "relay")]
+        if let Some(ref id) = relay_identity {
+            output["identity"] = serde_json::json!(id.as_str());
+            let gossip = super::gossip::GossipEngine::new(id.as_str(), 5, 30);
+            output["sync_states"] = serde_json::json!(gossip.all_sync_states());
+        }
         println!("{}", serde_json::to_string_pretty(&output).unwrap());
     } else {
         println!("Hive Knowledge Store");
         println!();
-        println!("  Identity: {}", local_id);
+        if let Some(ref id) = relay_identity {
+            println!("  Identity: {}", id);
+        }
         println!("  Total units: {} / {} max", all.len(), hive_cfg.max_units);
         if !by_category.is_empty() {
             println!("  Categories:");
@@ -112,15 +120,20 @@ fn cmd_status(json_mode: bool) -> io::Result<()> {
             println!();
             println!("  Merge conflicts: {conflict_count} (see ~/.claudectl/hive/conflicts.jsonl)");
         }
-        if !sync_states.is_empty() {
-            println!();
-            println!("  Gossip sync state:");
-            for (peer_id, state) in sync_states {
-                println!(
-                    "    {peer_id}: {} units sent, last sync epoch {}",
-                    state.units_sent.len(),
-                    state.last_sync_epoch
-                );
+        #[cfg(feature = "relay")]
+        if let Some(ref id) = relay_identity {
+            let gossip = super::gossip::GossipEngine::new(id.as_str(), 5, 30);
+            let sync_states = gossip.all_sync_states();
+            if !sync_states.is_empty() {
+                println!();
+                println!("  Gossip sync state:");
+                for (peer_id, state) in sync_states {
+                    println!(
+                        "    {peer_id}: {} units sent, last sync epoch {}",
+                        state.units_sent.len(),
+                        state.last_sync_epoch
+                    );
+                }
             }
         }
     }

--- a/src/hive/mod.rs
+++ b/src/hive/mod.rs
@@ -3,6 +3,7 @@
 pub mod archive;
 pub mod cli;
 pub mod distiller;
+#[cfg(feature = "relay")]
 pub mod gossip;
 pub mod injection;
 pub mod merger;
@@ -265,19 +266,31 @@ pub fn epoch_secs() -> u64 {
         .as_secs()
 }
 
+/// Local identity for hive knowledge (used when relay feature is not enabled).
+/// Returns hostname or "local" as a fallback.
+pub fn local_identity() -> String {
+    std::process::Command::new("hostname")
+        .output()
+        .ok()
+        .and_then(|o| {
+            let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            if s.is_empty() { None } else { Some(s) }
+        })
+        .unwrap_or_else(|| "local".into())
+}
+
 // ────────────────────────────────────────────────────────────────────────────
-// Broadcast channel for triggering gossip after distillation
+// Broadcast channel for triggering gossip after distillation (relay only)
 // ────────────────────────────────────────────────────────────────────────────
 
+#[cfg(feature = "relay")]
 use std::sync::Mutex;
 
-/// Global sender for signaling the relay that new knowledge is available.
-/// Set once during relay startup; the distillation thread sends a unit count through it.
-/// Uses Mutex because mpsc::Sender is Send but not Sync — the Mutex is only contended
-/// during initialization and the rare distillation cycle (every 10 decisions).
+#[cfg(feature = "relay")]
 static HIVE_BROADCAST_TX: Mutex<Option<std::sync::mpsc::Sender<u32>>> = Mutex::new(None);
 
-/// Set the broadcast channel (called once during relay/TUI startup).
+/// Set the broadcast channel (called once during relay startup).
+#[cfg(feature = "relay")]
 pub fn set_broadcast_channel(tx: std::sync::mpsc::Sender<u32>) {
     if let Ok(mut guard) = HIVE_BROADCAST_TX.lock() {
         *guard = Some(tx);
@@ -285,7 +298,7 @@ pub fn set_broadcast_channel(tx: std::sync::mpsc::Sender<u32>) {
 }
 
 /// Signal that new knowledge units are available for gossip.
-/// Called from the distillation background thread.
+#[cfg(feature = "relay")]
 pub fn signal_new_knowledge(count: u32) {
     if let Ok(guard) = HIVE_BROADCAST_TX.lock() {
         if let Some(ref tx) = *guard {


### PR DESCRIPTION
## Summary

- Hive (local knowledge distillation, archive, curriculum, trust) is now a **default feature** — included in `cargo install claudectl` with no feature flags needed
- Relay (TCP networking, gossip, task delegation) stays **opt-in** via `--features relay`
- Hive no longer depends on relay — it works fully locally without any networking code

## Install matrix

| Command | What you get |
|---------|--------------|
| `cargo install claudectl` | Dashboard + brain + hive (local knowledge) |
| `cargo install claudectl --features relay` | + cross-machine networking |
| `cargo install claudectl --features "relay,coord"` | + coordination layer |
| `cargo install claudectl --no-default-features` | Minimal (no hive) |

## Why

Hive is the brain's knowledge backbone — distillation, archiving, curriculum generation, trust management. Without it, the brain learns but can't retain or distill learnings. Making users opt-in to the main value proposition via `--features hive` was friction without benefit.

## Test plan

- [x] `cargo build` (default = hive) — compiles, `--hive` shows in help
- [x] `cargo build --features relay` — compiles, both `--relay` and `--hive` show
- [x] `cargo build --no-default-features` — compiles, neither shows
- [x] `cargo clippy -- -D warnings` — clean
- [x] All existing tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)