### PR TITLE
feat: migrate --relay/--hive/--coord to proper clap subcommands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2024"
 description = "Mission control for Claude Code — supervise, orchestrate, and connect coding agents with a local LLM brain and hive mind"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -168,27 +168,27 @@ Build with `cargo build --features coord` to enable.
 
 ```bash
 # Ownership leases — prevent two agents from editing the same file
-claudectl --coord "claim --session sess_1 --path src/app.rs --mode exclusive"
-claudectl --coord "release lease_123"
+claudectl coord claim --session sess_1 --path src/app.rs --mode exclusive
+claudectl coord release lease_123
 
 # Handoffs — structured context transfer between sessions
-claudectl --coord "handoff --from sess_1 --to sess_2 --task task_1 --summary 'Fix path normalization'"
+claudectl coord handoff --from sess_1 --to sess_2 --task task_1 --summary 'Fix path normalization'
 
 # Interrupts — typed cross-agent signals with delivery modes
-claudectl --coord "raise --type pause --target sess_1 --reason 'lease conflict'"
-claudectl --coord "ack intr_123"
+claudectl coord raise --type pause --target sess_1 --reason 'lease conflict'
+claudectl coord ack intr_123
 
 # Memory — validated patterns promoted from brain decisions
-claudectl --coord "promote --project myproject"
-claudectl --coord "context --session sess_1"      # Preview injected context
+claudectl coord promote --project myproject
+claudectl coord context --session sess_1           # Preview injected context
 
 # Inspection
-claudectl --coord leases                           # Active ownership leases
-claudectl --coord interrupts                       # Pending interrupts
-claudectl --coord events                           # Event audit log
-claudectl --coord metrics                          # Coordination health metrics
-claudectl --coord eval                             # Run 10 eval scenarios
-claudectl --coord adapters                         # Registered agent adapters
+claudectl coord leases                             # Active ownership leases
+claudectl coord interrupts                         # Pending interrupts
+claudectl coord events                             # Event audit log
+claudectl coord metrics                            # Coordination health metrics
+claudectl coord eval                               # Run 10 eval scenarios
+claudectl coord adapters                           # Registered agent adapters
 ```
 
 The coordination layer stores state in a local SQLite database (`~/.claudectl/coord/coord.db`) and injects compact context into the brain's prompt before every decision.
@@ -199,15 +199,15 @@ The brain distills your decisions into shareable knowledge. Connect instances ac
 
 ```bash
 # Hive knowledge is built-in — view what the brain has learned
-claudectl --hive status
-claudectl --hive knowledge
-claudectl --hive distill              # Condense archive into curriculum
+claudectl hive status
+claudectl hive knowledge
+claudectl hive distill                # Condense archive into curriculum
 
 # Add relay for cross-machine networking
 cargo install claudectl --features relay
-claudectl --relay invite              # Generate an invite code
-claudectl --relay "join YEK-AGA-YHK-QAA-BM"   # Join from another machine
-claudectl --relay discover            # Scan LAN for nearby instances
+claudectl relay invite                # Generate an invite code
+claudectl relay join YEK-AGA-YHK-QAA-BM       # Join from another machine
+claudectl relay discover              # Scan LAN for nearby instances
 ```
 
 Knowledge categories (best practices, techniques, workflow patterns) propagate automatically. Personal patterns (time-of-day habits, cost tolerance) stay local. You control what's shared:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,7 +205,7 @@ You can use both. The `--init` hooks notify claudectl of tool completions. The p
 
 ## Coordination Layer (--features coord)
 
