### PR TITLE
feat: hive skill, command, and hook transfer across instances

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -220,6 +220,8 @@ pub struct HiveConfig {
     pub exclude_tools: Vec<String>,
     /// Command patterns to exclude from sharing (substring match).
     pub exclude_commands: Vec<String>,
+    /// Content types to exclude from sharing (e.g., "skill", "command", "hook").
+    pub exclude_content_types: Vec<String>,
     /// Maximum knowledge units to keep in the store. Oldest/lowest-confidence evicted.
     pub max_units: usize,
     /// Maximum knowledge units to inject into the brain prompt per evaluation.
@@ -242,6 +244,7 @@ impl Default for HiveConfig {
             share_categories: Vec::new(),
             exclude_tools: Vec::new(),
             exclude_commands: Vec::new(),
+            exclude_content_types: Vec::new(),
             max_units: 500,
             max_prompt_units: 20,
             stale_peer_days: 90,
@@ -331,6 +334,7 @@ struct RawHiveConfig {
     share_categories: Vec<String>,
     exclude_tools: Vec<String>,
     exclude_commands: Vec<String>,
+    exclude_content_types: Vec<String>,
     max_units: Option<usize>,
     max_prompt_units: Option<usize>,
     stale_peer_days: Option<u32>,
@@ -531,6 +535,9 @@ impl Config {
             }
             if !raw_hive.exclude_commands.is_empty() {
                 hive.exclude_commands = raw_hive.exclude_commands;
+            }
+            if !raw_hive.exclude_content_types.is_empty() {
+                hive.exclude_content_types = raw_hive.exclude_content_types;
             }
             if let Some(v) = raw_hive.max_units {
                 hive.max_units = v;
@@ -1158,6 +1165,9 @@ fn parse_config_file(path: &PathBuf) -> Option<RawConfig> {
                     }
                     "exclude_commands" => {
                         hive.exclude_commands = parse_string_array(value);
+                    }
+                    "exclude_content_types" => {
+                        hive.exclude_content_types = parse_string_array(value);
                     }
                     "max_units" => {
                         hive.max_units = value.parse().ok();

--- a/src/hive/cli.rs
+++ b/src/hive/cli.rs
@@ -57,6 +57,36 @@ pub enum HiveCommand {
 
     /// Show distilled curriculum
     Curriculum,
+
+    /// Share a local skill, command, or hook with the hive
+    Share {
+        /// Content type: skill, command, or hook
+        content_type: String,
+        /// Path to the file (skill .md, command .md, or hooks.json entry)
+        path: String,
+        /// Scope: universal, language:X, or project:X
+        #[arg(long, default_value = "universal")]
+        scope: String,
+    },
+
+    /// Install a received skill, command, or hook from the hive
+    Install {
+        /// Knowledge unit ID to install
+        unit_id: String,
+        /// Target directory (default: ~/.claude)
+        #[arg(long)]
+        target: Option<String>,
+    },
+
+    /// List available shared skills, commands, and hooks from peers
+    Shared {
+        /// Filter by type: skill, command, hook
+        #[arg(long, name = "type")]
+        content_type: Option<String>,
+        /// Show items from ignored peers
+        #[arg(long)]
+        show_ignored: bool,
+    },
 }
 
 /// Dispatch a hive subcommand.
@@ -73,6 +103,18 @@ pub fn dispatch_command(command: &HiveCommand, json_mode: bool) -> io::Result<()
         HiveCommand::Archive { prune } => cmd_archive(prune.as_deref(), json_mode),
         HiveCommand::Distill => cmd_distill(json_mode),
         HiveCommand::Curriculum => cmd_curriculum(json_mode),
+        HiveCommand::Share {
+            content_type,
+            path,
+            scope,
+        } => cmd_share(content_type, path, scope, json_mode),
+        HiveCommand::Install { unit_id, target } => {
+            cmd_install(unit_id, target.as_deref(), json_mode)
+        }
+        HiveCommand::Shared {
+            content_type,
+            show_ignored,
+        } => cmd_shared(content_type.as_deref(), *show_ignored, json_mode),
     }
 }
 
@@ -351,6 +393,463 @@ fn parse_scope(s: &str) -> KnowledgeScope {
     } else {
         // Try shorthand: "rust" -> Language, anything else -> Project
         KnowledgeScope::Project(s.to_string())
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Frontmatter parsing
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Parse YAML frontmatter from a markdown file.
+/// Returns key-value pairs from the `---`-delimited block.
+fn parse_frontmatter(content: &str) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return map;
+    }
+
+    // Find closing ---
+    let after_open = &trimmed[3..].trim_start_matches('\r');
+    let after_open = after_open.strip_prefix('\n').unwrap_or(after_open);
+
+    let Some(close_pos) = after_open.find("\n---") else {
+        return map;
+    };
+
+    let yaml_block = &after_open[..close_pos];
+
+    for line in yaml_block.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once(':') {
+            let key = key.trim().to_string();
+            let value = value
+                .trim()
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_string();
+            if !key.is_empty() && !value.is_empty() {
+                map.insert(key, value);
+            }
+        }
+    }
+
+    map
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Share, Install, Shared commands
+// ────────────────────────────────────────────────────────────────────────────
+
+/// `claudectl hive share <type> <path> [--scope X]`
+fn cmd_share(content_type: &str, path: &str, scope_str: &str, json_mode: bool) -> io::Result<()> {
+    let body =
+        std::fs::read_to_string(path).map_err(|e| io::Error::other(format!("read {path}: {e}")))?;
+
+    let scope = parse_scope(scope_str);
+    let identity = super::local_identity();
+    let now = super::epoch_secs();
+
+    let content = match content_type {
+        "skill" => {
+            if body.len() > super::MAX_SKILL_BYTES {
+                return Err(io::Error::other(format!(
+                    "skill body too large: {} bytes (max {})",
+                    body.len(),
+                    super::MAX_SKILL_BYTES
+                )));
+            }
+            let fm = parse_frontmatter(&body);
+            let name = fm
+                .get("name")
+                .cloned()
+                .ok_or_else(|| io::Error::other("skill missing 'name' in frontmatter"))?;
+            let description = fm
+                .get("description")
+                .cloned()
+                .unwrap_or_else(|| name.clone());
+            let version = fm.get("version").cloned().unwrap_or_else(|| "0.0.0".into());
+            super::KnowledgeContent::Skill {
+                name,
+                description,
+                version,
+                body,
+            }
+        }
+        "command" => {
+            if body.len() > super::MAX_COMMAND_BYTES {
+                return Err(io::Error::other(format!(
+                    "command body too large: {} bytes (max {})",
+                    body.len(),
+                    super::MAX_COMMAND_BYTES
+                )));
+            }
+            let fm = parse_frontmatter(&body);
+            let name = fm
+                .get("name")
+                .cloned()
+                .ok_or_else(|| io::Error::other("command missing 'name' in frontmatter"))?;
+            let description = fm
+                .get("description")
+                .cloned()
+                .unwrap_or_else(|| name.clone());
+            let args = fm.get("args").cloned();
+            super::KnowledgeContent::Command {
+                name,
+                description,
+                args,
+                body,
+            }
+        }
+        "hook" => {
+            if body.len() > super::MAX_HOOK_CONFIG_BYTES {
+                return Err(io::Error::other(format!(
+                    "hook config too large: {} bytes (max {})",
+                    body.len(),
+                    super::MAX_HOOK_CONFIG_BYTES
+                )));
+            }
+            // Parse as JSON hook config
+            let parsed: serde_json::Value = serde_json::from_str(&body)
+                .map_err(|e| io::Error::other(format!("invalid JSON: {e}")))?;
+
+            let event = parsed
+                .get("event")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| io::Error::other("hook config missing 'event' field"))?
+                .to_string();
+            let matcher = parsed
+                .get("matcher")
+                .and_then(|v| v.as_str())
+                .unwrap_or("*")
+                .to_string();
+            let description = parsed
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            let sanitized = super::sanitize_hook_config(&body);
+
+            super::KnowledgeContent::HookConfig {
+                event,
+                matcher,
+                description,
+                config_json: sanitized,
+            }
+        }
+        other => {
+            return Err(io::Error::other(format!(
+                "unknown content type: {other} (expected: skill, command, hook)"
+            )));
+        }
+    };
+
+    let category = match &content {
+        super::KnowledgeContent::HookConfig { .. } => super::KnowledgeCategory::WorkflowPattern,
+        _ => super::KnowledgeCategory::Technique,
+    };
+
+    let unit = super::KnowledgeUnit {
+        id: super::gen_ku_id(),
+        scope,
+        category,
+        content,
+        evidence_count: 1,
+        confidence: 1.0,
+        source_peer: identity,
+        originated_at: now,
+        last_validated_at: now,
+        propagation_count: 0,
+        version: 1,
+    };
+
+    let summary = unit.content.summary_line();
+    let unit_id = unit.id.clone();
+
+    let mut store = HiveStore::load();
+    store.insert(unit);
+    store
+        .save()
+        .map_err(|e| io::Error::other(format!("save: {e}")))?;
+
+    // Signal gossip if relay is active
+    #[cfg(feature = "relay")]
+    super::signal_new_knowledge(1);
+
+    if json_mode {
+        let output = serde_json::json!({
+            "action": "shared",
+            "unit_id": unit_id,
+            "content_type": content_type,
+            "summary": summary,
+        });
+        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+    } else {
+        println!("Shared {content_type}: {summary}");
+        println!("  Unit ID: {unit_id}");
+    }
+
+    Ok(())
+}
+
+/// `claudectl hive install <unit_id> [--target dir]`
+fn cmd_install(unit_id: &str, target: Option<&str>, json_mode: bool) -> io::Result<()> {
+    let store = HiveStore::load();
+    let unit = store
+        .get(unit_id)
+        .ok_or_else(|| io::Error::other(format!("unknown unit: {unit_id}")))?;
+
+    // Check trust tier
+    let trust_store = super::trust::TrustStore::load();
+    let tier = trust_store
+        .get(&unit.source_peer)
+        .map(|t| t.tier())
+        .unwrap_or(super::trust::TrustTier::Suggested);
+
+    if tier == super::trust::TrustTier::Ignored {
+        return Err(io::Error::other(format!(
+            "source peer '{}' is in Ignored tier (trust < 0.2). \
+             Set higher trust first: claudectl hive trust {} 0.5",
+            unit.source_peer, unit.source_peer,
+        )));
+    }
+
+    let base_dir = match target {
+        Some(t) => std::path::PathBuf::from(t),
+        None => {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+            std::path::PathBuf::from(home).join(".claude")
+        }
+    };
+
+    match &unit.content {
+        super::KnowledgeContent::Skill {
+            name,
+            version,
+            body,
+            ..
+        } => {
+            let slug = name.to_lowercase().replace(' ', "-");
+            let skill_dir = base_dir.join("skills").join(&slug);
+            std::fs::create_dir_all(&skill_dir)?;
+            let file_path = skill_dir.join("SKILL.md");
+            std::fs::write(&file_path, body)?;
+
+            if tier == super::trust::TrustTier::Unverified {
+                eprintln!(
+                    "Warning: source peer '{}' is unverified (trust < 0.5). \
+                     Review the installed skill before relying on it.",
+                    unit.source_peer
+                );
+            }
+
+            if json_mode {
+                let output = serde_json::json!({
+                    "action": "installed",
+                    "content_type": "skill",
+                    "name": name,
+                    "version": version,
+                    "path": file_path.display().to_string(),
+                    "trust_tier": tier.label(),
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            } else {
+                println!(
+                    "Installed skill '{name}' v{version} to {}",
+                    file_path.display()
+                );
+            }
+        }
+        super::KnowledgeContent::Command {
+            name, body, args, ..
+        } => {
+            let cmds_dir = base_dir.join("commands");
+            std::fs::create_dir_all(&cmds_dir)?;
+            let file_path = cmds_dir.join(format!("{name}.md"));
+            std::fs::write(&file_path, body)?;
+
+            if tier == super::trust::TrustTier::Unverified {
+                eprintln!(
+                    "Warning: source peer '{}' is unverified. Review before use.",
+                    unit.source_peer
+                );
+            }
+
+            if json_mode {
+                let output = serde_json::json!({
+                    "action": "installed",
+                    "content_type": "command",
+                    "name": name,
+                    "args": args,
+                    "path": file_path.display().to_string(),
+                    "trust_tier": tier.label(),
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            } else {
+                println!("Installed command '/{name}' to {}", file_path.display());
+            }
+        }
+        super::KnowledgeContent::HookConfig {
+            event,
+            matcher,
+            description,
+            config_json,
+            ..
+        } => {
+            if tier == super::trust::TrustTier::Unverified {
+                eprintln!(
+                    "Warning: source peer '{}' is unverified. Review the hook config carefully.",
+                    unit.source_peer
+                );
+            }
+
+            if json_mode {
+                let output = serde_json::json!({
+                    "action": "installed",
+                    "content_type": "hook",
+                    "event": event,
+                    "matcher": matcher,
+                    "description": description,
+                    "config_json": config_json,
+                    "trust_tier": tier.label(),
+                    "note": "Add this config to your hooks.json manually",
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            } else {
+                println!("Hook config: {event}[{matcher}] — {description}");
+                println!();
+                println!("Add the following to your hooks.json:");
+                println!("{config_json}");
+                println!();
+                println!("Note: You must create the hook script implementation yourself.");
+            }
+        }
+        _ => {
+            return Err(io::Error::other(format!(
+                "unit {unit_id} is not a skill, command, or hook"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// `claudectl hive shared [--type X] [--show-ignored]`
+fn cmd_shared(
+    content_type_filter: Option<&str>,
+    show_ignored: bool,
+    json_mode: bool,
+) -> io::Result<()> {
+    let store = HiveStore::load();
+    let trust_store = super::trust::TrustStore::load();
+
+    let units: Vec<(&super::KnowledgeUnit, super::trust::TrustTier)> = store
+        .all_units()
+        .into_iter()
+        .filter_map(|unit| {
+            // Filter to artifact types only
+            let type_label = match &unit.content {
+                super::KnowledgeContent::Skill { .. } => "skill",
+                super::KnowledgeContent::Command { .. } => "command",
+                super::KnowledgeContent::HookConfig { .. } => "hook",
+                _ => return None,
+            };
+
+            // Apply type filter
+            if let Some(filter) = content_type_filter {
+                if type_label != filter {
+                    return None;
+                }
+            }
+
+            let tier = trust_store
+                .get(&unit.source_peer)
+                .map(|t| t.tier())
+                .unwrap_or(super::trust::TrustTier::Suggested);
+
+            // Skip ignored unless requested
+            if tier == super::trust::TrustTier::Ignored && !show_ignored {
+                return None;
+            }
+
+            Some((unit, tier))
+        })
+        .collect();
+
+    if json_mode {
+        let items: Vec<serde_json::Value> = units
+            .iter()
+            .map(|(unit, tier)| {
+                serde_json::json!({
+                    "id": unit.id,
+                    "type": content_type_label(&unit.content),
+                    "name": content_name(&unit.content),
+                    "source_peer": unit.source_peer,
+                    "trust_tier": tier.label(),
+                    "summary": unit.content.summary_line(),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&items).unwrap());
+    } else if units.is_empty() {
+        println!("No shared skills, commands, or hooks available.");
+        println!("Share content with: claudectl hive share <skill|command|hook> <path>");
+    } else {
+        println!(
+            "{:<12} {:<8} {:<20} {:<16} CONTENT",
+            "ID", "TYPE", "SOURCE", "TRUST"
+        );
+        println!("{}", "─".repeat(80));
+        for (unit, tier) in &units {
+            let id_short = if unit.id.len() > 11 {
+                &unit.id[..11]
+            } else {
+                &unit.id
+            };
+            let type_label = content_type_label(&unit.content);
+            println!(
+                "{:<12} {:<8} {:<20} {:<16} {}",
+                id_short,
+                type_label,
+                unit.source_peer,
+                tier.label(),
+                unit.content.summary_line(),
+            );
+        }
+        println!();
+        println!(
+            "{} items total. Install with: claudectl hive install <id>",
+            units.len()
+        );
+    }
+
+    Ok(())
+}
+
+/// Get the content type label for display.
+fn content_type_label(content: &super::KnowledgeContent) -> &'static str {
+    match content {
+        super::KnowledgeContent::Skill { .. } => "skill",
+        super::KnowledgeContent::Command { .. } => "command",
+        super::KnowledgeContent::HookConfig { .. } => "hook",
+        _ => "other",
+    }
+}
+
+/// Get the name from a content unit.
+fn content_name(content: &super::KnowledgeContent) -> String {
+    match content {
+        super::KnowledgeContent::Skill { name, .. } => name.clone(),
+        super::KnowledgeContent::Command { name, .. } => name.clone(),
+        super::KnowledgeContent::HookConfig { event, matcher, .. } => {
+            format!("{event}[{matcher}]")
+        }
+        _ => String::new(),
     }
 }
 

--- a/src/hive/cli.rs
+++ b/src/hive/cli.rs
@@ -76,6 +76,9 @@ pub enum HiveCommand {
         /// Target directory (default: ~/.claude)
         #[arg(long)]
         target: Option<String>,
+        /// Force install even if compatibility checks fail
+        #[arg(long)]
+        force: bool,
     },
 
     /// List available shared skills, commands, and hooks from peers
@@ -108,9 +111,11 @@ pub fn dispatch_command(command: &HiveCommand, json_mode: bool) -> io::Result<()
             path,
             scope,
         } => cmd_share(content_type, path, scope, json_mode),
-        HiveCommand::Install { unit_id, target } => {
-            cmd_install(unit_id, target.as_deref(), json_mode)
-        }
+        HiveCommand::Install {
+            unit_id,
+            target,
+            force,
+        } => cmd_install(unit_id, target.as_deref(), *force, json_mode),
         HiveCommand::Shared {
             content_type,
             show_ignored,
@@ -445,6 +450,34 @@ fn parse_frontmatter(content: &str) -> std::collections::HashMap<String, String>
 // Share, Install, Shared commands
 // ────────────────────────────────────────────────────────────────────────────
 
+/// Build `ArtifactRequires` from frontmatter overrides + auto-detection.
+/// Frontmatter keys: `requires_cli`, `requires_os`, `requires_min_version`.
+fn build_requires(
+    fm: &std::collections::HashMap<String, String>,
+    body: &str,
+) -> super::ArtifactRequires {
+    // Frontmatter overrides take priority
+    let cli = if let Some(val) = fm.get("requires_cli") {
+        val.split(',').map(|s| s.trim().to_string()).collect()
+    } else {
+        super::detect_cli_deps(body)
+    };
+
+    let os = if let Some(val) = fm.get("requires_os") {
+        val.split(',').map(|s| s.trim().to_string()).collect()
+    } else {
+        super::detect_os_deps(body)
+    };
+
+    let min_version = fm.get("requires_min_version").cloned();
+
+    super::ArtifactRequires {
+        cli,
+        os,
+        min_version,
+    }
+}
+
 /// `claudectl hive share <type> <path> [--scope X]`
 fn cmd_share(content_type: &str, path: &str, scope_str: &str, json_mode: bool) -> io::Result<()> {
     let body =
@@ -473,11 +506,13 @@ fn cmd_share(content_type: &str, path: &str, scope_str: &str, json_mode: bool) -
                 .cloned()
                 .unwrap_or_else(|| name.clone());
             let version = fm.get("version").cloned().unwrap_or_else(|| "0.0.0".into());
+            let requires = build_requires(&fm, &body);
             super::KnowledgeContent::Skill {
                 name,
                 description,
                 version,
                 body,
+                requires,
             }
         }
         "command" => {
@@ -498,11 +533,13 @@ fn cmd_share(content_type: &str, path: &str, scope_str: &str, json_mode: bool) -
                 .cloned()
                 .unwrap_or_else(|| name.clone());
             let args = fm.get("args").cloned();
+            let requires = build_requires(&fm, &body);
             super::KnowledgeContent::Command {
                 name,
                 description,
                 args,
                 body,
+                requires,
             }
         }
         "hook" => {
@@ -535,11 +572,21 @@ fn cmd_share(content_type: &str, path: &str, scope_str: &str, json_mode: bool) -
 
             let sanitized = super::sanitize_hook_config(&body);
 
+            // For hooks: extract command binary as a CLI dep
+            let mut requires = super::ArtifactRequires::default();
+            if let Some(cmd) = parsed.get("command").and_then(|v| v.as_str()) {
+                let binary = cmd.rsplit('/').next().unwrap_or(cmd);
+                if !binary.is_empty() {
+                    requires.cli.push(binary.to_string());
+                }
+            }
+
             super::KnowledgeContent::HookConfig {
                 event,
                 matcher,
                 description,
                 config_json: sanitized,
+                requires,
             }
         }
         other => {
@@ -597,8 +644,13 @@ fn cmd_share(content_type: &str, path: &str, scope_str: &str, json_mode: bool) -
     Ok(())
 }
 
-/// `claudectl hive install <unit_id> [--target dir]`
-fn cmd_install(unit_id: &str, target: Option<&str>, json_mode: bool) -> io::Result<()> {
+/// `claudectl hive install <unit_id> [--target dir] [--force]`
+fn cmd_install(
+    unit_id: &str,
+    target: Option<&str>,
+    force: bool,
+    json_mode: bool,
+) -> io::Result<()> {
     let store = HiveStore::load();
     let unit = store
         .get(unit_id)
@@ -617,6 +669,26 @@ fn cmd_install(unit_id: &str, target: Option<&str>, json_mode: bool) -> io::Resu
              Set higher trust first: claudectl hive trust {} 0.5",
             unit.source_peer, unit.source_peer,
         )));
+    }
+
+    // Check compatibility
+    if let Some(requires) = super::get_requires(&unit.content) {
+        let issues = super::check_compatibility(requires);
+        if !issues.is_empty() {
+            let has_blocking = issues.iter().any(|i| i.is_blocking());
+            for issue in &issues {
+                if issue.is_blocking() {
+                    eprintln!("Error: {issue}");
+                } else {
+                    eprintln!("Warning: {issue}");
+                }
+            }
+            if has_blocking && !force {
+                return Err(io::Error::other(
+                    "compatibility check failed. Use --force to install anyway.",
+                ));
+            }
+        }
     }
 
     let base_dir = match target {
@@ -785,14 +857,20 @@ fn cmd_shared(
         let items: Vec<serde_json::Value> = units
             .iter()
             .map(|(unit, tier)| {
-                serde_json::json!({
+                let compat = super::compat_label(&unit.content);
+                let mut obj = serde_json::json!({
                     "id": unit.id,
                     "type": content_type_label(&unit.content),
                     "name": content_name(&unit.content),
                     "source_peer": unit.source_peer,
                     "trust_tier": tier.label(),
+                    "compat": compat,
                     "summary": unit.content.summary_line(),
-                })
+                });
+                if let Some(req) = super::get_requires(&unit.content) {
+                    obj["requires"] = serde_json::json!(req);
+                }
+                obj
             })
             .collect();
         println!("{}", serde_json::to_string_pretty(&items).unwrap());
@@ -801,10 +879,10 @@ fn cmd_shared(
         println!("Share content with: claudectl hive share <skill|command|hook> <path>");
     } else {
         println!(
-            "{:<12} {:<8} {:<20} {:<16} CONTENT",
-            "ID", "TYPE", "SOURCE", "TRUST"
+            "{:<12} {:<8} {:<16} {:<16} {:<6} CONTENT",
+            "ID", "TYPE", "SOURCE", "TRUST", "COMPAT"
         );
-        println!("{}", "─".repeat(80));
+        println!("{}", "─".repeat(90));
         for (unit, tier) in &units {
             let id_short = if unit.id.len() > 11 {
                 &unit.id[..11]
@@ -812,12 +890,14 @@ fn cmd_shared(
                 &unit.id
             };
             let type_label = content_type_label(&unit.content);
+            let compat = super::compat_label(&unit.content);
             println!(
-                "{:<12} {:<8} {:<20} {:<16} {}",
+                "{:<12} {:<8} {:<16} {:<16} {:<6} {}",
                 id_short,
                 type_label,
                 unit.source_peer,
                 tier.label(),
+                compat,
                 unit.content.summary_line(),
             );
         }

--- a/src/hive/injection.rs
+++ b/src/hive/injection.rs
@@ -26,9 +26,21 @@ pub fn build_hive_context(
     }
 
     // Score and sort: higher confidence * evidence first
+    // Skip Skill/Command/HookConfig — they aren't decision guidance for the brain.
+    // Users discover them via `claudectl hive shared`.
     let mut scored: Vec<(&super::KnowledgeUnit, f64, TrustTier)> = all
         .iter()
         .filter_map(|unit| {
+            // Skip artifact types — not relevant for brain decision-making
+            if matches!(
+                &unit.content,
+                KnowledgeContent::Skill { .. }
+                    | KnowledgeContent::Command { .. }
+                    | KnowledgeContent::HookConfig { .. }
+            ) {
+                return None;
+            }
+
             let tier = trust_store
                 .get(&unit.source_peer)
                 .map(|t| t.tier())
@@ -349,6 +361,47 @@ mod tests {
 
         let results = check_concordance(Some("Write"), Some("test"), "accept", &store);
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn build_context_excludes_skill_bodies() {
+        let mut store = empty_store();
+        store.insert(make_pattern_unit(
+            "ku_1",
+            "Bash",
+            Some("cargo test"),
+            "approve",
+            "peer-a",
+        ));
+        // Add a skill — should NOT appear in brain context
+        store.insert(KnowledgeUnit {
+            id: "ku_skill_1".into(),
+            scope: KnowledgeScope::Universal,
+            category: crate::hive::KnowledgeCategory::Technique,
+            content: KnowledgeContent::Skill {
+                name: "Session Monitoring".into(),
+                description: "Monitors sessions".into(),
+                version: "0.31.0".into(),
+                body: "Full skill body here".into(),
+            },
+            evidence_count: 1,
+            confidence: 1.0,
+            source_peer: "peer-a".into(),
+            originated_at: 1000,
+            last_validated_at: 2000,
+            propagation_count: 0,
+            version: 1,
+        });
+
+        let trust_store = TrustStore::load_with_default(0.5);
+        let ctx = build_hive_context(&store, &trust_store, true, 0);
+
+        // Should contain the pattern unit but NOT the skill
+        assert!(ctx.contains("Bash"));
+        assert!(!ctx.contains("Session Monitoring"));
+        assert!(!ctx.contains("skill"));
+        // Should show 1 unit, not 2
+        assert!(ctx.contains("1 units"));
     }
 
     #[test]

--- a/src/hive/injection.rs
+++ b/src/hive/injection.rs
@@ -383,6 +383,7 @@ mod tests {
                 description: "Monitors sessions".into(),
                 version: "0.31.0".into(),
                 body: "Full skill body here".into(),
+                requires: crate::hive::ArtifactRequires::default(),
             },
             evidence_count: 1,
             confidence: 1.0,

--- a/src/hive/mod.rs
+++ b/src/hive/mod.rs
@@ -115,6 +115,20 @@ pub const MAX_COMMAND_BYTES: usize = 16 * 1024;
 /// Maximum size for a shared hook config JSON (4 KB).
 pub const MAX_HOOK_CONFIG_BYTES: usize = 4 * 1024;
 
+/// Compatibility requirements for a shared artifact.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ArtifactRequires {
+    /// CLI binaries that must be on PATH (e.g., ["claudectl", "jq"]).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cli: Vec<String>,
+    /// Target OS labels (e.g., ["macos", "linux"]). Empty = any OS.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub os: Vec<String>,
+    /// Minimum claudectl version (e.g., "0.42.0"). None = any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_version: Option<String>,
+}
+
 /// The actual knowledge payload.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -153,6 +167,9 @@ pub enum KnowledgeContent {
         version: String,
         /// Full markdown content (frontmatter + body). Capped at MAX_SKILL_BYTES.
         body: String,
+        /// Compatibility requirements (CLIs, OS, version).
+        #[serde(default)]
+        requires: ArtifactRequires,
     },
     /// A shared slash command (markdown with YAML frontmatter).
     Command {
@@ -161,6 +178,9 @@ pub enum KnowledgeContent {
         args: Option<String>,
         /// Full markdown content (frontmatter + body). Capped at MAX_COMMAND_BYTES.
         body: String,
+        /// Compatibility requirements (CLIs, OS, version).
+        #[serde(default)]
+        requires: ArtifactRequires,
     },
     /// A shared hook configuration (declarative JSON, no executables).
     HookConfig {
@@ -171,6 +191,9 @@ pub enum KnowledgeContent {
         description: String,
         /// Sanitized hook config JSON (no secrets). Capped at MAX_HOOK_CONFIG_BYTES.
         config_json: String,
+        /// Compatibility requirements (CLIs, OS, version).
+        #[serde(default)]
+        requires: ArtifactRequires,
     },
 }
 
@@ -558,6 +581,287 @@ fn sanitize_user_paths(input: &str) -> String {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Compatibility checking
+// ────────────────────────────────────────────────────────────────────────────
+
+/// A compatibility issue found when checking an artifact against the local environment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompatIssue {
+    /// A required CLI binary is not on PATH.
+    MissingCli(String),
+    /// The artifact targets a different OS.
+    WrongOs {
+        current: String,
+        required: Vec<String>,
+    },
+    /// The local claudectl version is too old.
+    VersionTooOld { current: String, required: String },
+}
+
+impl CompatIssue {
+    /// Short label for display in the COMPAT column.
+    pub fn short_label(&self) -> &'static str {
+        match self {
+            Self::MissingCli(_) => "!cli",
+            Self::WrongOs { .. } => "!os",
+            Self::VersionTooOld { .. } => "!ver",
+        }
+    }
+
+    /// Whether this issue should block installation (vs just warn).
+    pub fn is_blocking(&self) -> bool {
+        matches!(self, Self::WrongOs { .. } | Self::VersionTooOld { .. })
+    }
+}
+
+impl std::fmt::Display for CompatIssue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingCli(cli) => write!(f, "missing CLI: {cli}"),
+            Self::WrongOs { current, required } => {
+                write!(
+                    f,
+                    "OS mismatch: running {current}, requires {}",
+                    required.join("/")
+                )
+            }
+            Self::VersionTooOld { current, required } => {
+                write!(f, "claudectl {current} too old, requires >= {required}")
+            }
+        }
+    }
+}
+
+/// Check an artifact's requirements against the local environment.
+pub fn check_compatibility(requires: &ArtifactRequires) -> Vec<CompatIssue> {
+    let mut issues = Vec::new();
+
+    for cli in &requires.cli {
+        if !is_cli_available(cli) {
+            issues.push(CompatIssue::MissingCli(cli.clone()));
+        }
+    }
+
+    if !requires.os.is_empty() {
+        let current = current_os_label();
+        if !requires.os.iter().any(|o| o == current) {
+            issues.push(CompatIssue::WrongOs {
+                current: current.to_string(),
+                required: requires.os.clone(),
+            });
+        }
+    }
+
+    if let Some(min_ver) = &requires.min_version {
+        let current = env!("CARGO_PKG_VERSION");
+        if !version_gte(current, min_ver) {
+            issues.push(CompatIssue::VersionTooOld {
+                current: current.to_string(),
+                required: min_ver.clone(),
+            });
+        }
+    }
+
+    issues
+}
+
+/// Check if a CLI binary is available on PATH.
+pub fn is_cli_available(name: &str) -> bool {
+    // Reject names with path separators or shell metacharacters
+    if name.contains('/') || name.contains('\\') || name.contains(';') || name.is_empty() {
+        return false;
+    }
+    std::process::Command::new("which")
+        .arg(name)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Current OS label for compatibility matching.
+pub fn current_os_label() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        "unknown"
+    }
+}
+
+/// Simple semver comparison: is `current` >= `required`?
+/// Compares major.minor.patch numerically. Non-numeric parts are treated as 0.
+fn version_gte(current: &str, required: &str) -> bool {
+    let parse = |s: &str| -> (u32, u32, u32) {
+        let parts: Vec<u32> = s
+            .split('.')
+            .take(3)
+            .map(|p| p.parse().unwrap_or(0))
+            .collect();
+        (
+            parts.first().copied().unwrap_or(0),
+            parts.get(1).copied().unwrap_or(0),
+            parts.get(2).copied().unwrap_or(0),
+        )
+    };
+    parse(current) >= parse(required)
+}
+
+/// Shell builtins and common shell syntax tokens to exclude from CLI detection.
+const SHELL_BUILTINS: &[&str] = &[
+    "if", "then", "else", "fi", "for", "do", "done", "while", "until", "case", "esac", "in",
+    "echo", "printf", "cd", "export", "set", "unset", "local", "return", "exit", "source", ".",
+    "true", "false", "test", "[", "[[", "read", "shift", "eval", "exec", "trap", "wait", "sleep",
+    "cat", "head", "tail", "grep", "sed", "awk", "tr", "cut", "sort", "uniq", "wc", "tee", "mkdir",
+    "rm", "cp", "mv", "ls", "touch", "chmod", "chown", "ln", "find", "xargs",
+];
+
+/// Detect CLI dependencies by scanning bash code blocks in a markdown body.
+pub fn detect_cli_deps(body: &str) -> Vec<String> {
+    let mut deps = std::collections::BTreeSet::new();
+    let mut in_bash_block = false;
+
+    for line in body.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with("```bash") || trimmed.starts_with("```sh") {
+            in_bash_block = true;
+            continue;
+        }
+        if trimmed.starts_with("```") && in_bash_block {
+            in_bash_block = false;
+            continue;
+        }
+
+        if !in_bash_block {
+            continue;
+        }
+
+        // Skip comments and empty lines
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        // Extract the first token (the command being run)
+        // Handle pipes: each segment after | is a new command
+        for segment in trimmed.split('|') {
+            let segment = segment.trim();
+            // Strip leading env var assignments (KEY=val cmd)
+            let cmd_part = skip_env_assignments(segment);
+            if let Some(cmd) = cmd_part.split_whitespace().next() {
+                // Strip path prefix if present
+                let base = cmd.rsplit('/').next().unwrap_or(cmd);
+                if !base.is_empty()
+                    && !SHELL_BUILTINS.contains(&base)
+                    && base
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+                {
+                    deps.insert(base.to_string());
+                }
+            }
+        }
+    }
+
+    deps.into_iter().collect()
+}
+
+/// Skip leading `KEY=value` assignments to find the actual command.
+fn skip_env_assignments(s: &str) -> &str {
+    let mut rest = s;
+    loop {
+        let trimmed = rest.trim_start();
+        // Check for KEY=... pattern (uppercase start, has =)
+        if let Some(eq_pos) = trimmed.find('=') {
+            let key = &trimmed[..eq_pos];
+            if !key.is_empty()
+                && key
+                    .chars()
+                    .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+            {
+                // Skip past the value
+                let after_eq = &trimmed[eq_pos + 1..];
+                // Quoted value
+                if let Some(inner) = after_eq.strip_prefix('"') {
+                    if let Some(end) = inner.find('"') {
+                        rest = &inner[end + 1..];
+                        continue;
+                    }
+                } else if let Some(inner) = after_eq.strip_prefix('\'') {
+                    if let Some(end) = inner.find('\'') {
+                        rest = &inner[end + 1..];
+                        continue;
+                    }
+                } else {
+                    // Unquoted — next whitespace
+                    let end = after_eq.find(char::is_whitespace).unwrap_or(after_eq.len());
+                    rest = &after_eq[end..];
+                    continue;
+                }
+            }
+        }
+        return trimmed;
+    }
+}
+
+/// Detect OS requirements from body content heuristics.
+pub fn detect_os_deps(body: &str) -> Vec<String> {
+    let mut os_set = std::collections::BTreeSet::new();
+
+    let lower = body.to_lowercase();
+
+    // macOS signals
+    if lower.contains("brew ") || lower.contains("brew install") || lower.contains("/usr/local/bin")
+    {
+        os_set.insert("macos".to_string());
+    }
+
+    // Linux signals
+    if lower.contains("apt-get")
+        || lower.contains("apt install")
+        || lower.contains("systemctl")
+        || lower.contains("yum install")
+        || lower.contains("dnf install")
+    {
+        os_set.insert("linux".to_string());
+    }
+
+    os_set.into_iter().collect()
+}
+
+/// Get the `requires` field from a KnowledgeContent, if it's an artifact type.
+pub fn get_requires(content: &KnowledgeContent) -> Option<&ArtifactRequires> {
+    match content {
+        KnowledgeContent::Skill { requires, .. }
+        | KnowledgeContent::Command { requires, .. }
+        | KnowledgeContent::HookConfig { requires, .. } => Some(requires),
+        _ => None,
+    }
+}
+
+/// Compute a short compatibility label for display.
+/// Returns "ok", "!cli", "!os", "!ver", or "?" (no requirements declared).
+pub fn compat_label(content: &KnowledgeContent) -> &'static str {
+    match get_requires(content) {
+        None => "—",
+        Some(req) if req.cli.is_empty() && req.os.is_empty() && req.min_version.is_none() => "?",
+        Some(req) => {
+            let issues = check_compatibility(req);
+            if issues.is_empty() {
+                "ok"
+            } else {
+                // Return the first (most important) issue label
+                issues[0].short_label()
+            }
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Display helpers
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -826,6 +1130,7 @@ mod tests {
                 description: "Monitors sessions".into(),
                 version: "0.31.0".into(),
                 body: "---\nname: Session Monitoring\n---\nContent here".into(),
+                requires: ArtifactRequires::default(),
             },
             evidence_count: 1,
             confidence: 1.0,
@@ -847,6 +1152,7 @@ mod tests {
                 description: "Toggle brain gate".into(),
                 args: Some("[on|off|auto|status]".into()),
                 body: "---\nname: brain\n---\nContent".into(),
+                requires: ArtifactRequires::default(),
             },
             evidence_count: 1,
             confidence: 1.0,
@@ -868,6 +1174,7 @@ mod tests {
                 matcher: "Bash|Write|Edit".into(),
                 description: "Brain gate hook".into(),
                 config_json: r#"{"command": "brain-gate.sh", "timeout": 5000}"#.into(),
+                requires: ArtifactRequires::default(),
             },
             evidence_count: 1,
             confidence: 1.0,
@@ -924,6 +1231,7 @@ mod tests {
             description: "List sessions".into(),
             args: None,
             body: "body".into(),
+            requires: ArtifactRequires::default(),
         };
         let line = content.summary_line();
         assert_eq!(line, "command: /sessions");
@@ -1090,5 +1398,245 @@ mod tests {
         let input = r#"{"command": "brain-gate.sh", "timeout": 5000}"#;
         let result = sanitize_hook_config(input);
         assert_eq!(result, input);
+    }
+
+    // ── Compatibility tests ────────────────────────────────────────────
+
+    #[test]
+    fn artifact_requires_serde_roundtrip() {
+        let req = ArtifactRequires {
+            cli: vec!["claudectl".into(), "jq".into()],
+            os: vec!["macos".into()],
+            min_version: Some("0.42.0".into()),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let back: ArtifactRequires = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.cli, vec!["claudectl", "jq"]);
+        assert_eq!(back.os, vec!["macos"]);
+        assert_eq!(back.min_version.as_deref(), Some("0.42.0"));
+    }
+
+    #[test]
+    fn artifact_requires_default_empty() {
+        let req = ArtifactRequires::default();
+        assert!(req.cli.is_empty());
+        assert!(req.os.is_empty());
+        assert!(req.min_version.is_none());
+    }
+
+    #[test]
+    fn artifact_requires_skips_empty_on_serialize() {
+        let req = ArtifactRequires::default();
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn artifact_requires_backward_compat_deserialize() {
+        // Old units without `requires` should deserialize with empty default
+        let json =
+            r#"{"type":"skill","name":"Test","description":"Test","version":"1.0","body":"x"}"#;
+        let content: KnowledgeContent = serde_json::from_str(json).unwrap();
+        if let KnowledgeContent::Skill { requires, .. } = content {
+            assert!(requires.cli.is_empty());
+            assert!(requires.os.is_empty());
+        } else {
+            panic!("expected Skill");
+        }
+    }
+
+    #[test]
+    fn version_gte_basic() {
+        assert!(version_gte("0.42.0", "0.42.0"));
+        assert!(version_gte("0.43.0", "0.42.0"));
+        assert!(version_gte("1.0.0", "0.99.99"));
+        assert!(!version_gte("0.41.0", "0.42.0"));
+        assert!(!version_gte("0.42.0", "0.42.1"));
+    }
+
+    #[test]
+    fn version_gte_partial() {
+        assert!(version_gte("1.0", "0.42.0"));
+        assert!(version_gte("1", "0"));
+    }
+
+    #[test]
+    fn current_os_label_not_unknown() {
+        let label = current_os_label();
+        assert!(label == "macos" || label == "linux" || label == "windows");
+    }
+
+    #[test]
+    fn is_cli_available_rejects_path_traversal() {
+        assert!(!is_cli_available("../../../etc/passwd"));
+        assert!(!is_cli_available("foo;rm -rf /"));
+        assert!(!is_cli_available(""));
+    }
+
+    #[test]
+    fn detect_cli_deps_basic() {
+        let body = r#"
+# Usage
+
+```bash
+claudectl --list
+jq '.sessions[]' output.json
+cargo test --all
+```
+
+Some text.
+"#;
+        let deps = detect_cli_deps(body);
+        assert!(deps.contains(&"claudectl".to_string()));
+        assert!(deps.contains(&"jq".to_string()));
+        assert!(deps.contains(&"cargo".to_string()));
+    }
+
+    #[test]
+    fn detect_cli_deps_skips_builtins() {
+        let body = r#"
+```bash
+echo "hello"
+cd /tmp
+export FOO=bar
+if [ -f test ]; then echo ok; fi
+```
+"#;
+        let deps = detect_cli_deps(body);
+        assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn detect_cli_deps_handles_pipes() {
+        let body = r#"
+```bash
+claudectl --json | jq '.[] | .cost'
+```
+"#;
+        let deps = detect_cli_deps(body);
+        assert!(deps.contains(&"claudectl".to_string()));
+        assert!(deps.contains(&"jq".to_string()));
+    }
+
+    #[test]
+    fn detect_cli_deps_skips_non_bash_blocks() {
+        let body = r#"
+```python
+import json
+```
+
+```bash
+claudectl --list
+```
+
+```rust
+fn main() {}
+```
+"#;
+        let deps = detect_cli_deps(body);
+        assert_eq!(deps, vec!["claudectl"]);
+    }
+
+    #[test]
+    fn detect_cli_deps_handles_env_assignments() {
+        let body = r#"
+```bash
+FOO=bar claudectl --list
+```
+"#;
+        let deps = detect_cli_deps(body);
+        assert!(deps.contains(&"claudectl".to_string()));
+    }
+
+    #[test]
+    fn detect_os_deps_macos() {
+        let body = "Install with: brew install claudectl";
+        assert_eq!(detect_os_deps(body), vec!["macos"]);
+    }
+
+    #[test]
+    fn detect_os_deps_linux() {
+        let body = "Install with: apt-get install tool";
+        assert_eq!(detect_os_deps(body), vec!["linux"]);
+    }
+
+    #[test]
+    fn detect_os_deps_none() {
+        let body = "Just run claudectl";
+        assert!(detect_os_deps(body).is_empty());
+    }
+
+    #[test]
+    fn compat_issue_display() {
+        let issue = CompatIssue::MissingCli("jq".into());
+        assert_eq!(format!("{issue}"), "missing CLI: jq");
+        assert_eq!(issue.short_label(), "!cli");
+        assert!(!issue.is_blocking());
+
+        let issue = CompatIssue::WrongOs {
+            current: "macos".into(),
+            required: vec!["linux".into()],
+        };
+        assert!(issue.is_blocking());
+        assert_eq!(issue.short_label(), "!os");
+    }
+
+    #[test]
+    fn check_compatibility_no_requirements() {
+        let req = ArtifactRequires::default();
+        assert!(check_compatibility(&req).is_empty());
+    }
+
+    #[test]
+    fn check_compatibility_missing_cli() {
+        let req = ArtifactRequires {
+            cli: vec!["this_binary_surely_does_not_exist_xyz".into()],
+            ..Default::default()
+        };
+        let issues = check_compatibility(&req);
+        assert_eq!(issues.len(), 1);
+        assert!(
+            matches!(&issues[0], CompatIssue::MissingCli(s) if s == "this_binary_surely_does_not_exist_xyz")
+        );
+    }
+
+    #[test]
+    fn check_compatibility_version_ok() {
+        let req = ArtifactRequires {
+            min_version: Some("0.1.0".into()),
+            ..Default::default()
+        };
+        // Current version is always >= 0.1.0
+        assert!(check_compatibility(&req).is_empty());
+    }
+
+    #[test]
+    fn check_compatibility_version_too_high() {
+        let req = ArtifactRequires {
+            min_version: Some("99.99.99".into()),
+            ..Default::default()
+        };
+        let issues = check_compatibility(&req);
+        assert_eq!(issues.len(), 1);
+        assert!(matches!(&issues[0], CompatIssue::VersionTooOld { .. }));
+    }
+
+    #[test]
+    fn get_requires_returns_none_for_pattern() {
+        let unit = sample_pattern_unit("Bash", Some("test"));
+        assert!(get_requires(&unit.content).is_none());
+    }
+
+    #[test]
+    fn get_requires_returns_some_for_skill() {
+        let unit = sample_skill_unit();
+        assert!(get_requires(&unit.content).is_some());
+    }
+
+    #[test]
+    fn compat_label_no_requirements() {
+        let unit = sample_skill_unit();
+        // Default requires is empty — should show "?"
+        assert_eq!(compat_label(&unit.content), "?");
     }
 }

--- a/src/hive/mod.rs
+++ b/src/hive/mod.rs
@@ -104,6 +104,17 @@ pub enum KnowledgeScope {
     Project(String),
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// Content size limits for shared artifacts
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Maximum size for a shared skill body (32 KB).
+pub const MAX_SKILL_BYTES: usize = 32 * 1024;
+/// Maximum size for a shared command body (16 KB).
+pub const MAX_COMMAND_BYTES: usize = 16 * 1024;
+/// Maximum size for a shared hook config JSON (4 KB).
+pub const MAX_HOOK_CONFIG_BYTES: usize = 4 * 1024;
+
 /// The actual knowledge payload.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -135,6 +146,32 @@ pub enum KnowledgeContent {
     },
     /// A promoted rule from coord memory.
     PromotedRule { rule: String, source_type: String },
+    /// A shared skill (markdown with YAML frontmatter).
+    Skill {
+        name: String,
+        description: String,
+        version: String,
+        /// Full markdown content (frontmatter + body). Capped at MAX_SKILL_BYTES.
+        body: String,
+    },
+    /// A shared slash command (markdown with YAML frontmatter).
+    Command {
+        name: String,
+        description: String,
+        args: Option<String>,
+        /// Full markdown content (frontmatter + body). Capped at MAX_COMMAND_BYTES.
+        body: String,
+    },
+    /// A shared hook configuration (declarative JSON, no executables).
+    HookConfig {
+        /// Hook event type (e.g., "PreToolUse", "PostToolUse").
+        event: String,
+        /// Matcher pattern (e.g., "Bash|Write|Edit").
+        matcher: String,
+        description: String,
+        /// Sanitized hook config JSON (no secrets). Capped at MAX_HOOK_CONFIG_BYTES.
+        config_json: String,
+    },
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -178,6 +215,15 @@ pub fn semantic_key(unit: &KnowledgeUnit) -> String {
         KnowledgeContent::PromotedRule { rule, .. } => {
             format!("rule:{}", truncate_chars(rule, 40))
         }
+        KnowledgeContent::Skill { name, .. } => {
+            format!("skill:{}", name.to_lowercase().replace(' ', "-"))
+        }
+        KnowledgeContent::Command { name, .. } => {
+            format!("command:{}", name.to_lowercase())
+        }
+        KnowledgeContent::HookConfig { event, matcher, .. } => {
+            format!("hook:{}:{}", event.to_lowercase(), matcher.to_lowercase())
+        }
     };
     format!("{scope_part}/{content_part}")
 }
@@ -196,6 +242,8 @@ pub struct SharingFilter {
     pub exclude_tools: Vec<String>,
     /// Command substrings to exclude.
     pub exclude_commands: Vec<String>,
+    /// Content types to exclude from sharing (e.g., "skill", "command", "hook").
+    pub exclude_content_types: Vec<String>,
 }
 
 impl SharingFilter {
@@ -205,6 +253,7 @@ impl SharingFilter {
             allow_categories: cfg.share_categories.clone(),
             exclude_tools: cfg.exclude_tools.clone(),
             exclude_commands: cfg.exclude_commands.clone(),
+            exclude_content_types: cfg.exclude_content_types.clone(),
         }
     }
 
@@ -241,6 +290,33 @@ impl SharingFilter {
             if self.exclude_tools.iter().any(|t| t == tool) {
                 return false;
             }
+        }
+
+        // Content type exclusions for shared artifacts
+        match &unit.content {
+            KnowledgeContent::Skill { .. } => {
+                if self.exclude_content_types.iter().any(|t| t == "skill") {
+                    return false;
+                }
+            }
+            KnowledgeContent::Command { name, .. } => {
+                if self.exclude_content_types.iter().any(|t| t == "command") {
+                    return false;
+                }
+                if self
+                    .exclude_commands
+                    .iter()
+                    .any(|exc| name.contains(exc.as_str()))
+                {
+                    return false;
+                }
+            }
+            KnowledgeContent::HookConfig { .. } => {
+                if self.exclude_content_types.iter().any(|t| t == "hook") {
+                    return false;
+                }
+            }
+            _ => {}
         }
 
         true
@@ -308,6 +384,180 @@ pub fn signal_new_knowledge(count: u32) {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Hook config sanitization
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Environment variables safe to keep in shared hook configs.
+const SAFE_ENV_VARS: &[&str] = &["HOME", "PWD", "PATH", "CLAUDE_PLUGIN_ROOT", "USER", "SHELL"];
+
+/// Credential-like key prefixes (case-insensitive match).
+const CREDENTIAL_KEYS: &[&str] = &[
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "api-key",
+    "auth_token",
+    "access_key",
+    "private_key",
+];
+
+/// Sanitize a hook config string before sharing: strip credentials, unsafe env
+/// vars, and absolute user paths. Returns the sanitized version.
+pub fn sanitize_hook_config(input: &str) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    for line in input.lines() {
+        let mut sanitized = sanitize_credentials(line);
+        sanitized = sanitize_env_vars(&sanitized);
+        sanitized = sanitize_user_paths(&sanitized);
+        lines.push(sanitized);
+    }
+
+    lines.join("\n")
+}
+
+/// Replace credential-like `key=value`, `key: value`, `"key": "value"` patterns.
+fn sanitize_credentials(line: &str) -> String {
+    let lower = line.to_lowercase();
+    for key in CREDENTIAL_KEYS {
+        // Check for JSON-style: "key": "value" or "key":"value"
+        if lower.contains(key) {
+            // Check "key": "value" pattern
+            if let Some(pos) = lower.find(key) {
+                let after_key = &line[pos + key.len()..];
+                let after_key_trimmed = after_key.trim_start_matches('"').trim_start();
+                if after_key_trimmed.starts_with(':') || after_key_trimmed.starts_with('=') {
+                    let sep_char = if after_key_trimmed.starts_with(':') {
+                        ':'
+                    } else {
+                        '='
+                    };
+                    let before = &line[..pos];
+                    // Find the key boundary (include quotes if present)
+                    let key_start = if before.ends_with('"') {
+                        before.len() - 1
+                    } else {
+                        pos
+                    };
+                    let after_sep = &after_key_trimmed[1..].trim_start();
+                    let redacted = if let Some(stripped) = after_sep.strip_prefix('"') {
+                        // JSON string value — find closing quote
+                        if let Some(end) = stripped.find('"') {
+                            let rest_start =
+                                pos + key.len() + (after_key.len() - after_sep.len()) + 2 + end;
+                            format!(
+                                "{}\"{key}\"{sep_char} \"REDACTED\"{}",
+                                &line[..key_start],
+                                &line[rest_start..]
+                            )
+                        } else {
+                            format!("{}\"{key}\"{sep_char} \"REDACTED\"", &line[..key_start])
+                        }
+                    } else {
+                        // Unquoted value — redact to end of token
+                        let end = after_sep
+                            .find(|c: char| c.is_whitespace() || c == ',' || c == '}')
+                            .unwrap_or(after_sep.len());
+                        let rest_start =
+                            pos + key.len() + (after_key.len() - after_sep.len()) + end;
+                        format!(
+                            "{}{}{}REDACTED{}",
+                            &line[..pos],
+                            key,
+                            sep_char,
+                            &line[rest_start..]
+                        )
+                    };
+                    return redacted;
+                }
+            }
+        }
+    }
+    line.to_string()
+}
+
+/// Replace `$VAR` and `${VAR}` references with `$REDACTED` / `${REDACTED}`
+/// unless the variable name is in the safe list.
+fn sanitize_env_vars(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let chars: Vec<char> = input.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        if chars[i] == '$' && i + 1 < chars.len() {
+            if chars[i + 1] == '{' {
+                // ${VAR} form
+                if let Some(close) = chars[i + 2..].iter().position(|&c| c == '}') {
+                    let var_name: String = chars[i + 2..i + 2 + close].iter().collect();
+                    if is_env_var_name(&var_name) {
+                        if SAFE_ENV_VARS.contains(&var_name.as_str()) {
+                            result.push_str(&format!("${{{var_name}}}"));
+                        } else {
+                            result.push_str("${REDACTED}");
+                        }
+                        i += 3 + close; // skip past }
+                        continue;
+                    }
+                }
+            } else if chars[i + 1].is_ascii_uppercase() || chars[i + 1] == '_' {
+                // $VAR form
+                let start = i + 1;
+                let mut end = start;
+                while end < chars.len() && (chars[end].is_ascii_alphanumeric() || chars[end] == '_')
+                {
+                    end += 1;
+                }
+                let var_name: String = chars[start..end].iter().collect();
+                if is_env_var_name(&var_name) {
+                    if SAFE_ENV_VARS.contains(&var_name.as_str()) {
+                        result.push('$');
+                        result.push_str(&var_name);
+                    } else {
+                        result.push_str("$REDACTED");
+                    }
+                    i = end;
+                    continue;
+                }
+            }
+        }
+        result.push(chars[i]);
+        i += 1;
+    }
+
+    result
+}
+
+/// Check if a string looks like an env var name (uppercase + underscores + digits).
+fn is_env_var_name(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+}
+
+/// Replace `/Users/<name>` and `/home/<name>` with `$HOME`.
+fn sanitize_user_paths(input: &str) -> String {
+    let mut result = input.to_string();
+    for prefix in &["/Users/", "/home/"] {
+        while let Some(pos) = result.find(prefix) {
+            let after = &result[pos + prefix.len()..];
+            let username_end = after
+                .find(|c: char| !c.is_ascii_alphanumeric() && c != '.' && c != '-' && c != '_')
+                .unwrap_or(after.len());
+            if username_end > 0 {
+                let end = pos + prefix.len() + username_end;
+                result = format!("{}$HOME{}", &result[..pos], &result[end..]);
+            } else {
+                break;
+            }
+        }
+    }
+    result
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Display helpers
 // ────────────────────────────────────────────────────────────────────────────
 
@@ -358,6 +608,30 @@ impl KnowledgeContent {
             }
             Self::PromotedRule { rule, .. } => {
                 format!("rule: {rule}")
+            }
+            Self::Skill {
+                name,
+                version,
+                body,
+                ..
+            } => {
+                format!("skill: {name} v{version} ({} bytes)", body.len())
+            }
+            Self::Command { name, args, .. } => {
+                let arg_str = args.as_deref().unwrap_or("");
+                if arg_str.is_empty() {
+                    format!("command: /{name}")
+                } else {
+                    format!("command: /{name} {arg_str}")
+                }
+            }
+            Self::HookConfig {
+                event,
+                matcher,
+                description,
+                ..
+            } => {
+                format!("hook: {event}[{matcher}] — {description}")
             }
         }
     }
@@ -538,5 +812,283 @@ mod tests {
         };
         let key = semantic_key(&unit);
         assert!(key.starts_with("universal/insight:error_loop:"));
+    }
+
+    // ── New content type tests ─────────────────────────────────────────
+
+    fn sample_skill_unit() -> KnowledgeUnit {
+        KnowledgeUnit {
+            id: "ku_skill_1".into(),
+            scope: KnowledgeScope::Universal,
+            category: KnowledgeCategory::Technique,
+            content: KnowledgeContent::Skill {
+                name: "Session Monitoring".into(),
+                description: "Monitors sessions".into(),
+                version: "0.31.0".into(),
+                body: "---\nname: Session Monitoring\n---\nContent here".into(),
+            },
+            evidence_count: 1,
+            confidence: 1.0,
+            source_peer: "peer-a".into(),
+            originated_at: 1000,
+            last_validated_at: 2000,
+            propagation_count: 0,
+            version: 1,
+        }
+    }
+
+    fn sample_command_unit() -> KnowledgeUnit {
+        KnowledgeUnit {
+            id: "ku_cmd_1".into(),
+            scope: KnowledgeScope::Universal,
+            category: KnowledgeCategory::Technique,
+            content: KnowledgeContent::Command {
+                name: "brain".into(),
+                description: "Toggle brain gate".into(),
+                args: Some("[on|off|auto|status]".into()),
+                body: "---\nname: brain\n---\nContent".into(),
+            },
+            evidence_count: 1,
+            confidence: 1.0,
+            source_peer: "peer-b".into(),
+            originated_at: 1000,
+            last_validated_at: 2000,
+            propagation_count: 0,
+            version: 1,
+        }
+    }
+
+    fn sample_hook_unit() -> KnowledgeUnit {
+        KnowledgeUnit {
+            id: "ku_hook_1".into(),
+            scope: KnowledgeScope::Universal,
+            category: KnowledgeCategory::WorkflowPattern,
+            content: KnowledgeContent::HookConfig {
+                event: "PreToolUse".into(),
+                matcher: "Bash|Write|Edit".into(),
+                description: "Brain gate hook".into(),
+                config_json: r#"{"command": "brain-gate.sh", "timeout": 5000}"#.into(),
+            },
+            evidence_count: 1,
+            confidence: 1.0,
+            source_peer: "peer-a".into(),
+            originated_at: 1000,
+            last_validated_at: 2000,
+            propagation_count: 0,
+            version: 1,
+        }
+    }
+
+    #[test]
+    fn semantic_key_skill() {
+        let unit = sample_skill_unit();
+        assert_eq!(semantic_key(&unit), "universal/skill:session-monitoring");
+    }
+
+    #[test]
+    fn semantic_key_command() {
+        let unit = sample_command_unit();
+        assert_eq!(semantic_key(&unit), "universal/command:brain");
+    }
+
+    #[test]
+    fn semantic_key_hook() {
+        let unit = sample_hook_unit();
+        assert_eq!(
+            semantic_key(&unit),
+            "universal/hook:pretooluse:bash|write|edit"
+        );
+    }
+
+    #[test]
+    fn summary_line_skill() {
+        let unit = sample_skill_unit();
+        let line = unit.content.summary_line();
+        assert!(line.contains("Session Monitoring"));
+        assert!(line.contains("v0.31.0"));
+        assert!(line.contains("bytes"));
+    }
+
+    #[test]
+    fn summary_line_command() {
+        let unit = sample_command_unit();
+        let line = unit.content.summary_line();
+        assert!(line.contains("/brain"));
+        assert!(line.contains("[on|off|auto|status]"));
+    }
+
+    #[test]
+    fn summary_line_command_no_args() {
+        let content = KnowledgeContent::Command {
+            name: "sessions".into(),
+            description: "List sessions".into(),
+            args: None,
+            body: "body".into(),
+        };
+        let line = content.summary_line();
+        assert_eq!(line, "command: /sessions");
+    }
+
+    #[test]
+    fn summary_line_hook() {
+        let unit = sample_hook_unit();
+        let line = unit.content.summary_line();
+        assert!(line.contains("PreToolUse"));
+        assert!(line.contains("Bash|Write|Edit"));
+    }
+
+    #[test]
+    fn serde_roundtrip_skill() {
+        let unit = sample_skill_unit();
+        let json = serde_json::to_string(&unit).unwrap();
+        let back: KnowledgeUnit = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, "ku_skill_1");
+        if let KnowledgeContent::Skill { name, version, .. } = &back.content {
+            assert_eq!(name, "Session Monitoring");
+            assert_eq!(version, "0.31.0");
+        } else {
+            panic!("expected Skill variant");
+        }
+    }
+
+    #[test]
+    fn serde_roundtrip_command() {
+        let unit = sample_command_unit();
+        let json = serde_json::to_string(&unit).unwrap();
+        let back: KnowledgeUnit = serde_json::from_str(&json).unwrap();
+        if let KnowledgeContent::Command { name, args, .. } = &back.content {
+            assert_eq!(name, "brain");
+            assert_eq!(args.as_deref(), Some("[on|off|auto|status]"));
+        } else {
+            panic!("expected Command variant");
+        }
+    }
+
+    #[test]
+    fn serde_roundtrip_hook() {
+        let unit = sample_hook_unit();
+        let json = serde_json::to_string(&unit).unwrap();
+        let back: KnowledgeUnit = serde_json::from_str(&json).unwrap();
+        if let KnowledgeContent::HookConfig { event, matcher, .. } = &back.content {
+            assert_eq!(event, "PreToolUse");
+            assert_eq!(matcher, "Bash|Write|Edit");
+        } else {
+            panic!("expected HookConfig variant");
+        }
+    }
+
+    #[test]
+    fn sharing_filter_excludes_skills() {
+        let filter = SharingFilter {
+            exclude_content_types: vec!["skill".into()],
+            ..Default::default()
+        };
+        let unit = sample_skill_unit();
+        assert!(!filter.allows(&unit));
+
+        // Commands should still be allowed
+        let cmd = sample_command_unit();
+        assert!(filter.allows(&cmd));
+    }
+
+    #[test]
+    fn sharing_filter_excludes_commands() {
+        let filter = SharingFilter {
+            exclude_content_types: vec!["command".into()],
+            ..Default::default()
+        };
+        let cmd = sample_command_unit();
+        assert!(!filter.allows(&cmd));
+
+        // Skills should still be allowed
+        let skill = sample_skill_unit();
+        assert!(filter.allows(&skill));
+    }
+
+    #[test]
+    fn sharing_filter_excludes_hooks() {
+        let filter = SharingFilter {
+            exclude_content_types: vec!["hook".into()],
+            ..Default::default()
+        };
+        let hook = sample_hook_unit();
+        assert!(!filter.allows(&hook));
+    }
+
+    #[test]
+    fn sharing_filter_allows_all_by_default() {
+        let filter = SharingFilter::default();
+        assert!(filter.allows(&sample_skill_unit()));
+        assert!(filter.allows(&sample_command_unit()));
+        assert!(filter.allows(&sample_hook_unit()));
+    }
+
+    #[test]
+    fn sharing_filter_command_name_exclusion() {
+        let filter = SharingFilter {
+            exclude_commands: vec!["brain".into()],
+            ..Default::default()
+        };
+        let cmd = sample_command_unit();
+        assert!(!filter.allows(&cmd));
+    }
+
+    // ── Sanitization tests ─────────────────────────────────────────────
+
+    #[test]
+    fn sanitize_strips_env_vars() {
+        let input = "cmd: $API_KEY and ${SECRET_TOKEN}";
+        let result = sanitize_hook_config(input);
+        assert!(result.contains("$REDACTED"));
+        assert!(result.contains("${REDACTED}"));
+        assert!(!result.contains("API_KEY"));
+        assert!(!result.contains("SECRET_TOKEN"));
+    }
+
+    #[test]
+    fn sanitize_keeps_safe_vars() {
+        let input = "path: $HOME/.claudectl and ${CLAUDE_PLUGIN_ROOT}/hooks";
+        let result = sanitize_hook_config(input);
+        assert!(result.contains("$HOME"));
+        assert!(result.contains("${CLAUDE_PLUGIN_ROOT}"));
+    }
+
+    #[test]
+    fn sanitize_strips_absolute_paths() {
+        let input = "file: /Users/barada/.claudectl/config";
+        let result = sanitize_hook_config(input);
+        assert!(result.contains("$HOME"));
+        assert!(!result.contains("/Users/barada"));
+    }
+
+    #[test]
+    fn sanitize_strips_home_paths() {
+        let input = "file: /home/ubuntu/.config/thing";
+        let result = sanitize_hook_config(input);
+        assert!(result.contains("$HOME"));
+        assert!(!result.contains("/home/ubuntu"));
+    }
+
+    #[test]
+    fn sanitize_strips_credentials() {
+        let input = r#""api_key": "sk-1234567890""#;
+        let result = sanitize_hook_config(input);
+        assert!(result.contains("REDACTED"));
+        assert!(!result.contains("sk-1234567890"));
+    }
+
+    #[test]
+    fn sanitize_strips_unquoted_credentials() {
+        let input = "token=abc123def";
+        let result = sanitize_hook_config(input);
+        assert!(result.contains("REDACTED"));
+        assert!(!result.contains("abc123def"));
+    }
+
+    #[test]
+    fn sanitize_preserves_safe_content() {
+        let input = r#"{"command": "brain-gate.sh", "timeout": 5000}"#;
+        let result = sanitize_hook_config(input);
+        assert_eq!(result, input);
     }
 }

--- a/src/hive/mod.rs
+++ b/src/hive/mod.rs
@@ -294,10 +294,10 @@ impl SharingFilter {
 
         // Content type exclusions for shared artifacts
         match &unit.content {
-            KnowledgeContent::Skill { .. } => {
-                if self.exclude_content_types.iter().any(|t| t == "skill") {
-                    return false;
-                }
+            KnowledgeContent::Skill { .. }
+                if self.exclude_content_types.iter().any(|t| t == "skill") =>
+            {
+                return false;
             }
             KnowledgeContent::Command { name, .. } => {
                 if self.exclude_content_types.iter().any(|t| t == "command") {
@@ -311,10 +311,10 @@ impl SharingFilter {
                     return false;
                 }
             }
-            KnowledgeContent::HookConfig { .. } => {
-                if self.exclude_content_types.iter().any(|t| t == "hook") {
-                    return false;
-                }
+            KnowledgeContent::HookConfig { .. }
+                if self.exclude_content_types.iter().any(|t| t == "hook") =>
+            {
+                return false;
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary

- Adds three new `KnowledgeContent` variants (`Skill`, `Command`, `HookConfig`) so the hive gossip protocol can share executable artifacts, not just learning traces
- New CLI: `claudectl hive share`, `claudectl hive install`, `claudectl hive shared` — promote local artifacts, install from peers, browse available content
- Trust-gated installation: Ignored-tier peers are blocked, Unverified peers trigger warnings
- Hook configs are sanitized before sharing (credentials, unsafe env vars, absolute user paths stripped)
- Users control sharing via `exclude_content_types` config (e.g., `["skill", "command", "hook"]`)
- Skills/commands/hooks are excluded from brain prompt injection — they're discovered via `claudectl hive shared`
- Zero new dependencies, all existing 1,038 tests pass, clippy clean

Closes #214

## Test plan

- [x] 22 new unit tests: serde roundtrip, semantic keys, summary lines, filter behavior, sanitization
- [x] Injection test: skills excluded from brain prompt context
- [x] All 1,038 existing tests pass (`cargo test --features hive,relay`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: `claudectl hive share skill claude-plugin/skills/session-monitoring/SKILL.md`
- [ ] Manual: `claudectl hive shared` lists the shared skill
- [ ] Manual: `claudectl hive install <id>` writes to `~/.claude/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)