-Multi-session coordination on a single machine. Stores events, leases, blockers, handoffs, interrupts, and memory in a local SQLite database at `~/.claudectl/coord.db`. No TOML configuration needed — inspect with `claudectl --coord <subcommand>`. See [Reference](reference.md#coordination---features-coord) for all subcommands.
+Multi-session coordination on a single machine. Stores events, leases, blockers, handoffs, interrupts, and memory in a local SQLite database at `~/.claudectl/coord.db`. No TOML configuration needed — inspect with `claudectl coord <subcommand>`. See [Reference](reference.md#coordination---features-coord) for all subcommands.
 
 ## Relay & Hive Mind Configuration
 

--- a/docs/hive-storage.md
+++ b/docs/hive-storage.md
@@ -242,28 +242,28 @@ if warm_store.find_by_tool("docker").is_empty() {
 A background thread (or CLI command) runs distillation:
 
 ```bash
-claudectl --hive distill          # manual trigger
-claudectl --hive curriculum       # show current curriculum
-claudectl --hive "curriculum --pull"  # pull latest into warm tier
+claudectl hive distill          # manual trigger
+claudectl hive curriculum       # show current curriculum
+claudectl hive curriculum --pull  # pull latest into warm tier
 ```
 
 ## CLI
 
 ```bash
 # Archive management
-claudectl --hive archive          # show archive stats
-claudectl --hive "archive --prune 90d"  # prune archive entries older than 90 days
+claudectl hive archive          # show archive stats
+claudectl hive archive --prune 90d  # prune archive entries older than 90 days
 
 # Distillation
-claudectl --hive distill          # run cold distillation now
-claudectl --hive curriculum       # show current curriculum
-claudectl --hive "curriculum --pull"    # pull curriculum into warm tier
-claudectl --hive "curriculum --pin v3"  # pin to a specific curriculum version
+claudectl hive distill          # run cold distillation now
+claudectl hive curriculum       # show current curriculum
+claudectl hive curriculum --pull    # pull curriculum into warm tier
+claudectl hive curriculum --pin v3  # pin to a specific curriculum version
 
 # Storage backend
-claudectl --hive "storage status"     # show backend config and stats
-claudectl --hive "storage push"       # manually push warm tier to cold
-claudectl --hive "storage pull"       # manually pull from cold to warm
+claudectl hive storage status     # show backend config and stats
+claudectl hive storage push       # manually push warm tier to cold
+claudectl hive storage pull       # manually pull from cold to warm
 ```
 
 ## Future: Cloud Backends

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -140,46 +140,46 @@ Press `R` on any session to record a per-session highlight reel (edits, commands
 
 Inspect multi-session coordination state. Requires `cargo install claudectl --features coord`.
 
-| Flag | Description |
-|------|-------------|
-| `--coord events [N] [type]` | Show last N coordination events (default 50), optionally filtered by type |
-| `--coord leases` | Show active ownership leases |
-| `--coord blockers` | Show open blockers |
-| `--coord handoffs` | Show handoffs |
-| `--coord interrupts` | Show pending interrupts |
-| `--coord memory` | List recent coordination memory records |
-| `--coord "memory search <q>"` | Full-text search coordination memory |
-| `--coord "promote --project <name>"` | Promote brain patterns to coordination memory |
-| `--coord "prune [--days N]"` | Delete old events, resolved blockers, expired leases (default: 30 days) |
+| Command | Description |
+|---------|-------------|
+| `coord events [N] [type]` | Show last N coordination events (default 50), optionally filtered by type |
+| `coord leases` | Show active ownership leases |
+| `coord blockers` | Show open blockers |
+| `coord handoffs` | Show handoffs |
+| `coord interrupts` | Show pending interrupts |
+| `coord memory` | List recent coordination memory records |
+| `coord memory search <q>` | Full-text search coordination memory |
+| `coord promote --project <name>` | Promote brain patterns to coordination memory |
+| `coord prune [--days N]` | Delete old events, resolved blockers, expired leases (default: 30 days) |
 
 ### Relay (--features relay)
 
 Connect machines, delegate tasks. See the [full relay guide](relay.md).
 
-| Flag | Description |
-|------|-------------|
-| `--relay serve` | Start the relay listener for peer connections |
-| `--relay invite [--qr] [--words]` | Generate invite code, link, and word phrase |
-| `--relay "join <code>"` | Connect using any invite format (code, words, or link) |
-| `--relay discover` | Scan LAN for nearby claudectl instances |
-| `--relay peers` | List known and connected peers |
-| `--relay "delegate <peer> <prompt>"` | Delegate a task to a remote peer |
-| `--relay identity` | Show this instance's relay identity |
+| Command | Description |
+|---------|-------------|
+| `relay serve [--port N]` | Start the relay listener for peer connections |
+| `relay invite [--qr] [--words]` | Generate invite code, link, and word phrase |
+| `relay join <code>` | Connect using any invite format (code, words, or link) |
+| `relay discover` | Scan LAN for nearby claudectl instances |
+| `relay peers` | List known and connected peers |
+| `relay delegate <peer> <prompt>` | Delegate a task to a remote peer |
+| `relay identity` | Show this instance's relay identity |
 
 ### Hive Mind (--features hive)
 
 Share knowledge, distill learnings. Requires relay for transport.
 
-| Flag | Description |
-|------|-------------|
-| `--hive status` | Knowledge store overview (units, categories, conflicts) |
-| `--hive knowledge [--from X]` | List knowledge units, filter by peer or scope |
-| `--hive trust [<peer> [<level>]]` | Show or set peer trust levels |
-| `--hive export` | Export all knowledge as JSON |
-| `--hive "import <file>"` | Import knowledge from JSON file |
-| `--hive archive` | Show cold storage archive stats |
-| `--hive distill` | Run distillation pipeline (dedup, condense, curriculum) |
-| `--hive curriculum` | Show distilled curriculum |
+| Command | Description |
+|---------|-------------|
+| `hive status` | Knowledge store overview (units, categories, conflicts) |
+| `hive knowledge [--from X]` | List knowledge units, filter by peer or scope |
+| `hive trust [<peer> [<level>]]` | Show or set peer trust levels |
+| `hive export` | Export all knowledge as JSON |
+| `hive import <file>` | Import knowledge from JSON file |
+| `hive archive [--prune Nd]` | Show cold storage archive stats |
+| `hive distill` | Run distillation pipeline (dedup, condense, curriculum) |
+| `hive curriculum` | Show distilled curriculum |
 
 ### Cleanup
 

--- a/docs/relay-discovery.md
+++ b/docs/relay-discovery.md
@@ -10,13 +10,13 @@ Current pairing flow:
 
 ```
 # Machine A                        # Machine B
-claudectl --relay pair             
+claudectl relay pair             
 # → PAIR CODE: a3f2-9b1c-d4e5-f678
-# → "They should run: claudectl --relay accept a3f2-9b1c-d4e5-f678 machineA-x7f2"
+# → "They should run: claudectl relay accept a3f2-9b1c-d4e5-f678 machineA-x7f2"
 
-                                    claudectl --relay "accept a3f2-9b1c-d4e5-f678 machineA-x7f2"
-claudectl --relay serve
-                                    claudectl --relay "connect 192.168.1.50:9847"
+                                    claudectl relay accept a3f2-9b1c-d4e5-f678 machineA-x7f2
+claudectl relay serve
+                                    claudectl relay connect 192.168.1.50:9847
 ```
 
 Four friction points:
@@ -65,13 +65,13 @@ Machine B starts relay:
 
 ```bash
 # Discover nearby instances (one-shot scan)
-claudectl --relay discover
+claudectl relay discover
 # → Found 2 claudectl instances on LAN:
 # →   laptop-a3f2    192.168.1.50:9847   v0.36.0
 # →   ci-runner-9d1e 192.168.1.101:9847  v0.36.0
 
 # Pair with a discovered instance (interactive)
-claudectl --relay "pair-with laptop-a3f2"
+claudectl relay pair-with laptop-a3f2
 # → Sending pair request to laptop-a3f2...
 # → Waiting for approval on the remote side...
 # → Paired! Connected to laptop-a3f2.
@@ -148,7 +148,7 @@ auto_approve_lan = false      # if true, skip approval prompt (team LAN)
 
 ```
 # One-time: team lead sets up the peer list
-claudectl --relay "project-init"
+claudectl relay project-init
 # → Created .claudectl/peers.toml with your identity
 
 # Commit it to the repo
@@ -164,8 +164,8 @@ git add .claudectl/peers.toml && git commit -m "add claudectl relay peers"
 
 ```toml
 # Team claudectl relay peers
-# Add your identity with: claudectl --relay "project-add"
-# Connect with: claudectl --relay "project-connect"
+# Add your identity with: claudectl relay project-add
+# Connect with: claudectl relay project-connect
 
 [[peers]]
 identity = "laptop-a3f2"
@@ -183,18 +183,18 @@ addr = "10.0.0.42:9847"
 
 ```bash
 # Add yourself to the project peer list
-claudectl --relay "project-add"
+claudectl relay project-add
 # → Added laptop-a3f2 to .claudectl/peers.toml
 # → Commit this file to share with your team.
 
 # Show project peers and connection status
-claudectl --relay "project-peers"
+claudectl relay project-peers
 # → PROJECT PEERS (.claudectl/peers.toml):
 # →   laptop-a3f2    Barada's laptop     ● connected
 # →   ci-runner-9d1e CI runner           ○ not paired
 
 # Connect to all project peers (pairs if needed)
-claudectl --relay "project-connect"
+claudectl relay project-connect
 # → Connecting to ci-runner-9d1e at 10.0.0.42:9847...
 # → Pair request sent. Waiting for approval...
 # → Connected!
@@ -226,10 +226,10 @@ If the address is stale or wrong, it falls back to LAN discovery or prompts for 
 
 ```bash
 # Generate an invite link
-claudectl --relay invite
+claudectl relay invite
 # → Your relay invite link (valid for 24 hours):
 # →
-# →   claudectl --relay "join cctl://laptop-a3f2@192.168.1.50:9847/k/a3f29b1cd4e5f678"
+# →   claudectl relay join cctl://laptop-a3f2@192.168.1.50:9847/k/a3f29b1cd4e5f678
 # →
 # → Or scan this QR code:
 # →   ██████████████
@@ -237,7 +237,7 @@ claudectl --relay invite
 # →   ...
 
 # Recipient runs the join command
-claudectl --relay "join cctl://laptop-a3f2@192.168.1.50:9847/k/a3f29b1cd4e5f678"
+claudectl relay join cctl://laptop-a3f2@192.168.1.50:9847/k/a3f29b1cd4e5f678
 # → Connecting to laptop-a3f2 at 192.168.1.50:9847...
 # → Authenticated!
 # → Paired with laptop-a3f2.
@@ -261,10 +261,10 @@ Components:
 
 ```bash
 # Generate invite
-claudectl --relay invite [--ttl 24h] [--json]
+claudectl relay invite [--ttl 24h] [--json]
 
 # Accept invite
-claudectl --relay "join <link>"
+claudectl relay join <link>
 
 # The join command:
 # 1. Parses the link
@@ -294,9 +294,9 @@ The invite link itself doesn't expire (it's just data). TTL is enforced by:
 The link is short enough for a QR code (under 80 characters). claudectl can render the QR in the terminal using Unicode block characters — no external dependencies. This is particularly useful for pairing a laptop with a CI server or remote machine where you can see the terminal.
 
 ```bash
-claudectl --relay "invite --qr"
+claudectl relay invite --qr
 # → Renders a scannable QR code in the terminal
-# → (The other machine runs: claudectl --relay "join <scanned-text>")
+# → (The other machine runs: claudectl relay join <scanned-text>)
 ```
 
 ---
@@ -358,7 +358,7 @@ With all four mechanisms, the ideal experience is:
 ### Same room, same WiFi (LAN discovery)
 
 ```
-1. Both run: claudectl --relay serve (or TUI with relay.enabled = true)
+1. Both run: claudectl relay serve (or TUI with relay.enabled = true)
 2. Both see each other in the discovery overlay
 3. One presses "Pair", the other approves
 4. Connected. Knowledge flows.
@@ -367,17 +367,17 @@ With all four mechanisms, the ideal experience is:
 ### Same team, same repo (project peers)
 
 ```
-1. Lead runs: claudectl --relay "project-add" && git commit && git push
-2. Teammate clones, runs: claudectl --relay "project-connect"
+1. Lead runs: claudectl relay project-add && git commit && git push
+2. Teammate clones, runs: claudectl relay project-connect
 3. Pair request sent, approved, connected.
 ```
 
 ### Remote colleague (invite link)
 
 ```
-1. You run: claudectl --relay invite
+1. You run: claudectl relay invite
 2. Paste the link in Slack
-3. They run: claudectl --relay "join <link>"
+3. They run: claudectl relay join <link>
 4. Connected.
 ```
 
@@ -431,23 +431,23 @@ invite_ttl_hours = 24
 
 ```bash
 # Discovery
-claudectl --relay discover              # scan LAN for nearby instances
-claudectl --relay "project-peers"       # show project peer list
+claudectl relay discover              # scan LAN for nearby instances
+claudectl relay project-peers       # show project peer list
 
 # Pairing (new)
-claudectl --relay invite [--qr] [--ttl 24h]   # generate invite link
-claudectl --relay "join <link>"                # accept invite link
-claudectl --relay "pair-with <identity>"       # pair with discovered peer
+claudectl relay invite [--qr] [--ttl 24h]   # generate invite link
+claudectl relay join <link>                # accept invite link
+claudectl relay pair-with <identity>       # pair with discovered peer
 
 # Project peers
-claudectl --relay "project-init"        # create .claudectl/peers.toml
-claudectl --relay "project-add"         # add yourself to peer list
-claudectl --relay "project-connect"     # connect to all project peers
+claudectl relay project-init        # create .claudectl/peers.toml
+claudectl relay project-add         # add yourself to peer list
+claudectl relay project-connect     # connect to all project peers
 
 # Existing (unchanged)
-claudectl --relay serve
-claudectl --relay pair
-claudectl --relay "accept <code> <peer-id>"
-claudectl --relay "connect <host:port>"
-claudectl --relay peers
+claudectl relay serve
+claudectl relay pair
+claudectl relay accept <code> <peer-id>
+claudectl relay connect <host:port>
+claudectl relay peers
 ```

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -29,7 +29,7 @@ Without relay, hive works locally — knowledge is distilled, archived, and used
 On Machine A:
 
 ```bash
-claudectl --relay invite
+claudectl relay invite
 ```
 
 Output:
@@ -43,14 +43,14 @@ Your identity: laptop-a3f2
 
 Share any of the above with your peer. They run:
 
-  claudectl --relay "join YEK-AGA-YHK-QAA-BM"
-  claudectl --relay "join cctl://laptop-a3f2@192.168.1.50:9847/k/a3f29b1cd4e5f678"
+  claudectl relay join YEK-AGA-YHK-QAA-BM
+  claudectl relay join cctl://laptop-a3f2@192.168.1.50:9847/k/a3f29b1cd4e5f678
 ```
 
 ### Step 3: Join from Machine B
 
 ```bash
-claudectl --relay "join YEK-AGA-YHK-QAA-BM"
+claudectl relay join YEK-AGA-YHK-QAA-BM
 ```
 
 That's it. Both machines are paired and connected.
@@ -60,13 +60,13 @@ That's it. Both machines are paired and connected.
 On Machine A (the one that generated the invite):
 
 ```bash
-claudectl --relay serve
+claudectl relay serve
 ```
 
 Machine B connects:
 
 ```bash
-claudectl --relay "connect 192.168.1.50:9847"
+claudectl relay connect 192.168.1.50:9847
 ```
 
 ## Three Ways to Share a Code
@@ -84,7 +84,7 @@ YEK-AGA-YHK-QAA-BM
 ### Word Phrase (memorable)
 
 ```bash
-claudectl --relay "invite --words"
+claudectl relay invite --words
 ```
 
 ```
@@ -96,7 +96,7 @@ fur-hue-ace-bid-ice-ape-cod-elk-ace
 ### Invite Link + QR Code
 
 ```bash
-claudectl --relay "invite --qr"
+claudectl relay invite --qr
 ```
 
 ```
@@ -108,9 +108,9 @@ Plus a scannable QR code in the terminal (requires `qrencode` installed).
 The `join` command auto-detects the format:
 
 ```bash
-claudectl --relay "join YEK-AGA-YHK-QAA-BM"           # relay code
-claudectl --relay "join fur-hue-ace-bid-ice-..."        # word phrase
-claudectl --relay "join cctl://laptop-a3f2@..."         # invite link
+claudectl relay join YEK-AGA-YHK-QAA-BM           # relay code
+claudectl relay join fur-hue-ace-bid-ice-..."        # word phrase
+claudectl relay join cctl://laptop-a3f2@..."         # invite link
 ```
 
 ## LAN Discovery
@@ -118,7 +118,7 @@ claudectl --relay "join cctl://laptop-a3f2@..."         # invite link
 Find nearby claudectl instances without codes:
 
 ```bash
-claudectl --relay discover
+claudectl relay discover
 ```
 
 ```
@@ -130,7 +130,7 @@ Found 2 instance(s):
   ci-runner-9d1e       192.168.1.101:9847       v0.40.0
 ```
 
-This sends a UDP broadcast and listens for 3 seconds. Peers running `claudectl --relay serve` announce themselves automatically.
+This sends a UDP broadcast and listens for 3 seconds. Peers running `claudectl relay serve` announce themselves automatically.
 
 ## Hive Mind: Knowledge Sharing
 
@@ -161,38 +161,38 @@ Trust adjusts automatically: when your brain makes a decision that agrees with h
 
 ```bash
 # Overview
-claudectl --hive status
+claudectl hive status
 
 # List all knowledge units
-claudectl --hive knowledge
+claudectl hive knowledge
 
 # Filter by source peer
-claudectl --hive "knowledge --from ci-runner"
+claudectl hive knowledge --from ci-runner
 
 # Filter by scope
-claudectl --hive "knowledge --scope project:myapp"
+claudectl hive knowledge --scope project:myapp
 
 # Export all knowledge as JSON
-claudectl --hive export > team-knowledge.json
+claudectl hive export > team-knowledge.json
 
 # Import knowledge from a file
-claudectl --hive "import team-knowledge.json"
+claudectl hive import team-knowledge.json
 
 # Remove a specific unit
-claudectl --hive "forget ku_1745539200_3"
+claudectl hive forget ku_1745539200_3
 ```
 
 ### Manage trust
 
 ```bash
 # Show all peer trust levels
-claudectl --hive trust
+claudectl hive trust
 
 # Show trust for one peer
-claudectl --hive "trust ci-runner"
+claudectl hive trust ci-runner
 
 # Manually set trust
-claudectl --hive "trust ci-runner 0.9"
+claudectl hive trust ci-runner 0.9
 ```
 
 ## Remote Task Delegation
@@ -224,17 +224,17 @@ Tasks with `"peer"` are delegated to the remote machine. Tasks without `"peer"` 
 ### Manual delegation
 
 ```bash
-claudectl --relay "delegate ci-runner 'Fix the auth tests' --cwd /project"
+claudectl relay delegate ci-runner 'Fix the auth tests' --cwd /project
 ```
 
 ### Interrupts
 
 ```bash
 # Nudge a remote task (informational)
-claudectl --relay "interrupt task_123 nudge 'dependency resolved'"
+claudectl relay interrupt task_123 nudge 'dependency resolved'
 
 # Stop a remote task
-claudectl --relay "interrupt task_123 stop 'no longer needed'"
+claudectl relay interrupt task_123 stop 'no longer needed'
 ```
 
 ## TUI Integration
@@ -297,34 +297,33 @@ exclude_commands = []             # command patterns to never share
 
 | Command | Description |
 |---------|-------------|
-| `--relay serve [--port N]` | Start the relay listener |
-| `--relay invite [--qr] [--words]` | Generate invite code/link/phrase |
-| `--relay "join <code>"` | Join using any invite format |
-| `--relay discover` | Scan LAN for nearby instances |
-| `--relay pair` | Generate a raw PSK code |
-| `--relay "accept <code> <peer>"` | Accept a raw PSK from a peer |
-| `--relay "connect <host:port>"` | Connect to a remote relay |
-| `--relay peers [--json]` | List known peers |
-| `--relay "forget <peer>"` | Remove a peer |
-| `--relay identity` | Show this instance's relay identity |
-| `--relay "delegate <peer> <prompt>"` | Delegate a task |
-| `--relay status` | Show remote task status |
-| `--relay "interrupt <task> <type>"` | Interrupt a remote task |
+| `relay serve [--port N]` | Start the relay listener |
+| `relay invite [--qr] [--words]` | Generate invite code/link/phrase |
+| `relay join <code>` | Join using any invite format |
+| `relay discover` | Scan LAN for nearby instances |
+| `relay pair` | Generate a raw PSK code |
+| `relay accept <code> <peer>` | Accept a raw PSK from a peer |
+| `relay connect <host:port>` | Connect to a remote relay |
+| `relay peers` | List known peers |
+| `relay forget <peer>` | Remove a peer |
+| `relay identity` | Show this instance's relay identity |
+| `relay delegate <peer> <prompt>` | Delegate a task |
+| `relay status` | Show remote task status |
+| `relay interrupt <task> <type>` | Interrupt a remote task |
 
 ### Hive commands
 
 | Command | Description |
 |---------|-------------|
-| `--hive status` | Show knowledge store overview |
-| `--hive knowledge [--from X] [--scope Y]` | List knowledge units |
-| `--hive export` | Export knowledge as JSON |
-| `--hive "import <file>"` | Import knowledge from JSON |
-| `--hive "forget <unit-id>"` | Remove a knowledge unit |
-| `--hive trust` | Show/set peer trust levels |
-| `--hive archive` | Show cold storage archive stats |
-| `--hive "archive --prune 90d"` | Prune archive entries older than 90 days |
-| `--hive distill` | Run distillation pipeline on archive |
-| `--hive curriculum` | Show distilled curriculum |
+| `hive status` | Show knowledge store overview |
+| `hive knowledge [--from X] [--scope Y]` | List knowledge units |
+| `hive export` | Export knowledge as JSON |
+| `hive import <file>` | Import knowledge from JSON |
+| `hive forget <unit-id>` | Remove a knowledge unit |
+| `hive trust [<peer> [<level>]]` | Show/set peer trust levels |
+| `hive archive [--prune Nd]` | Show cold storage archive stats |
+| `hive distill` | Run distillation pipeline on archive |
+| `hive curriculum` | Show distilled curriculum |
 
 ## Architecture
 

--- a/src/coord/cli.rs
+++ b/src/coord/cli.rs
@@ -1,43 +1,234 @@
 use std::io;
 
+use clap::Subcommand;
+
 use super::store;
 use super::types::*;
 
-pub fn dispatch(subcommand: &str, json_mode: bool) -> io::Result<()> {
-    let parts: Vec<&str> = subcommand.split_whitespace().collect();
-    let cmd = parts.first().copied().unwrap_or("help");
+#[derive(Subcommand)]
+pub enum CoordCommand {
+    /// Show last N events, optionally filtered by type
+    Events {
+        /// Number of events to show
+        #[arg(default_value_t = 50)]
+        limit: usize,
+        /// Filter by event type
+        type_filter: Option<String>,
+    },
 
-    match cmd {
-        "events" => {
-            let limit = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(50);
-            let type_filter = parts.get(2).copied();
-            list_events(limit, type_filter, json_mode)
+    /// Show active ownership leases
+    Leases,
+
+    /// Show open blockers
+    Blockers,
+
+    /// Show handoffs
+    Handoffs,
+
+    /// Show pending interrupts
+    Interrupts,
+
+    /// List or search memory records
+    Memory {
+        /// Subcommand and arguments (e.g., "search <query>")
+        args: Vec<String>,
+    },
+
+    /// Claim ownership of a resource
+    Claim {
+        /// Session ID
+        #[arg(long)]
+        session: String,
+        /// Resource path to claim
+        #[arg(long)]
+        path: String,
+        /// Lease mode (exclusive or advisory)
+        #[arg(long, default_value = "exclusive")]
+        mode: String,
+        /// Reason for the claim
+        #[arg(long)]
+        reason: Option<String>,
+    },
+
+    /// Release an ownership lease
+    Release {
+        /// Lease ID to release
+        lease_id: String,
+    },
+
+    /// Create a handoff between sessions
+    Handoff {
+        /// Source session ID
+        #[arg(long)]
+        from: String,
+        /// Task ID
+        #[arg(long)]
+        task: String,
+        /// Summary text
+        #[arg(long)]
+        summary: String,
+        /// Target session ID
+        #[arg(long)]
+        to: Option<String>,
+        /// Priority (high, medium, low)
+        #[arg(long, default_value = "medium")]
+        priority: String,
+    },
+
+    /// Accept a handoff
+    Accept {
+        /// Handoff ID to accept
+        handoff_id: String,
+    },
+
+    /// Open a blocker
+    Block {
+        /// Task ID
+        #[arg(long)]
+        task: String,
+        /// Session ID
+        #[arg(long)]
+        session: String,
+        /// What the task is waiting for
+        #[arg(long)]
+        waiting_for: String,
+        /// Optional dependency task ID
+        #[arg(long)]
+        depends_on: Option<String>,
+    },
+
+    /// Resolve a blocker
+    Unblock {
+        /// Blocker ID to resolve
+        blocker_id: String,
+    },
+
+    /// Raise an interrupt
+    Raise {
+        /// Interrupt type
+        #[arg(long = "type")]
+        interrupt_type: String,
+        /// Target session ID
+        #[arg(long)]
+        target: String,
+        /// Reason text
+        #[arg(long)]
+        reason: String,
+        /// Priority (high, medium, low)
+        #[arg(long, default_value = "medium")]
+        priority: String,
+        /// Delivery mode
+        #[arg(long, default_value = "safe_boundary")]
+        delivery: String,
+        /// Deduplication key
+        #[arg(long)]
+        dedupe: Option<String>,
+        /// Expiration in seconds
+        #[arg(long)]
+        expires: Option<u64>,
+    },
+
+    /// Acknowledge a delivered interrupt
+    Ack {
+        /// Interrupt ID to acknowledge
+        interrupt_id: String,
+    },
+
+    /// Promote brain patterns to coordination memory
+    Promote {
+        /// Project name
+        #[arg(long)]
+        project: String,
+    },
+
+    /// Show coordination context for a session
+    Context {
+        /// Session ID
+        #[arg(long)]
+        session: String,
+    },
+
+    /// List registered agent adapters
+    Adapters {
+        /// Filter by adapter family
+        family: Option<String>,
+    },
+
+    /// Show coordination metrics
+    Metrics {
+        /// Filter events since timestamp
+        #[arg(long)]
+        since: Option<String>,
+    },
+
+    /// Run coordination eval scenarios
+    Eval,
+
+    /// Delete old events, resolved blockers, expired leases
+    Prune {
+        /// Retention period in days
+        #[arg(long, default_value_t = 30)]
+        days: u64,
+    },
+}
+
+pub fn dispatch_command(command: &CoordCommand, json_mode: bool) -> io::Result<()> {
+    match command {
+        CoordCommand::Events { limit, type_filter } => {
+            list_events(*limit, type_filter.as_deref(), json_mode)
         }
-        "leases" => list_leases(json_mode),
-        "blockers" => list_blockers(json_mode),
-        "handoffs" => list_handoffs(json_mode),
-        "interrupts" => list_interrupts(json_mode),
-        "memory" => handle_memory(&parts[1..], json_mode),
-        "claim" => cmd_claim(&parts, json_mode),
-        "release" => cmd_release(&parts, json_mode),
-        "handoff" => cmd_handoff(&parts, json_mode),
-        "accept" => cmd_accept_handoff(&parts, json_mode),
-        "block" => cmd_open_blocker(&parts, json_mode),
-        "unblock" => cmd_resolve_blocker(&parts, json_mode),
-        "raise" => cmd_raise(&parts, json_mode),
-        "ack" => cmd_ack(&parts, json_mode),
-        "promote" => cmd_promote(&parts, json_mode),
-        "context" => cmd_context(&parts, json_mode),
-        "adapters" => cmd_adapters(&parts, json_mode),
-        "metrics" => cmd_metrics(&parts, json_mode),
-        "eval" => cmd_eval(json_mode),
-        "prune" => cmd_prune(&parts, json_mode),
-        "help" | "" => print_help(),
-        _ => {
-            eprintln!("Unknown coord subcommand: '{cmd}'");
-            eprintln!();
-            print_help()
-        }
+        CoordCommand::Leases => list_leases(json_mode),
+        CoordCommand::Blockers => list_blockers(json_mode),
+        CoordCommand::Handoffs => list_handoffs(json_mode),
+        CoordCommand::Interrupts => list_interrupts(json_mode),
+        CoordCommand::Memory { args } => handle_memory(args, json_mode),
+        CoordCommand::Claim {
+            session,
+            path,
+            mode,
+            reason,
+        } => cmd_claim(session, path, mode, reason.as_deref(), json_mode),
+        CoordCommand::Release { lease_id } => cmd_release(lease_id, json_mode),
+        CoordCommand::Handoff {
+            from,
+            task,
+            summary,
+            to,
+            priority,
+        } => cmd_handoff(from, task, summary, to.as_deref(), priority, json_mode),
+        CoordCommand::Accept { handoff_id } => cmd_accept_handoff(handoff_id, json_mode),
+        CoordCommand::Block {
+            task,
+            session,
+            waiting_for,
+            depends_on,
+        } => cmd_open_blocker(task, session, waiting_for, depends_on.as_deref(), json_mode),
+        CoordCommand::Unblock { blocker_id } => cmd_resolve_blocker(blocker_id, json_mode),
+        CoordCommand::Raise {
+            interrupt_type,
+            target,
+            reason,
+            priority,
+            delivery,
+            dedupe,
+            expires,
+        } => cmd_raise(
+            interrupt_type,
+            target,
+            reason,
+            priority,
+            delivery,
+            dedupe.as_deref(),
+            *expires,
+            json_mode,
+        ),
+        CoordCommand::Ack { interrupt_id } => cmd_ack(interrupt_id, json_mode),
+        CoordCommand::Promote { project } => cmd_promote(project, json_mode),
+        CoordCommand::Context { session } => cmd_context(session, json_mode),
+        CoordCommand::Adapters { family } => cmd_adapters(family.as_deref(), json_mode),
+        CoordCommand::Metrics { since } => cmd_metrics(since.as_deref(), json_mode),
+        CoordCommand::Eval => cmd_eval(json_mode),
+        CoordCommand::Prune { days } => cmd_prune(*days, json_mode),
     }
 }
 
@@ -264,17 +455,18 @@ fn list_interrupts(json_mode: bool) -> io::Result<()> {
 
 // -- Memory --------------------------------------------------------------------
 
-fn handle_memory(args: &[&str], json_mode: bool) -> io::Result<()> {
+fn handle_memory(args: &[String], json_mode: bool) -> io::Result<()> {
     let conn = open_or_exit();
 
-    let (records, is_search) = if args.first().copied() == Some("search") && args.len() > 1 {
-        let query = args[1..].join(" ");
-        let results = store::search_memory(&conn, &query, 20).map_err(io::Error::other)?;
-        (results, true)
-    } else {
-        let results = store::list_memory(&conn, 50).map_err(io::Error::other)?;
-        (results, false)
-    };
+    let (records, is_search) =
+        if args.first().map(|s| s.as_str()) == Some("search") && args.len() > 1 {
+            let query = args[1..].join(" ");
+            let results = store::search_memory(&conn, &query, 20).map_err(io::Error::other)?;
+            (results, true)
+        } else {
+            let results = store::list_memory(&conn, 50).map_err(io::Error::other)?;
+            (results, false)
+        };
 
     if json_mode {
         let json = serde_json::to_string_pretty(&records).unwrap_or_default();
@@ -310,20 +502,15 @@ fn handle_memory(args: &[&str], json_mode: bool) -> io::Result<()> {
 
 // -- Claim Ownership -----------------------------------------------------------
 
-fn cmd_claim(parts: &[&str], json_mode: bool) -> io::Result<()> {
-    let session = extract_flag(parts, "session");
-    let path = extract_flag(parts, "path");
-
-    let (Some(session_id), Some(resource)) = (session, path) else {
-        eprintln!(
-            "Usage: claudectl --coord \"claim --session <id> --path <resource> [--mode exclusive|advisory] [--reason text]\""
-        );
-        return Err(io::Error::other("missing required flags"));
-    };
-
-    let mode_str = extract_flag(parts, "mode").unwrap_or("exclusive");
+fn cmd_claim(
+    session_id: &str,
+    resource: &str,
+    mode_str: &str,
+    reason: Option<&str>,
+    json_mode: bool,
+) -> io::Result<()> {
     let mode = LeaseMode::parse(mode_str).unwrap_or(LeaseMode::Exclusive);
-    let reason = extract_flag_rest(parts, "reason").unwrap_or_default();
+    let reason = reason.unwrap_or("").to_string();
 
     let conn = open_or_exit();
     let _ = store::expire_stale_leases(&conn);
@@ -388,12 +575,7 @@ fn cmd_claim(parts: &[&str], json_mode: bool) -> io::Result<()> {
 
 // -- Release Ownership ---------------------------------------------------------
 
-fn cmd_release(parts: &[&str], json_mode: bool) -> io::Result<()> {
-    let Some(lease_id) = parts.get(1) else {
-        eprintln!("Usage: claudectl --coord \"release <lease_id>\"");
-        return Err(io::Error::other("missing lease_id"));
-    };
-
+fn cmd_release(lease_id: &str, json_mode: bool) -> io::Result<()> {
     let conn = open_or_exit();
 
     let Some(lease) = store::get_lease(&conn, lease_id).map_err(io::Error::other)? else {
@@ -441,21 +623,14 @@ fn cmd_release(parts: &[&str], json_mode: bool) -> io::Result<()> {
 
 // -- Create Handoff ------------------------------------------------------------
 
-fn cmd_handoff(parts: &[&str], json_mode: bool) -> io::Result<()> {
-    let from = extract_flag(parts, "from");
-    let task = extract_flag(parts, "task");
-    let summary = extract_flag_rest(parts, "summary");
-
-    let (Some(from_session), Some(task_id), Some(summary_text)) = (from, task, summary) else {
-        eprintln!(
-            "Usage: claudectl --coord \"handoff --from <session> --task <task_id> --summary <text> [--to <session>] [--priority high|medium|low]\""
-        );
-        return Err(io::Error::other("missing required flags"));
-    };
-
-    let to_session = extract_flag(parts, "to").map(|s| s.to_string());
-    let priority = extract_flag(parts, "priority").unwrap_or("medium");
-
+fn cmd_handoff(
+    from_session: &str,
+    task_id: &str,
+    summary_text: &str,
+    to_session: Option<&str>,
+    priority: &str,
+    json_mode: bool,
+) -> io::Result<()> {
     let conn = open_or_exit();
     let handoff_id = store::gen_id("handoff");
     let now = crate::logger::timestamp_now();
@@ -463,11 +638,11 @@ fn cmd_handoff(parts: &[&str], json_mode: bool) -> io::Result<()> {
     let handoff = Handoff {
         id: handoff_id.clone(),
         from_session_id: from_session.to_string(),
-        to_session_id: to_session,
+        to_session_id: to_session.map(|s| s.to_string()),
         task_id: task_id.to_string(),
-        summary: summary_text.clone(),
+        summary: summary_text.to_string(),
         state: HandoffState {
-            goal: summary_text,
+            goal: summary_text.to_string(),
             artifacts: vec![],
             attempted: vec![],
             next_steps: vec![],
@@ -509,12 +684,7 @@ fn cmd_handoff(parts: &[&str], json_mode: bool) -> io::Result<()> {
 
 // -- Accept Handoff ------------------------------------------------------------
 
-fn cmd_accept_handoff(parts: &[&str], json_mode: bool) -> io::Result<()> {
-    let Some(handoff_id) = parts.get(1) else {
-        eprintln!("Usage: claudectl --coord \"accept <handoff_id>\"");
-        return Err(io::Error::other("missing handoff_id"));
-    };
-
+fn cmd_accept_handoff(handoff_id: &str, json_mode: bool) -> io::Result<()> {
     let conn = open_or_exit();
 
     let Some(handoff) = store::get_handoff(&conn, handoff_id).map_err(io::Error::other)? else {
@@ -563,19 +733,13 @@ fn cmd_accept_handoff(parts: &[&str], json_mode: bool) -> io::Result<()> {
 
 // -- Blockers ------------------------------------------------------------------
 
-fn cmd_open_blocker(parts: &[&str], json_mode: bool) -> io::Result<()> {
-    let task = extract_flag(parts, "task");
-    let waiting_for = extract_flag_rest(parts, "waiting-for");
-    let session = extract_flag(parts, "session");
-
-    let (Some(task_id), Some(waiting_text), Some(session_id)) = (task, waiting_for, session) else {
-        eprintln!(
-            "Usage: claudectl --coord \"block --task <id> --session <id> --waiting-for <text> [--depends-on <task_id>]\""
-        );
-        return Err(io::Error::other("missing required flags"));
-    };
-
-    let depends_on = extract_flag(parts, "depends-on").map(|s| s.to_string());
+fn cmd_open_blocker(
+    task_id: &str,
+    session_id: &str,
+    waiting_for: &str,
+    depends_on: Option<&str>,
+    json_mode: bool,
+) -> io::Result<()> {
     let conn = open_or_exit();
     let blocker_id = store::gen_id("blocker");
     let now = crate::logger::timestamp_now();
@@ -583,8 +747,8 @@ fn cmd_open_blocker(parts: &[&str], json_mode: bool) -> io::Result<()> {
     let blocker = Blocker {
         id: blocker_id.clone(),
         task_id: task_id.to_string(),
-        depends_on,
-        waiting_for: waiting_text,
+        depends_on: depends_on.map(|s| s.to_string()),
+        waiting_for: waiting_for.to_string(),
         status: BlockerStatus::Open,
         owner_session_id: session_id.to_string(),
         created_at: now.clone(),
@@ -616,12 +780,7 @@ fn cmd_open_blocker(parts: &[&str], json_mode: bool) -> io::Result<()> {
     Ok(())
 }
 
-fn cmd_resolve_blocker(parts: &[&str], json_mode: bool) -> io::Result<()> {
-    let Some(blocker_id) = parts.get(1) else {
-        eprintln!("Usage: claudectl --coord \"unblock <blocker_id>\"");
-        return Err(io::Error::other("missing blocker_id"));
-    };
-
+fn cmd_resolve_blocker(blocker_id: &str, json_mode: bool) -> io::Result<()> {
     let conn = open_or_exit();
 
     let blockers = store::list_blockers(&conn, None).map_err(io::Error::other)?;
@@ -672,19 +831,17 @@ fn cmd_resolve_blocker(parts: &[&str], json_mode: bool) -> io::Result<()> {
 
 // -- Raise Interrupt -----------------------------------------------------------
 
-fn cmd_raise(parts: &[&str], json_mode: bool) -> io::Result<()> {
-    let itype_str = extract_flag(parts, "type");
-    let target = extract_flag(parts, "target");
-    let reason = extract_flag_rest(parts, "reason");
-
-    let (Some(itype_str), Some(target_session), Some(reason_text)) = (itype_str, target, reason)
-    else {
-        eprintln!(
-            "Usage: claudectl --coord \"raise --type <type> --target <session> --reason <text> [--priority high] [--delivery safe_boundary] [--dedupe key] [--expires secs]\""
-        );
-        return Err(io::Error::other("missing required flags"));
-    };
-
+#[allow(clippy::too_many_arguments)]
+fn cmd_raise(
+    itype_str: &str,
+    target_session: &str,
+    reason_text: &str,
+    priority: &str,
+    delivery: &str,
+    dedupe_key: Option<&str>,
+    expires_secs: Option<u64>,
+    json_mode: bool,
+) -> io::Result<()> {
     let Some(itype) = InterruptType::parse(itype_str) else {
         eprintln!("Unknown interrupt type: '{itype_str}'");
         eprintln!(
@@ -693,15 +850,10 @@ fn cmd_raise(parts: &[&str], json_mode: bool) -> io::Result<()> {
         return Err(io::Error::other("invalid type"));
     };
 
-    let priority = extract_flag(parts, "priority").unwrap_or("medium");
-    let delivery = extract_flag(parts, "delivery").unwrap_or("safe_boundary");
-    let dedupe_key = extract_flag(parts, "dedupe").map(|s| s.to_string());
-    let expires_secs: Option<u64> = extract_flag(parts, "expires").and_then(|s| s.parse().ok());
-
     let conn = open_or_exit();
 
     // Deduplication check
-    if let Some(ref key) = dedupe_key {
+    if let Some(key) = dedupe_key {
         if let Ok(Some(existing)) = store::find_duplicate_interrupt(&conn, key) {
             let msg = format!(
                 "Duplicate interrupt exists: {} (dedupe_key: {key})",
@@ -728,7 +880,6 @@ fn cmd_raise(parts: &[&str], json_mode: bool) -> io::Result<()> {
             .unwrap_or_default()
             .as_secs()
             + secs;
-        // Approximate ISO timestamp from epoch (good enough for comparison)
         format_epoch_iso(epoch)
     });
 
@@ -737,14 +888,14 @@ fn cmd_raise(parts: &[&str], json_mode: bool) -> io::Result<()> {
         interrupt_type: itype,
         priority: priority.to_string(),
         target_session_id: target_session.to_string(),
-        reason: reason_text,
+        reason: reason_text.to_string(),
         payload: None,
         delivery_mode: delivery.to_string(),
         max_retries: 3,
         retry_count: 0,
         next_retry_at: None,
         expires_at,
-        dedupe_key,
+        dedupe_key: dedupe_key.map(|s| s.to_string()),
         state: InterruptState::Pending,
         created_at: now.clone(),
         delivered_at: None,
@@ -781,12 +932,7 @@ fn cmd_raise(parts: &[&str], json_mode: bool) -> io::Result<()> {
 
 // -- Acknowledge Interrupt -----------------------------------------------------
 
-fn cmd_ack(parts: &[&str], json_mode: bool) -> io::Result<()> {
-    let Some(intr_id) = parts.get(1) else {
-        eprintln!("Usage: claudectl --coord \"ack <interrupt_id>\"");
-        return Err(io::Error::other("missing interrupt_id"));
-    };
-
+fn cmd_ack(intr_id: &str, json_mode: bool) -> io::Result<()> {
     let conn = open_or_exit();
 
     let Some(interrupt) = store::get_interrupt(&conn, intr_id).map_err(io::Error::other)? else {
@@ -850,14 +996,7 @@ fn format_epoch_iso(epoch_secs: u64) -> String {
 
 // -- Promote Memory ------------------------------------------------------------
 
-fn cmd_promote(parts: &[&str], json_mode: bool) -> io::Result<()> {
-    let project = extract_flag(parts, "project");
-
-    let Some(project_name) = project else {
-        eprintln!("Usage: claudectl --coord \"promote --project <name>\"");
-        return Err(io::Error::other("missing --project"));
-    };
-
+fn cmd_promote(project_name: &str, json_mode: bool) -> io::Result<()> {
     match super::promotion::promote_project(project_name) {
         Ok(count) => {
             if json_mode {
@@ -885,14 +1024,7 @@ fn cmd_promote(parts: &[&str], json_mode: bool) -> io::Result<()> {
 
 // -- Show Context --------------------------------------------------------------
 
-fn cmd_context(parts: &[&str], json_mode: bool) -> io::Result<()> {
-    let session_id = extract_flag(parts, "session");
-
-    let Some(session_id) = session_id else {
-        eprintln!("Usage: claudectl --coord \"context --session <id>\"");
-        return Err(io::Error::other("missing --session"));
-    };
-
+fn cmd_context(session_id: &str, json_mode: bool) -> io::Result<()> {
     // Build a minimal session for the injection engine
     let session = crate::session::ClaudeSession::from_raw(crate::session::RawSession {
         pid: 0,
@@ -922,10 +1054,8 @@ fn cmd_context(parts: &[&str], json_mode: bool) -> io::Result<()> {
 
 // -- Adapters ------------------------------------------------------------------
 
-fn cmd_adapters(parts: &[&str], json_mode: bool) -> io::Result<()> {
+fn cmd_adapters(filter: Option<&str>, json_mode: bool) -> io::Result<()> {
     use super::adapter;
-
-    let filter = parts.get(1).copied();
 
     if json_mode {
         let adapters: Vec<serde_json::Value> = adapter::all_adapters()
@@ -994,10 +1124,8 @@ fn yn(b: bool) -> &'static str {
 
 // -- Metrics -------------------------------------------------------------------
 
-fn cmd_metrics(parts: &[&str], json_mode: bool) -> io::Result<()> {
+fn cmd_metrics(since: Option<&str>, json_mode: bool) -> io::Result<()> {
     let conn = open_or_exit();
-
-    let since = extract_flag(parts, "since");
 
     let m = super::metrics::compute(&conn, since);
 
@@ -1031,20 +1159,18 @@ fn cmd_eval(json_mode: bool) -> io::Result<()> {
 
 // -- Prune ---------------------------------------------------------------------
 
-fn cmd_prune(parts: &[&str], json_mode: bool) -> io::Result<()> {
-    let days: Option<u64> = extract_flag(parts, "days").and_then(|s| s.parse().ok());
+fn cmd_prune(days: u64, json_mode: bool) -> io::Result<()> {
     let conn = open_or_exit();
 
-    match store::prune(&conn, days) {
+    match store::prune(&conn, Some(days)) {
         Ok(count) => {
             if json_mode {
                 println!(
                     "{}",
-                    serde_json::json!({"pruned": count, "retention_days": days.unwrap_or(30)})
+                    serde_json::json!({"pruned": count, "retention_days": days})
                 );
             } else {
-                let d = days.unwrap_or(30);
-                println!("Pruned {count} rows (retention: {d} days).");
+                println!("Pruned {count} rows (retention: {days} days).");
             }
             Ok(())
         }
@@ -1055,58 +1181,6 @@ fn cmd_prune(parts: &[&str], json_mode: bool) -> io::Result<()> {
     }
 }
 
-// -- Help ----------------------------------------------------------------------
-
-fn print_help() -> io::Result<()> {
-    println!("Coordination Layer");
-    println!();
-    println!("Usage: claudectl --coord <subcommand>");
-    println!();
-    println!("Read commands:");
-    println!("  events [N] [type]   Show last N events (default 50), optionally filtered by type");
-    println!("  leases              Show active ownership leases");
-    println!("  blockers            Show open blockers");
-    println!("  handoffs            Show handoffs");
-    println!("  interrupts          Show pending interrupts");
-    println!("  memory              List recent memory records");
-    println!("  memory search <q>   Search memory records (full-text)");
-    println!("  context --session <id>  Show coordination context that would be injected");
-    println!();
-    println!("Write commands:");
-    println!(
-        "  claim --session <id> --path <resource> [--mode exclusive|advisory] [--reason text]"
-    );
-    println!("  release <lease_id>");
-    println!(
-        "  handoff --from <session> --task <id> --summary <text> [--to <session>] [--priority high|medium|low]"
-    );
-    println!(
-        "  raise --type <type> --target <session> --reason <text> [--priority high] [--delivery safe_boundary] [--dedupe key] [--expires secs]"
-    );
-    println!("  accept <handoff_id>");
-    println!("  block --task <id> --session <id> --waiting-for <text> [--depends-on <task_id>]");
-    println!("  unblock <blocker_id>");
-    println!("  ack <interrupt_id>");
-    println!("  promote --project <name>  Promote brain patterns to coordination memory");
-    println!();
-    println!("Adapters:");
-    println!("  adapters [family]   List registered agent adapters and their capabilities");
-    println!();
-    println!("Evaluation:");
-    println!("  metrics [--since ts]  Show coordination metrics from event log");
-    println!("  eval                  Run coordination eval scenarios");
-    println!();
-    println!("Maintenance:");
-    println!(
-        "  prune [--days N]      Delete old events, resolved blockers, expired leases (default: 30 days)"
-    );
-    println!();
-    println!("  help                Show this help");
-    println!();
-    println!("Add --json for machine-readable output.");
-    Ok(())
-}
-
 // -- Helpers -------------------------------------------------------------------
 
 fn truncate(s: &str, max: usize) -> String {
@@ -1114,32 +1188,5 @@ fn truncate(s: &str, max: usize) -> String {
         s.to_string()
     } else {
         format!("{}...", &s[..max.saturating_sub(3)])
-    }
-}
-
-/// Extract a single-value flag: `--flag value` -> `Some("value")`.
-fn extract_flag<'a>(parts: &[&'a str], flag: &str) -> Option<&'a str> {
-    let target = format!("--{flag}");
-    parts
-        .iter()
-        .position(|p| *p == target)
-        .and_then(|i| parts.get(i + 1).copied())
-}
-
-/// Extract a multi-word flag value: collects tokens after `--flag` until the next `--*` flag.
-fn extract_flag_rest(parts: &[&str], flag: &str) -> Option<String> {
-    let target = format!("--{flag}");
-    let start = parts.iter().position(|p| *p == target)?;
-    let mut words = Vec::new();
-    for p in &parts[start + 1..] {
-        if p.starts_with("--") {
-            break;
-        }
-        words.push(*p);
-    }
-    if words.is_empty() {
-        None
-    } else {
-        Some(words.join(" "))
     }
 }

--- a/src/hive/cli.rs
+++ b/src/hive/cli.rs
@@ -2,54 +2,78 @@
 
 use std::io;
 
+use clap::Subcommand;
+
 use super::KnowledgeScope;
 use super::store::HiveStore;
 
-/// Dispatch a hive subcommand.
-pub fn dispatch(subcommand: &str, _json_mode: bool) -> io::Result<()> {
-    let parts: Vec<&str> = subcommand.split_whitespace().collect();
-    match parts.first().copied() {
-        Some("status") => cmd_status(_json_mode),
-        Some("knowledge") => cmd_knowledge(&parts[1..], _json_mode),
-        Some("export") => cmd_export(),
-        Some("import") => cmd_import(&parts[1..]),
-        Some("forget") => cmd_forget(&parts[1..]),
-        Some("trust") => cmd_trust(&parts[1..], _json_mode),
-        Some("archive") => cmd_archive(&parts[1..], _json_mode),
-        Some("distill") => cmd_distill(_json_mode),
-        Some("curriculum") => cmd_curriculum(_json_mode),
-        Some(other) => {
-            eprintln!("Unknown hive subcommand: {other}");
-            print_hive_help();
-            Err(io::Error::other("unknown subcommand"))
-        }
-        None => {
-            print_hive_help();
-            Ok(())
-        }
-    }
+#[derive(Subcommand)]
+pub enum HiveCommand {
+    /// Show knowledge store overview
+    Status,
+
+    /// List knowledge units
+    Knowledge {
+        /// Filter by source peer
+        #[arg(long)]
+        from: Option<String>,
+        /// Filter by scope (universal, language:X, project:X)
+        #[arg(long)]
+        scope: Option<String>,
+    },
+
+    /// Export all knowledge as JSON
+    Export,
+
+    /// Import knowledge from a JSON file
+    Import {
+        /// Path to JSON file
+        file: String,
+    },
+
+    /// Remove a knowledge unit
+    Forget {
+        /// Unit ID to remove
+        unit_id: String,
+    },
+
+    /// Show or set peer trust levels
+    Trust {
+        /// Peer ID (omit to list all)
+        peer: Option<String>,
+        /// Trust level 0.0-1.0 (omit to show current)
+        level: Option<f64>,
+    },
+
+    /// Show cold storage archive stats, or prune old entries
+    Archive {
+        /// Prune entries older than N days (e.g., "90d" or "90")
+        #[arg(long)]
+        prune: Option<String>,
+    },
+
+    /// Run distillation pipeline on archive
+    Distill,
+
+    /// Show distilled curriculum
+    Curriculum,
 }
 
-fn print_hive_help() {
-    eprintln!("Usage: claudectl --hive <subcommand>");
-    eprintln!();
-    eprintln!("Knowledge:");
-    eprintln!("  status                       Show knowledge store overview");
-    eprintln!("  knowledge [--from P] [--scope S]  List knowledge units");
-    eprintln!("  export                       Export all knowledge as JSON");
-    eprintln!("  import <file>                Import knowledge from JSON");
-    eprintln!("  forget <unit-id>             Remove a knowledge unit");
-    eprintln!();
-    eprintln!("Trust:");
-    eprintln!("  trust                        Show all peer trust levels");
-    eprintln!("  trust <peer>                 Show trust for one peer");
-    eprintln!("  trust <peer> <0.0-1.0>       Set trust level");
-    eprintln!();
-    eprintln!("Archive & Distillation:");
-    eprintln!("  archive                      Show cold storage stats");
-    eprintln!("  archive --prune <Nd>         Prune entries older than N days");
-    eprintln!("  distill                      Run distillation pipeline");
-    eprintln!("  curriculum                   Show distilled curriculum");
+/// Dispatch a hive subcommand.
+pub fn dispatch_command(command: &HiveCommand, json_mode: bool) -> io::Result<()> {
+    match command {
+        HiveCommand::Status => cmd_status(json_mode),
+        HiveCommand::Knowledge { from, scope } => {
+            cmd_knowledge(from.as_deref(), scope.as_deref(), json_mode)
+        }
+        HiveCommand::Export => cmd_export(),
+        HiveCommand::Import { file } => cmd_import(file),
+        HiveCommand::Forget { unit_id } => cmd_forget(unit_id),
+        HiveCommand::Trust { peer, level } => cmd_trust(peer.as_deref(), *level, json_mode),
+        HiveCommand::Archive { prune } => cmd_archive(prune.as_deref(), json_mode),
+        HiveCommand::Distill => cmd_distill(json_mode),
+        HiveCommand::Curriculum => cmd_curriculum(json_mode),
+    }
 }
 
 /// `claudectl hive status`
@@ -153,27 +177,17 @@ fn conflict_line_count() -> usize {
         .unwrap_or(0)
 }
 
-/// `claudectl hive knowledge [--scope X] [--from peer] [--json]`
-fn cmd_knowledge(args: &[&str], json_mode: bool) -> io::Result<()> {
+/// `claudectl hive knowledge [--scope X] [--from peer]`
+fn cmd_knowledge(
+    from_filter: Option<&str>,
+    scope_filter: Option<&str>,
+    json_mode: bool,
+) -> io::Result<()> {
     let store = HiveStore::load();
-    let mut scope_filter: Option<String> = None;
-    let mut from_filter: Option<String> = None;
 
-    let mut i = 0;
-    while i < args.len() {
-        if args[i] == "--scope" {
-            i += 1;
-            scope_filter = args.get(i).map(|s| s.to_string());
-        } else if args[i] == "--from" {
-            i += 1;
-            from_filter = args.get(i).map(|s| s.to_string());
-        }
-        i += 1;
-    }
-
-    let mut units: Vec<&super::KnowledgeUnit> = if let Some(ref from) = from_filter {
+    let mut units: Vec<&super::KnowledgeUnit> = if let Some(from) = from_filter {
         store.by_source(from)
-    } else if let Some(ref scope_str) = scope_filter {
+    } else if let Some(scope_str) = scope_filter {
         let scope = parse_scope(scope_str);
         store.by_scope(&scope)
     } else {
@@ -227,13 +241,7 @@ fn cmd_export() -> io::Result<()> {
 }
 
 /// `claudectl hive import <file>`
-fn cmd_import(args: &[&str]) -> io::Result<()> {
-    if args.is_empty() {
-        eprintln!("Usage: claudectl --hive \"import <file>\"");
-        return Err(io::Error::other("missing file path"));
-    }
-
-    let path = args[0];
+fn cmd_import(path: &str) -> io::Result<()> {
     let content =
         std::fs::read_to_string(path).map_err(|e| io::Error::other(format!("read {path}: {e}")))?;
 
@@ -251,13 +259,7 @@ fn cmd_import(args: &[&str]) -> io::Result<()> {
 }
 
 /// `claudectl hive forget <unit_id>`
-fn cmd_forget(args: &[&str]) -> io::Result<()> {
-    if args.is_empty() {
-        eprintln!("Usage: claudectl --hive \"forget <unit-id>\"");
-        return Err(io::Error::other("missing unit id"));
-    }
-
-    let unit_id = args[0];
+fn cmd_forget(unit_id: &str) -> io::Result<()> {
     let mut store = HiveStore::load();
 
     if store.remove(unit_id) {
@@ -274,11 +276,11 @@ fn cmd_forget(args: &[&str]) -> io::Result<()> {
 }
 
 /// `claudectl hive trust [peer_id] [level]`
-fn cmd_trust(args: &[&str], json_mode: bool) -> io::Result<()> {
+fn cmd_trust(peer: Option<&str>, level: Option<f64>, json_mode: bool) -> io::Result<()> {
     let mut trust_store = super::trust::TrustStore::load();
 
-    match args.len() {
-        0 => {
+    match (peer, level) {
+        (None, _) => {
             // Show all peer trust levels
             let all = trust_store.all();
             if json_mode {
@@ -304,9 +306,8 @@ fn cmd_trust(args: &[&str], json_mode: bool) -> io::Result<()> {
                 }
             }
         }
-        1 => {
+        (Some(peer_id), None) => {
             // Show trust for a specific peer
-            let peer_id = args[0];
             if let Some(trust) = trust_store.get(peer_id) {
                 if json_mode {
                     println!("{}", serde_json::to_string_pretty(trust).unwrap());
@@ -322,12 +323,8 @@ fn cmd_trust(args: &[&str], json_mode: bool) -> io::Result<()> {
                 return Err(io::Error::other("unknown peer"));
             }
         }
-        _ => {
+        (Some(peer_id), Some(level)) => {
             // Set trust level
-            let peer_id = args[0];
-            let level: f64 = args[1]
-                .parse()
-                .map_err(|_| io::Error::other("invalid trust level (must be 0.0-1.0)"))?;
             trust_store.set_trust(peer_id, level);
             trust_store.save().map_err(io::Error::other)?;
             let actual = trust_store.get(peer_id).unwrap();
@@ -362,21 +359,12 @@ fn parse_scope(s: &str) -> KnowledgeScope {
 // ────────────────────────────────────────────────────────────────────────────
 
 /// `claudectl hive archive [--prune Nd]`
-fn cmd_archive(args: &[&str], json_mode: bool) -> io::Result<()> {
-    let mut prune_days: Option<u32> = None;
-    let mut i = 0;
-    while i < args.len() {
-        if args[i] == "--prune" {
-            i += 1;
-            if let Some(val) = args.get(i) {
-                let days_str = val.trim_end_matches('d');
-                prune_days = days_str.parse().ok();
-            }
-        }
-        i += 1;
-    }
-
-    if let Some(days) = prune_days {
+fn cmd_archive(prune: Option<&str>, json_mode: bool) -> io::Result<()> {
+    if let Some(val) = prune {
+        let days_str = val.trim_end_matches('d');
+        let days: u32 = days_str
+            .parse()
+            .map_err(|_| io::Error::other(format!("invalid prune value: {val}")))?;
         let pruned = super::archive::prune_archive(days)
             .map_err(|e| io::Error::other(format!("prune: {e}")))?;
         println!("Pruned {pruned} archive entries older than {days} days.");
@@ -407,7 +395,7 @@ fn cmd_archive(args: &[&str], json_mode: bool) -> io::Result<()> {
             println!("    Source: {} archive units", m.source_archive_units);
         } else {
             println!();
-            println!("  No curriculum yet. Run: claudectl --hive distill");
+            println!("  No curriculum yet. Run: claudectl hive distill");
         }
     }
 
@@ -453,7 +441,7 @@ fn cmd_curriculum(json_mode: bool) -> io::Result<()> {
     }
 
     if curriculum.is_empty() {
-        println!("No curriculum yet. Run: claudectl --hive distill");
+        println!("No curriculum yet. Run: claudectl hive distill");
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ mod ui;
 use std::io;
 use std::time::{Duration, Instant};
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use crossterm::{
     event::{self, Event},
     execute,
@@ -55,6 +55,30 @@ pub(crate) struct ViewFilters {
     pub(crate) status_filter: StatusFilter,
     pub(crate) focus_filter: FocusFilter,
     pub(crate) search: String,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum Command {
+    #[cfg(feature = "relay")]
+    /// Relay: peer-to-peer connections, delegation, and discovery
+    Relay {
+        #[command(subcommand)]
+        command: relay::cli::RelayCommand,
+    },
+
+    #[cfg(feature = "hive")]
+    /// Hive: shared knowledge store, trust, archive, and distillation
+    Hive {
+        #[command(subcommand)]
+        command: hive::cli::HiveCommand,
+    },
+
+    #[cfg(feature = "coord")]
+    /// Coordination: events, leases, blockers, handoffs, interrupts, and memory
+    Coord {
+        #[command(subcommand)]
+        command: coord::cli::CoordCommand,
+    },
 }
 
 #[derive(Parser)]
@@ -237,22 +261,9 @@ pub(crate) struct Cli {
     #[arg(long, help_heading = "Orchestration")]
     pub(crate) parallel: bool,
 
-    // ── Coordination ──────────────────────────────────────────────────
-    /// Coordination layer inspection (events, leases, blockers, handoffs, interrupts, memory)
-    #[cfg(feature = "coord")]
-    #[arg(long, help_heading = "Coordination")]
-    coord: Option<String>,
-
-    // ── Relay ─────────────────────────────────────────────────────────
-    /// Relay: serve, invite, join, discover, pair, accept, connect, peers, delegate, status, interrupt, forget, identity
-    #[cfg(feature = "relay")]
-    #[arg(long, help_heading = "Relay")]
-    relay: Option<String>,
-
-    /// Hive: status, knowledge, trust, export, import, forget, archive, distill, curriculum
-    #[cfg(feature = "hive")]
-    #[arg(long, help_heading = "Hive Mind")]
-    hive: Option<String>,
+    // ── Subcommands ──────────────────────────────────────────────────
+    #[command(subcommand)]
+    command: Option<Command>,
 
     // ── Recording ──────────────────────────────────────────────────────
     /// Record the TUI session as an asciicast v2 file (e.g., --record demo.cast)
@@ -487,19 +498,17 @@ fn run_main(cli: Cli) -> io::Result<()> {
         return Ok(());
     }
 
-    #[cfg(feature = "coord")]
-    if let Some(ref sub) = cli.coord {
-        return coord::cli::dispatch(sub, cli.json);
-    }
+    if let Some(ref command) = cli.command {
+        match command {
+            #[cfg(feature = "relay")]
+            Command::Relay { command } => return relay::cli::dispatch_command(command, cli.json),
 
-    #[cfg(feature = "relay")]
-    if let Some(ref sub) = cli.relay {
-        return relay::cli::dispatch(sub, cli.json);
-    }
+            #[cfg(feature = "hive")]
+            Command::Hive { command } => return hive::cli::dispatch_command(command, cli.json),
 
-    #[cfg(feature = "hive")]
-    if let Some(ref sub) = cli.hive {
-        return hive::cli::dispatch(sub, cli.json);
+            #[cfg(feature = "coord")]
+            Command::Coord { command } => return coord::cli::dispatch_command(command, cli.json),
+        }
     }
 
     if cli.brain_query {

--- a/src/relay/cli.rs
+++ b/src/relay/cli.rs
@@ -4,6 +4,8 @@ use std::io;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
+use clap::Subcommand;
+
 use super::crypto;
 use super::delegation::{self, DelegationContext};
 use super::listener::RelayListener;
@@ -15,75 +17,130 @@ use super::{
     save_peer_psk, save_pending_psk,
 };
 
-/// Dispatch a relay subcommand.
-pub fn dispatch(subcommand: &str, json_mode: bool) -> io::Result<()> {
-    let parts: Vec<&str> = subcommand.split_whitespace().collect();
-    match parts.first().copied() {
-        Some("serve") => cmd_serve(&parts[1..]),
-        Some("pair") => cmd_pair(json_mode),
-        Some("accept") => cmd_accept(&parts[1..]),
-        Some("connect") => cmd_connect(&parts[1..]),
-        Some("peers") => cmd_peers(json_mode),
-        Some("disconnect") => cmd_disconnect(&parts[1..]),
-        Some("forget") => cmd_forget(&parts[1..]),
-        Some("identity") => cmd_identity(json_mode),
-        Some("delegate") => cmd_delegate(&parts[1..], json_mode),
-        Some("status") => cmd_task_status(json_mode),
-        Some("interrupt") => cmd_interrupt(&parts[1..]),
-        Some("invite") => cmd_invite(&parts[1..], json_mode),
-        Some("join") => cmd_join(&parts[1..]),
-        Some("discover") => cmd_discover(json_mode),
-        Some(other) => {
-            eprintln!("Unknown relay subcommand: {other}");
-            print_relay_help();
-            Err(io::Error::other("unknown subcommand"))
-        }
-        None => {
-            print_relay_help();
-            Ok(())
-        }
-    }
+#[derive(Subcommand)]
+pub enum RelayCommand {
+    /// Start relay listener
+    Serve {
+        /// Port to listen on
+        #[arg(long, default_value_t = 9847)]
+        port: u16,
+    },
+
+    /// Generate a raw PSK pairing code
+    Pair,
+
+    /// Accept a pairing code from another peer
+    Accept {
+        /// The pair code
+        code: String,
+        /// The peer identity
+        peer_id: String,
+    },
+
+    /// Connect to a remote relay
+    Connect {
+        /// Remote address (host:port)
+        addr: String,
+    },
+
+    /// List known peers
+    Peers,
+
+    /// Disconnect from a peer (informational in standalone mode)
+    Disconnect {
+        /// Peer ID to disconnect
+        peer_id: String,
+    },
+
+    /// Remove all data for a peer
+    Forget {
+        /// Peer ID to forget
+        peer_id: String,
+    },
+
+    /// Show this instance's relay identity
+    Identity,
+
+    /// Delegate a task to a remote peer
+    Delegate {
+        /// Target peer ID
+        peer: String,
+        /// Prompt to send
+        prompt: String,
+        /// Working directory for the task
+        #[arg(long)]
+        cwd: Option<String>,
+        /// Git ref for the task context
+        #[arg(long)]
+        git_ref: Option<String>,
+    },
+
+    /// Show remote task status
+    Status,
+
+    /// Interrupt a remote task
+    Interrupt {
+        /// Task ID
+        task_id: String,
+        /// Interrupt type (nudge, stop, reroute)
+        interrupt_type: String,
+        /// Optional reason
+        reason: Vec<String>,
+    },
+
+    /// Generate invite code/link/phrase
+    Invite {
+        /// Show QR code
+        #[arg(long)]
+        qr: bool,
+        /// Show word phrase
+        #[arg(long)]
+        words: bool,
+    },
+
+    /// Join using any invite format (relay code, word phrase, or invite link)
+    Join {
+        /// Invite code, word phrase, or invite link
+        input: Vec<String>,
+    },
+
+    /// Scan LAN for nearby claudectl instances
+    Discover,
 }
 
-fn print_relay_help() {
-    eprintln!("Usage: claudectl --relay <subcommand>");
-    eprintln!();
-    eprintln!("Connection:");
-    eprintln!("  serve [--port N]             Start relay listener");
-    eprintln!("  invite [--qr] [--words]      Generate invite code/link/phrase");
-    eprintln!("  join <code|link|phrase>       Connect using any invite format");
-    eprintln!("  discover                     Scan LAN for nearby instances");
-    eprintln!("  connect <host:port>          Connect to a known peer");
-    eprintln!();
-    eprintln!("Pairing:");
-    eprintln!("  pair                         Generate raw PSK code");
-    eprintln!("  accept <code> <peer-id>      Accept a PSK from a peer");
-    eprintln!("  peers [--json]               List known/connected peers");
-    eprintln!("  forget <peer-id>             Remove a peer");
-    eprintln!("  identity                     Show this instance's relay identity");
-    eprintln!();
-    eprintln!("Delegation:");
-    eprintln!("  delegate <peer> <prompt>     Delegate a task to a remote peer");
-    eprintln!("  status                       Show remote task status");
-    eprintln!("  interrupt <task> <type>       Interrupt a remote task (nudge/stop)");
+/// Dispatch a relay subcommand.
+pub fn dispatch_command(command: &RelayCommand, json_mode: bool) -> io::Result<()> {
+    match command {
+        RelayCommand::Serve { port } => cmd_serve(*port),
+        RelayCommand::Pair => cmd_pair(json_mode),
+        RelayCommand::Accept { code, peer_id } => cmd_accept(code, peer_id),
+        RelayCommand::Connect { addr } => cmd_connect(addr),
+        RelayCommand::Peers => cmd_peers(json_mode),
+        RelayCommand::Disconnect { peer_id } => cmd_disconnect(peer_id),
+        RelayCommand::Forget { peer_id } => cmd_forget(peer_id),
+        RelayCommand::Identity => cmd_identity(json_mode),
+        RelayCommand::Delegate {
+            peer,
+            prompt,
+            cwd,
+            git_ref,
+        } => cmd_delegate(peer, prompt, cwd.as_deref(), git_ref.clone(), json_mode),
+        RelayCommand::Status => cmd_task_status(json_mode),
+        RelayCommand::Interrupt {
+            task_id,
+            interrupt_type,
+            reason,
+        } => cmd_interrupt(task_id, interrupt_type, reason),
+        RelayCommand::Invite { qr, words } => cmd_invite(*qr, *words, json_mode),
+        RelayCommand::Join { input } => cmd_join(input),
+        RelayCommand::Discover => cmd_discover(json_mode),
+    }
 }
 
 /// `claudectl relay serve [--port PORT]`
 /// Start the relay listener in the foreground.
-fn cmd_serve(args: &[&str]) -> io::Result<()> {
-    let mut port: u16 = 9847;
-    let mut i = 0;
-    while i < args.len() {
-        if args[i] == "--port" {
-            i += 1;
-            if let Some(p) = args.get(i) {
-                port = p
-                    .parse()
-                    .map_err(|_| io::Error::other("invalid port number"))?;
-            }
-        }
-        i += 1;
-    }
+fn cmd_serve(port: u16) -> io::Result<()> {
+    let mut port = port;
 
     // Load config for relay/hive settings
     let cfg = crate::config::Config::load();
@@ -337,7 +394,7 @@ fn cmd_pair(json_mode: bool) -> io::Result<()> {
         println!();
         println!("Share this code with the peer you want to connect.");
         println!(
-            "They should run: claudectl --relay \"accept {} {}\"",
+            "They should run: claudectl relay accept {} {}",
             code, identity
         );
     }
@@ -354,14 +411,7 @@ fn cmd_pair(json_mode: bool) -> io::Result<()> {
 
 /// `claudectl relay accept <code> <peer_id>`
 /// Accept a pairing code from another peer.
-fn cmd_accept(args: &[&str]) -> io::Result<()> {
-    if args.len() < 2 {
-        eprintln!("Usage: claudectl --relay \"accept <pair-code> <peer-id>\"");
-        return Err(io::Error::other("missing arguments"));
-    }
-
-    let code = args[0];
-    let peer_id = args[1];
+fn cmd_accept(code: &str, peer_id: &str) -> io::Result<()> {
     if !is_valid_peer_id(peer_id) || peer_id == PENDING_PEER_ID {
         return Err(io::Error::other(format!("invalid peer id: {peer_id}")));
     }
@@ -375,7 +425,7 @@ fn cmd_accept(args: &[&str]) -> io::Result<()> {
 
     println!("Paired with peer: {}", peer_id);
     println!("PSK stored. You can now connect with:");
-    println!("  claudectl --relay \"connect <host>:<port>\"");
+    println!("  claudectl relay connect <host>:<port>");
 
     Ok(())
 }
@@ -474,15 +524,10 @@ fn reconnect_peer(
 
 /// `claudectl relay connect <host:port>`
 /// Connect to a remote relay.
-fn cmd_connect(args: &[&str]) -> io::Result<()> {
-    if args.is_empty() {
-        eprintln!("Usage: claudectl --relay \"connect <host:port>\"");
-        return Err(io::Error::other("missing address"));
-    }
-
-    let addr: SocketAddr = args[0]
+fn cmd_connect(addr_str: &str) -> io::Result<()> {
+    let addr: SocketAddr = addr_str
         .parse()
-        .map_err(|e| io::Error::other(format!("invalid address '{}': {e}", args[0])))?;
+        .map_err(|e| io::Error::other(format!("invalid address '{addr_str}': {e}")))?;
 
     let identity = load_or_create_identity();
 
@@ -514,14 +559,14 @@ fn cmd_connect(args: &[&str]) -> io::Result<()> {
         }
     }
 
-    eprintln!("Could not connect to {}", args[0]);
+    eprintln!("Could not connect to {}", addr_str);
     eprintln!("Make sure you have paired with this peer first:");
-    eprintln!("  1. Remote runs: claudectl --relay pair");
-    eprintln!("  2. You run:     claudectl --relay \"accept <code> <peer-id>\"");
+    eprintln!("  1. Remote runs: claudectl relay pair");
+    eprintln!("  2. You run:     claudectl relay accept <code> <peer-id>");
     Err(io::Error::other("connection failed"))
 }
 
-/// `claudectl relay peers [--json]`
+/// `claudectl relay peers`
 /// List known peers and their status.
 fn cmd_peers(json_mode: bool) -> io::Result<()> {
     let identity = load_or_create_identity();
@@ -549,7 +594,7 @@ fn cmd_peers(json_mode: bool) -> io::Result<()> {
         println!("Identity: {}", identity);
         println!();
         if known.is_empty() {
-            println!("No paired peers. Run 'claudectl --relay pair' to get started.");
+            println!("No paired peers. Run 'claudectl relay pair' to get started.");
         } else {
             println!("{:<20} {:<24} PAIRED", "PEER", "ADDRESS");
             println!("{}", "─".repeat(56));
@@ -572,29 +617,20 @@ fn cmd_peers(json_mode: bool) -> io::Result<()> {
 }
 
 /// `claudectl relay disconnect <peer_id>`
-fn cmd_disconnect(args: &[&str]) -> io::Result<()> {
-    if args.is_empty() {
-        eprintln!("Usage: claudectl --relay \"disconnect <peer-id>\"");
-        return Err(io::Error::other("missing peer id"));
-    }
+fn cmd_disconnect(peer_id: &str) -> io::Result<()> {
     // In standalone CLI mode, we can't disconnect a live connection
     // (that's handled by the TUI/serve loop). Just inform the user.
     println!("Note: to disconnect a live connection, stop the relay serve/connect process.");
     println!(
-        "To remove the pairing entirely, use: claudectl --relay \"forget {}\"",
-        args[0]
+        "To remove the pairing entirely, use: claudectl relay forget {}",
+        peer_id
     );
     Ok(())
 }
 
 /// `claudectl relay forget <peer_id>`
 /// Remove all data for a peer.
-fn cmd_forget(args: &[&str]) -> io::Result<()> {
-    if args.is_empty() {
-        eprintln!("Usage: claudectl --relay \"forget <peer-id>\"");
-        return Err(io::Error::other("missing peer id"));
-    }
-    let peer_id = args[0];
+fn cmd_forget(peer_id: &str) -> io::Result<()> {
     if load_peer_psk(peer_id).is_none() {
         eprintln!("Unknown peer: {}", peer_id);
         return Err(io::Error::other("unknown peer"));
@@ -621,43 +657,13 @@ fn cmd_identity(json_mode: bool) -> io::Result<()> {
 // ────────────────────────────────────────────────────────────────────────────
 
 /// `claudectl relay delegate <peer_id> "<prompt>" [--cwd /path] [--git-ref branch]`
-fn cmd_delegate(args: &[&str], json_mode: bool) -> io::Result<()> {
-    if args.len() < 2 {
-        eprintln!(
-            "Usage: claudectl --relay \"delegate <peer-id> <prompt> [--cwd /path] [--git-ref branch]\""
-        );
-        return Err(io::Error::other("missing arguments"));
-    }
-
-    let peer_id = args[0];
-    let mut prompt_parts: Vec<&str> = Vec::new();
-    let mut cwd: Option<&str> = None;
-    let mut git_ref: Option<String> = None;
-
-    let mut i = 1;
-    while i < args.len() {
-        if args[i] == "--cwd" {
-            i += 1;
-            cwd = args.get(i).copied();
-        } else if args[i] == "--git-ref" {
-            i += 1;
-            git_ref = args.get(i).map(|s| s.to_string());
-        } else {
-            prompt_parts.push(args[i]);
-        }
-        i += 1;
-    }
-
-    let prompt = prompt_parts
-        .join(" ")
-        .trim_matches('"')
-        .trim_matches('\'')
-        .to_string();
-    if prompt.is_empty() {
-        eprintln!("Usage: claudectl --relay \"delegate <peer-id> <prompt> [--cwd /path]\"");
-        return Err(io::Error::other("missing prompt"));
-    }
-
+fn cmd_delegate(
+    peer_id: &str,
+    prompt: &str,
+    cwd: Option<&str>,
+    git_ref: Option<String>,
+    json_mode: bool,
+) -> io::Result<()> {
     let identity = load_or_create_identity();
     let task_id = gen_msg_id().replace("msg_", "task_");
 
@@ -667,7 +673,7 @@ fn cmd_delegate(args: &[&str], json_mode: bool) -> io::Result<()> {
     };
 
     let msg =
-        delegation::build_delegate_message(&task_id, &prompt, cwd, &context, identity.as_str())
+        delegation::build_delegate_message(&task_id, prompt, cwd, &context, identity.as_str())
             .map_err(|e| io::Error::other(format!("build message: {e}")))?;
 
     if json_mode {
@@ -694,7 +700,7 @@ fn cmd_delegate(args: &[&str], json_mode: bool) -> io::Result<()> {
     Ok(())
 }
 
-/// `claudectl relay status [--json]`
+/// `claudectl relay status`
 /// Show status of delegated tasks.
 fn cmd_task_status(json_mode: bool) -> io::Result<()> {
     // In standalone CLI mode, we don't have a live relay connection.
@@ -719,29 +725,21 @@ fn cmd_task_status(json_mode: bool) -> io::Result<()> {
 }
 
 /// `claudectl relay interrupt <task_id> <type> [reason]`
-fn cmd_interrupt(args: &[&str]) -> io::Result<()> {
-    if args.len() < 2 {
-        eprintln!("Usage: claudectl --relay \"interrupt <task-id> <type> [reason]\"");
-        eprintln!("Types: nudge, stop, reroute");
-        return Err(io::Error::other("missing arguments"));
-    }
-
-    let task_id = args[0];
-    let interrupt_type = args[1];
-    let reason = if args.len() > 2 {
-        args[2..].join(" ")
-    } else {
-        String::new()
-    };
+fn cmd_interrupt(task_id: &str, interrupt_type: &str, reason: &[String]) -> io::Result<()> {
+    let reason_str = reason.join(" ");
 
     let identity = load_or_create_identity();
-    let msg =
-        delegation::build_interrupt_message(task_id, interrupt_type, &reason, identity.as_str());
+    let msg = delegation::build_interrupt_message(
+        task_id,
+        interrupt_type,
+        &reason_str,
+        identity.as_str(),
+    );
 
     println!("Interrupt built for task {}", task_id);
     println!("  Type: {}", interrupt_type);
-    if !reason.is_empty() {
-        println!("  Reason: {}", reason);
+    if !reason_str.is_empty() {
+        println!("  Reason: {}", reason_str);
     }
     println!("  Message ID: {}", msg.id);
     println!();
@@ -755,11 +753,8 @@ fn cmd_interrupt(args: &[&str]) -> io::Result<()> {
 // Discovery commands: invite, join, discover
 // ────────────────────────────────────────────────────────────────────────────
 
-/// `claudectl relay invite [--qr] [--words] [--json]`
-fn cmd_invite(args: &[&str], json_mode: bool) -> io::Result<()> {
-    let show_qr = args.contains(&"--qr");
-    let show_words = args.contains(&"--words");
-
+/// `claudectl relay invite [--qr] [--words]`
+fn cmd_invite(show_qr: bool, show_words: bool, json_mode: bool) -> io::Result<()> {
     let identity = load_or_create_identity();
     let cfg = crate::config::Config::load();
     let relay_cfg = cfg.relay.unwrap_or_default();
@@ -813,11 +808,11 @@ fn cmd_invite(args: &[&str], json_mode: bool) -> io::Result<()> {
     // Join instructions
     println!("Share any of the above with your peer. They run:");
     println!();
-    println!("  claudectl --relay \"join {}\"", relay_code);
+    println!("  claudectl relay join {}", relay_code);
     if show_words {
-        println!("  claudectl --relay \"join {}\"", word_phrase);
+        println!("  claudectl relay join {}", word_phrase);
     }
-    println!("  claudectl --relay \"join {}\"", invite_link);
+    println!("  claudectl relay join {}", invite_link);
     println!();
 
     // QR code
@@ -836,13 +831,13 @@ fn cmd_invite(args: &[&str], json_mode: bool) -> io::Result<()> {
 }
 
 /// `claudectl relay join <code|link|words>`
-fn cmd_join(args: &[&str]) -> io::Result<()> {
-    if args.is_empty() {
-        eprintln!("Usage: claudectl --relay \"join <relay-code | invite-link | word-phrase>\"");
+fn cmd_join(input: &[String]) -> io::Result<()> {
+    if input.is_empty() {
+        eprintln!("Usage: claudectl relay join <relay-code | invite-link | word-phrase>");
         return Err(io::Error::other("missing argument"));
     }
 
-    let input = args.join(" ");
+    let input = input.join(" ");
     let identity = load_or_create_identity();
 
     // Detect format and parse
@@ -895,7 +890,7 @@ fn cmd_join(args: &[&str]) -> io::Result<()> {
     Ok(())
 }
 
-/// `claudectl relay discover [--json]`
+/// `claudectl relay discover`
 fn cmd_discover(json_mode: bool) -> io::Result<()> {
     let identity = load_or_create_identity();
 
@@ -922,8 +917,8 @@ fn cmd_discover(json_mode: bool) -> io::Result<()> {
     if peers.is_empty() {
         println!("No claudectl instances found on the local network.");
         println!();
-        println!("Make sure peers are running: claudectl --relay serve");
-        println!("Or use invite codes: claudectl --relay invite");
+        println!("Make sure peers are running: claudectl relay serve");
+        println!("Or use invite codes: claudectl relay invite");
     } else {
         println!("Found {} instance(s):", peers.len());
         println!();
@@ -944,8 +939,8 @@ fn cmd_discover(json_mode: bool) -> io::Result<()> {
             );
         }
         println!();
-        println!("To pair, run: claudectl --relay \"invite\" on the remote machine,");
-        println!("then:         claudectl --relay \"join <code>\" here.");
+        println!("To pair, run: claudectl relay invite on the remote machine,");
+        println!("then:         claudectl relay join <code> here.");
     }
 
     Ok(())

--- a/src/ui/peers.rs
+++ b/src/ui/peers.rs
@@ -28,10 +28,9 @@ pub fn render_peers_panel(frame: &mut Frame, area: Rect, peers: &[PeerDisplayInf
         .border_style(Style::default().fg(theme.border));
 
     if peers.is_empty() {
-        let text =
-            Paragraph::new("No connected peers. Use `claudectl --relay pair` to get started.")
-                .block(block)
-                .style(Style::default().fg(theme.text_muted));
+        let text = Paragraph::new("No connected peers. Use `claudectl relay pair` to get started.")
+            .block(block)
+            .style(Style::default().fg(theme.text_muted));
         frame.render_widget(text, area);
         return;
     }


### PR DESCRIPTION
## Summary

- Replace string-based `--relay "..."`, `--hive "..."`, `--coord "..."` CLI flags with proper clap `#[derive(Subcommand)]` enums
- Define `RelayCommand` (14 variants), `HiveCommand` (9 variants), `CoordCommand` (21 variants) with typed fields
- Add `Command` top-level enum with feature-gated variants to `Cli` struct
- Update all documentation and user-facing strings to new syntax

## Motivation

Closes #208. The old string-based pattern had no shell tab completion, required quoting for inner flags, gave no clap validation or per-subcommand `--help`, and was inconsistent with `git`/`cargo`/`docker`.

## Breaking Change

```bash
# Before:
claudectl --relay "invite --qr --words"
claudectl --hive "knowledge --from ci-runner"
claudectl --coord "claim --session s1 --path src/app.rs"

# After:
claudectl relay invite --qr --words
claudectl hive knowledge --from ci-runner
claudectl coord claim --session s1 --path src/app.rs
```

Hard break (option 1 from #208) since pre-1.0.

## Test plan

- [x] `cargo build` with default features (hive)
- [x] `cargo build --features relay,coord` (all features)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test` — 399 tests pass
- [x] `claudectl hive --help` shows 9 subcommands
- [x] `claudectl hive trust --help` shows typed args
- [x] `claudectl --help` with all features shows relay/hive/coord subcommands
- [x] No remaining `--relay`/`--hive`/`--coord` references in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)