### PR TITLE
feat: P2 batch — retention config, recording UX, config validation, false-deny friction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.45.0] - 2026-04-28
+
+### Added
+- **Configurable event log retention** -- `retention_days` in `[lifecycle]` config section controls auto-prune period (default 30 days), wired to headless auto-prune loop (#186)
+- **Per-session recording toggle** -- `R` key now starts/stops recording for the selected session only, not all recordings. Recordings include a ~30-second lookback buffer of events before record-start. Output filenames include timestamps for uniqueness (#73)
+- **Config validation** -- `claudectl --config-validate` reports unknown keys, unknown sections, and malformed values in config files with line numbers and actionable messages (#74)
+- **Hook dry-run** -- `claudectl --init --dry-run` shows what hooks would be written to `.claude/settings.json` without modifying the file (#74)
+- **Sample config generation** -- `claudectl --config-init` writes an annotated `.claudectl.toml` template in the current directory (#74)
+- **False-deny friction cost** -- `--brain-stats false-deny` now shows friction cost (avg override delay, total friction time) and override reason breakdown. Brain denial overrides prompt for categorized reasons: always safe, one-time exception, or brain is wrong (#134)
+- **Override reason capture** -- when accepting a brain denial, TUI prompts for override reason (1/2/3 keys) to feed back into preference distillation
+- **Decision record timestamps** -- `resolved_at` field on all brain decisions enables friction latency measurement
+
+### Technical details
+- `LifecycleConfig` gains `retention_days: u64` (default 30), parsed from `[lifecycle]` TOML section
+- `SessionRecorder` lookback: seeks back 50KB and aligns to line boundary before recording
+- `validate_config_file()` enumerates valid keys per known section and reports unknowns
+- `DecisionRecord` gains `resolved_at: Option<u64>` and `override_reason: Option<String>`, backward-compatible with old JSONL
+- 677 tests passing across all build configurations
+
 ## [0.44.0] - 2026-04-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.44.0"
+version = "0.45.0"
 edition = "2024"
 description = "Mission control for Claude Code — supervise, orchestrate, and connect coding agents with a local LLM brain and hive mind"
 license = "MIT"

--- a/src/app.rs
+++ b/src/app.rs
@@ -263,6 +263,8 @@ pub struct App {
     pub sort_column: usize,
     pub auto_approve: HashSet<u32>,
     pub pending_auto_approve: Option<u32>,
+    /// PID awaiting override reason (1=always safe, 2=one-time, 3=brain is wrong).
+    pub pending_override_reason: Option<u32>,
     pub finished_at: HashMap<u32, std::time::Instant>, // When PIDs were first seen as Finished
     pub debug: bool,
     pub debug_timings: DebugTimings,
@@ -408,6 +410,7 @@ impl App {
             sort_column: 0,
             auto_approve: HashSet::new(),
             pending_auto_approve: None,
+            pending_override_reason: None,
             finished_at: HashMap::new(),
             debug: false,
             debug_timings: DebugTimings::default(),
@@ -1708,6 +1711,27 @@ impl App {
             return true;
         }
 
+        // Override reason prompt: waiting for 1/2/3/Esc
+        if self.pending_override_reason.is_some() {
+            match key.code {
+                KeyCode::Char('1') => {
+                    self.handle_brain_accept_with_reason(Some("always_safe"));
+                }
+                KeyCode::Char('2') => {
+                    self.handle_brain_accept_with_reason(Some("one_time_exception"));
+                }
+                KeyCode::Char('3') => {
+                    self.handle_brain_accept_with_reason(Some("brain_is_wrong"));
+                }
+                KeyCode::Esc => {
+                    self.pending_override_reason = None;
+                    self.status_msg = "Override cancelled".into();
+                }
+                _ => {}
+            }
+            return true;
+        }
+
         // Normal mode
         self.handle_normal_key(key);
         !self.should_quit
@@ -2152,6 +2176,10 @@ impl App {
     }
 
     fn handle_brain_accept(&mut self) {
+        self.handle_brain_accept_with_reason(None);
+    }
+
+    fn handle_brain_accept_with_reason(&mut self, override_reason: Option<&str>) {
         // Clone session data first to avoid borrow conflict with brain_engine
         let Some(session) = self.selected_session().cloned() else {
             return;
@@ -2171,6 +2199,18 @@ impl App {
             self.status_msg = "No brain suggestion pending for this session".into();
             return;
         }
+
+        // If brain suggested deny and no override reason yet, prompt for one
+        if let Some(ref sg) = suggestion {
+            if sg.action.label() == "deny" && override_reason.is_none() {
+                self.pending_override_reason = Some(pid);
+                self.status_msg =
+                    "Override reason: [1] Always safe  [2] One-time exception  [3] Brain is wrong  [Esc] Cancel"
+                        .into();
+                return;
+            }
+        }
+
         if let Some(msg) = engine.accept(pid, &session) {
             if let Some(ref sg) = suggestion {
                 crate::brain::decisions::log_decision(
@@ -2182,11 +2222,13 @@ impl App {
                     "accept",
                     Some(&session),
                     crate::brain::decisions::DecisionType::Session,
+                    override_reason,
                 );
             }
             crate::logger::log("BRAIN", &format!("Accepted: {msg}"));
             self.status_msg = msg;
         }
+        self.pending_override_reason = None;
     }
 
     fn handle_brain_reject(&mut self) {
@@ -2212,6 +2254,7 @@ impl App {
                 "reject",
                 Some(&session),
                 crate::brain::decisions::DecisionType::Session,
+                None,
             );
             let msg = format!(
                 "Rejected brain suggestion: {} ({})",
@@ -2256,20 +2299,6 @@ impl App {
     }
 
     fn toggle_session_recording(&mut self) {
-        // If any recordings are active, R stops ALL of them
-        if !self.session_recordings.is_empty() {
-            let count = self.session_recordings.len();
-            let paths: Vec<String> = self.session_recordings.values().cloned().collect();
-            self.session_recordings.clear();
-            self.status_msg = if count == 1 {
-                format!("Recording stopped → {}", paths[0])
-            } else {
-                format!("{count} recordings stopped")
-            };
-            return;
-        }
-
-        // No recordings active — start recording the selected session
         let info = self
             .selected_session()
             .map(|s| (s.pid, s.display_name().to_string(), s.jsonl_path.is_some()));
@@ -2277,11 +2306,23 @@ impl App {
             return;
         };
 
+        // Per-session toggle: if this session is recording, stop just this one
+        if self.session_recordings.contains_key(&pid) {
+            let path = self.session_recordings.remove(&pid).unwrap_or_default();
+            self.status_msg = format!("Recording stopped → {path}");
+            return;
+        }
+
+        // Start recording the selected session
         if !has_jsonl {
             self.status_msg = "Cannot record — no JSONL file for this session".into();
             return;
         }
-        let path = format!("{}-{}.gif", name, pid);
+        let epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let path = format!("{}-{}-{}.gif", name, pid, epoch);
         self.session_recordings.insert(pid, path.clone());
         self.status_msg = format!("Recording {name} → {path} (R to stop)");
     }

--- a/src/brain/decisions.rs
+++ b/src/brain/decisions.rs
@@ -90,6 +90,10 @@ pub struct DecisionRecord {
     /// Epoch seconds when the brain suggestion was created.
     /// None for old records or observations. Used by time-to-correct analysis.
     pub suggested_at: Option<u64>,
+    /// Epoch seconds when the user acted on the suggestion.
+    pub resolved_at: Option<u64>,
+    /// Why the user overrode a brain denial (if applicable).
+    pub override_reason: Option<String>,
 }
 
 /// Outcome of a decision, backfilled during distillation by looking at
@@ -289,7 +293,12 @@ pub fn log_decision(
     user_action: &str,
     session: Option<&crate::session::ClaudeSession>,
     decision_type: DecisionType,
+    override_reason: Option<&str>,
 ) {
+    let resolved_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
     let mut record = serde_json::json!({
         "ts": timestamp_now(),
         "pid": pid,
@@ -302,6 +311,8 @@ pub fn log_decision(
         "user_action": user_action,
         "decision_type": decision_type.label(),
         "suggested_at": suggestion.suggested_at,
+        "resolved_at": resolved_at,
+        "override_reason": override_reason,
     });
     if let Some(s) = session {
         record["context"] = snapshot_context(s);
@@ -621,8 +632,13 @@ pub fn read_all_decisions() -> Vec<DecisionRecord> {
                 context,
                 outcome: None, // Backfilled during distillation
                 decision_type,
-                // Backwards-compatible: old records won't have "suggested_at"
+                // Backwards-compatible: old records won't have these fields
                 suggested_at: json.get("suggested_at").and_then(|v| v.as_u64()),
+                resolved_at: json.get("resolved_at").and_then(|v| v.as_u64()),
+                override_reason: json
+                    .get("override_reason")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
             })
         })
         .collect()
@@ -662,6 +678,8 @@ mod tests {
             outcome: None,
             decision_type: DecisionType::Session,
             suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
         }
     }
 
@@ -715,6 +733,8 @@ mod tests {
             outcome: None,
             decision_type: DecisionType::Orchestration,
             suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
         }
     }
 

--- a/src/brain/detectors.rs
+++ b/src/brain/detectors.rs
@@ -469,6 +469,8 @@ mod tests {
             outcome: None,
             decision_type: DecisionType::Session,
             suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
         }
     }
 

--- a/src/brain/engine.rs
+++ b/src/brain/engine.rs
@@ -100,6 +100,7 @@ impl BrainEngine {
                                     "deny_rule_override",
                                     Some(session),
                                     DecisionType::Session,
+                                    None,
                                 );
                                 actions.push((
                                     result.pid,
@@ -133,6 +134,7 @@ impl BrainEngine {
                                     "deferred_low_confidence",
                                     Some(session),
                                     DecisionType::Session,
+                                    None,
                                 );
                                 self.pending.insert(result.pid, suggestion);
                                 continue;
@@ -152,6 +154,7 @@ impl BrainEngine {
                                     "deferred_file_conflict",
                                     Some(session),
                                     DecisionType::Session,
+                                    None,
                                 );
                                 let mut flagged = suggestion.clone();
                                 flagged.reasoning =
@@ -180,6 +183,7 @@ impl BrainEngine {
                                                     "auto",
                                                     Some(session),
                                                     DecisionType::Session,
+                                                    None,
                                                 );
                                                 actions.push((result.pid, msg));
                                             }
@@ -220,6 +224,7 @@ impl BrainEngine {
                                                     "auto",
                                                     Some(session),
                                                     DecisionType::Session,
+                                                    None,
                                                 );
                                                 actions.push((result.pid, msg));
                                             }
@@ -238,6 +243,7 @@ impl BrainEngine {
                                         "auto",
                                         Some(session),
                                         DecisionType::Session,
+                                        None,
                                     );
                                     actions.push((
                                         result.pid,
@@ -265,6 +271,7 @@ impl BrainEngine {
                                                 "auto",
                                                 Some(session),
                                                 DecisionType::Session,
+                                                None,
                                             );
                                             actions.push((result.pid, msg));
                                         }
@@ -612,6 +619,7 @@ impl BrainEngine {
             orch_user_action,
             None,
             DecisionType::Orchestration,
+            None,
         );
 
         // The orchestration response may suggest multiple actions.
@@ -969,6 +977,7 @@ mod tests {
             auto_restart: true,
             restart_threshold_pct: 90.0,
             restart_only_when_idle: false,
+            retention_days: 30,
         };
         let mut engine = BrainEngine::new(make_config());
         let mut s = make_session(100, SessionStatus::Processing);
@@ -985,6 +994,7 @@ mod tests {
             auto_restart: true,
             restart_threshold_pct: 90.0,
             restart_only_when_idle: false,
+            retention_days: 30,
         };
         let mut engine = BrainEngine::new(make_config());
         let mut s = make_session(100, SessionStatus::Processing);
@@ -1002,6 +1012,7 @@ mod tests {
             auto_restart: true,
             restart_threshold_pct: 90.0,
             restart_only_when_idle: false,
+            retention_days: 30,
         };
         let mut engine = BrainEngine::new(make_config());
         engine.restarted_pids.insert(100);
@@ -1019,6 +1030,7 @@ mod tests {
             auto_restart: true,
             restart_threshold_pct: 90.0,
             restart_only_when_idle: true,
+            retention_days: 30,
         };
         let mut engine = BrainEngine::new(make_config());
         let mut s = make_session(100, SessionStatus::Processing);

--- a/src/brain/insights.rs
+++ b/src/brain/insights.rs
@@ -450,6 +450,8 @@ mod tests {
             outcome: None,
             decision_type: DecisionType::Session,
             suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
         }
     }
 

--- a/src/brain/metrics.rs
+++ b/src/brain/metrics.rs
@@ -722,6 +722,49 @@ pub fn print_false_deny() {
     } else if overall_rate < 5.0 {
         println!("  GOOD: low override rate — brain denials are well-calibrated.");
     }
+
+    // Friction cost: time spent overriding denials
+    let mut override_delays: Vec<u64> = Vec::new();
+    let mut by_reason: HashMap<String, u32> = HashMap::new();
+    for d in &decisions {
+        if d.brain_action == "deny" && d.is_positive() {
+            if let (Some(suggested), Some(resolved)) = (d.suggested_at, d.resolved_at) {
+                let delay = resolved.saturating_sub(suggested);
+                if delay < 3600 {
+                    // Ignore delays > 1 hour (likely stale)
+                    override_delays.push(delay);
+                }
+            }
+            if let Some(ref reason) = d.override_reason {
+                *by_reason.entry(reason.clone()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    if !override_delays.is_empty() {
+        let avg_delay = override_delays.iter().sum::<u64>() as f64 / override_delays.len() as f64;
+        let total_friction = avg_delay * total_overrides as f64;
+        println!();
+        println!("  Friction Cost");
+        println!("  {}", "-".repeat(40));
+        println!("  avg override delay:     {:.1}s", avg_delay,);
+        println!(
+            "  total friction time:    {:.0}s ({:.1} min)",
+            total_friction,
+            total_friction / 60.0,
+        );
+    }
+
+    if !by_reason.is_empty() {
+        println!();
+        println!("  Override Reasons");
+        println!("  {}", "-".repeat(40));
+        let mut reasons: Vec<(String, u32)> = by_reason.into_iter().collect();
+        reasons.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
+        for (reason, count) in &reasons {
+            println!("  {:<25} {:>5}", reason, count);
+        }
+    }
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1872,6 +1915,8 @@ mod tests {
             outcome: None,
             decision_type: DecisionType::Session,
             suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
         }
     }
 

--- a/src/brain/pref_store.rs
+++ b/src/brain/pref_store.rs
@@ -253,6 +253,8 @@ mod tests {
             outcome: None,
             decision_type: DecisionType::Session,
             suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
         }
     }
 

--- a/src/brain/preferences.rs
+++ b/src/brain/preferences.rs
@@ -921,6 +921,8 @@ mod tests {
             outcome: None,
             decision_type: DecisionType::Session,
             suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
         }
     }
 
@@ -944,6 +946,8 @@ mod tests {
             outcome: None,
             decision_type: DecisionType::Session,
             suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
         }
     }
 
@@ -1002,6 +1006,8 @@ mod tests {
             outcome: None,
             decision_type: DecisionType::Session,
             suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
         }
     }
 
@@ -1285,6 +1291,8 @@ mod tests {
                 outcome: None,
                 decision_type: DecisionType::Session,
                 suggested_at: None,
+                resolved_at: None,
+                override_reason: None,
             },
             DecisionRecord {
                 timestamp: "2".into(),
@@ -1300,6 +1308,8 @@ mod tests {
                 outcome: None,
                 decision_type: DecisionType::Session,
                 suggested_at: None,
+                resolved_at: None,
+                override_reason: None,
             },
         ];
 
@@ -1334,6 +1344,8 @@ mod tests {
                 outcome: None,
                 decision_type: DecisionType::Session,
                 suggested_at: None,
+                resolved_at: None,
+                override_reason: None,
             });
         }
         // Then user denies
@@ -1351,6 +1363,8 @@ mod tests {
             outcome: None,
             decision_type: DecisionType::Session,
             suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
         });
         // Repeat the streak pattern to reach threshold of 2
         for _ in 0..4 {
@@ -1368,6 +1382,8 @@ mod tests {
                 outcome: None,
                 decision_type: DecisionType::Session,
                 suggested_at: None,
+                resolved_at: None,
+                override_reason: None,
             });
         }
         decisions.push(DecisionRecord {
@@ -1384,6 +1400,8 @@ mod tests {
             outcome: None,
             decision_type: DecisionType::Session,
             suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
         });
 
         let patterns = detect_temporal_patterns(&decisions);

--- a/src/brain/retrieval.rs
+++ b/src/brain/retrieval.rs
@@ -171,6 +171,8 @@ mod tests {
             outcome: None,
             decision_type: DecisionType::Session,
             suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
         }
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -197,6 +197,78 @@ pub(crate) fn print_doctor() -> io::Result<()> {
     Ok(())
 }
 
+pub(crate) fn validate_config() -> io::Result<()> {
+    use std::path::PathBuf;
+
+    let mut total_warnings = 0;
+    let mut any_errors = false;
+
+    let files: Vec<PathBuf> = [
+        config::Config::global_path(),
+        Some(PathBuf::from(".claudectl.toml")),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    for path in &files {
+        if !path.exists() {
+            println!("  {}: not found (skipped)", path.display());
+            continue;
+        }
+        let (warnings, has_errors) = config::validate_config_file(path);
+        any_errors |= has_errors;
+
+        if warnings.is_empty() {
+            println!("  {}: ok", path.display());
+        } else {
+            println!("  {}:", path.display());
+            for w in &warnings {
+                let prefix = if w.message.starts_with("unknown") {
+                    "warn"
+                } else {
+                    "error"
+                };
+                if w.line > 0 {
+                    println!("    [{prefix}] line {}: {}", w.line, w.message);
+                } else {
+                    println!("    [{prefix}] {}", w.message);
+                }
+            }
+            total_warnings += warnings.len();
+        }
+    }
+
+    println!();
+    if total_warnings == 0 {
+        println!("Config is valid.");
+    } else {
+        println!(
+            "{total_warnings} warning(s) found. Unknown keys are ignored but may indicate typos."
+        );
+    }
+
+    if any_errors {
+        Err(io::Error::other("config has errors"))
+    } else {
+        Ok(())
+    }
+}
+
+pub(crate) fn write_config_init() -> io::Result<()> {
+    let path = std::path::PathBuf::from(".claudectl.toml");
+    if path.exists() {
+        eprintln!("Error: .claudectl.toml already exists. Remove it first or edit directly.");
+        return Err(io::Error::other(".claudectl.toml already exists"));
+    }
+
+    let template = config::Config::template_string();
+    std::fs::write(&path, template).map_err(|e| io::Error::other(format!("write: {e}")))?;
+    println!("Created .claudectl.toml with annotated defaults.");
+    println!("Edit the file to customize, then run `claudectl --config-validate` to check.");
+    Ok(())
+}
+
 pub(crate) fn check_brain_endpoint(endpoint: &str, timeout_ms: u64) -> bool {
     let timeout_secs = (timeout_ms / 1000).max(1);
     std::process::Command::new("curl")
@@ -966,7 +1038,9 @@ pub(crate) fn run_headless(
         #[cfg(feature = "coord")]
         if tick_count % 1800 == 0 && tick_count > 0 {
             if let Ok(conn) = crate::coord::store::open() {
-                if let Ok(pruned) = crate::coord::store::prune(&conn, None) {
+                if let Ok(pruned) =
+                    crate::coord::store::prune(&conn, Some(cfg.lifecycle.retention_days))
+                {
                     if pruned > 0 {
                         emit_headless_event(
                             "pruned",

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,8 @@ pub struct LifecycleConfig {
     pub auto_restart: bool,
     pub restart_threshold_pct: f64,
     pub restart_only_when_idle: bool,
+    /// Retention period for coordination event logs (days). Used by auto-prune.
+    pub retention_days: u64,
 }
 
 impl Default for LifecycleConfig {
@@ -141,6 +143,7 @@ impl Default for LifecycleConfig {
             auto_restart: false,
             restart_threshold_pct: 90.0,
             restart_only_when_idle: true,
+            retention_days: 30,
         }
     }
 }
@@ -351,6 +354,7 @@ struct RawLifecycleConfig {
     auto_restart: Option<bool>,
     restart_threshold_pct: Option<f64>,
     restart_only_when_idle: Option<bool>,
+    retention_days: Option<u64>,
 }
 
 #[derive(Debug, Default)]
@@ -571,6 +575,9 @@ impl Config {
             if let Some(v) = lc.restart_only_when_idle {
                 self.lifecycle.restart_only_when_idle = v;
             }
+            if let Some(v) = lc.retention_days {
+                self.lifecycle.retention_days = v;
+            }
         }
         if let Some(idle) = raw.idle {
             if let Some(v) = idle.enabled {
@@ -690,6 +697,18 @@ impl Config {
             self.health.error_accel_factor,
             self.health.repetition_threshold,
         );
+        println!();
+        println!("  [lifecycle]");
+        println!("  auto_restart:     {}", self.lifecycle.auto_restart);
+        println!(
+            "  restart_threshold: {:.0}%",
+            self.lifecycle.restart_threshold_pct
+        );
+        println!(
+            "  restart_idle_only: {}",
+            self.lifecycle.restart_only_when_idle
+        );
+        println!("  retention_days:   {}", self.lifecycle.retention_days);
         if self.model_overrides.is_empty() {
             println!("  model_overrides: none");
         } else {
@@ -708,8 +727,12 @@ impl Config {
 
     /// Print an annotated default config template to stdout.
     pub fn print_template() {
-        print!(
-            r#"# claudectl configuration
+        print!("{}", Self::template_string());
+    }
+
+    /// Return the config template as a string.
+    pub fn template_string() -> &'static str {
+        r#"# claudectl configuration
 # Place this file at:
 #   Project: .claudectl.toml (in your project root)
 #   Global:  ~/.config/claudectl/config.toml
@@ -848,6 +871,14 @@ impl Config {
 # Available events: on_needs_input, on_finished, on_budget_80,
 #   on_budget_exceeded, on_context_high, on_status_change
 
+# ── Lifecycle ──────────────────────────────────────────────────────
+
+# [lifecycle]
+# auto_restart = false
+# restart_threshold_pct = 90.0
+# restart_only_when_idle = true
+# retention_days = 30           # Coordination event log retention (days)
+
 # ── Brain (Local LLM) ──────────────────────────────────────────────
 
 # [brain]
@@ -891,7 +922,6 @@ impl Config {
 # capabilities = ["code-review", "refactoring"]
 # cwd = "/path/to/project"
 "#
-        );
     }
 }
 
@@ -902,6 +932,13 @@ fn global_config_path() -> Option<PathBuf> {
             .join("claudectl")
             .join("config.toml")
     })
+}
+
+impl Config {
+    /// Path to the global config file (for validation and diagnostics).
+    pub fn global_path() -> Option<PathBuf> {
+        global_config_path()
+    }
 }
 
 /// Minimal TOML parser — avoids adding a toml crate dependency.
@@ -1056,6 +1093,7 @@ fn parse_config_file(path: &PathBuf) -> Option<RawConfig> {
                     "auto_restart" => lc.auto_restart = parse_bool(value),
                     "restart_threshold_pct" => lc.restart_threshold_pct = value.parse().ok(),
                     "restart_only_when_idle" => lc.restart_only_when_idle = parse_bool(value),
+                    "retention_days" => lc.retention_days = value.parse().ok(),
                     _ => {}
                 }
             }
@@ -1217,6 +1255,186 @@ fn parse_config_file(path: &PathBuf) -> Option<RawConfig> {
     }
 
     Some(raw)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Config validation
+// ────────────────────────────────────────────────────────────────────────────
+
+/// A warning or error from config validation.
+pub struct ConfigWarning {
+    pub line: usize,
+    pub message: String,
+}
+
+/// Known sections and their valid keys.
+fn known_keys(section: &str) -> Option<&'static [&'static str]> {
+    match section {
+        "" | "defaults" => Some(&[
+            "interval",
+            "notify",
+            "debug",
+            "grouped",
+            "sort",
+            "budget",
+            "kill_on_budget",
+            "context_warn",
+            "context_warn_threshold",
+            "file_conflicts",
+            "auto_deny_file_conflicts",
+        ]),
+        "webhook" => Some(&["url", "on"]),
+        "budget" => Some(&["daily", "daily_limit", "weekly", "weekly_limit"]),
+        "context" => Some(&["warn", "warn_threshold"]),
+        "orchestrate" => Some(&["file_conflicts", "auto_deny_file_conflicts"]),
+        "health" => Some(&[
+            "cache_critical_pct",
+            "cache_warning_pct",
+            "cache_min_tokens",
+            "cost_spike_critical",
+            "cost_spike_warning",
+            "loop_max_calls",
+            "stall_min_cost",
+            "stall_min_minutes",
+            "context_critical_pct",
+            "context_warning_pct",
+            "decay_compaction_pct",
+            "efficiency_critical_factor",
+            "error_accel_factor",
+            "repetition_threshold",
+        ]),
+        "lifecycle" => Some(&[
+            "auto_restart",
+            "restart_threshold_pct",
+            "restart_only_when_idle",
+            "retention_days",
+        ]),
+        "idle" => Some(&[
+            "enabled",
+            "after_idle_mins",
+            "max_concurrent",
+            "max_cost_usd",
+        ]),
+        "brain" => Some(&[
+            "enabled",
+            "endpoint",
+            "model",
+            "auto",
+            "timeout_ms",
+            "max_context_tokens",
+            "few_shot_count",
+            "max_sessions",
+            "orchestrate",
+            "orchestrate_interval",
+            "orchestrate_interval_secs",
+        ]),
+        "relay" => Some(&[
+            "enabled",
+            "listen_port",
+            "port",
+            "listen_addr",
+            "addr",
+            "max_peers",
+            "heartbeat_interval",
+            "heartbeat_interval_secs",
+            "reconnect_max",
+            "reconnect_max_secs",
+            "auto_connect",
+            "http_port",
+            "auth_token",
+        ]),
+        "hive" => Some(&[
+            "enabled",
+            "default_trust",
+            "auto_trust_drift",
+            "max_propagation",
+            "export_min_evidence",
+            "export_min_tool_decisions",
+            "knowledge_ttl_days",
+            "inject_unverified",
+            "share_categories",
+            "exclude_tools",
+            "exclude_content_types",
+            "max_units",
+            "max_prompt_units",
+            "stale_peer_days",
+        ]),
+        _ => None,
+    }
+}
+
+/// Validate a config file and return warnings for unknown keys/sections.
+pub fn validate_config_file(path: &PathBuf) -> (Vec<ConfigWarning>, bool) {
+    let content = match fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                vec![ConfigWarning {
+                    line: 0,
+                    message: format!("cannot read file: {e}"),
+                }],
+                true,
+            );
+        }
+    };
+
+    let mut warnings = Vec::new();
+    let mut section = String::new();
+    let mut has_errors = false;
+
+    for (line_num, line) in content.lines().enumerate() {
+        let line_1 = line_num + 1;
+        let line = line.trim();
+
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        // Section header
+        if line.starts_with('[') && line.ends_with(']') {
+            section = line[1..line.len() - 1].trim().to_string();
+            // Check if section is known (accounting for dynamic sections like models.*, rules.*, agents.*, hooks.*, idle.tasks.*)
+            let base = section.split('.').next().unwrap_or(&section);
+            let is_known = known_keys(&section).is_some()
+                || matches!(base, "models" | "rules" | "agents" | "hooks" | "idle");
+            if !is_known {
+                warnings.push(ConfigWarning {
+                    line: line_1,
+                    message: format!("unknown section [{section}]"),
+                });
+            }
+            continue;
+        }
+
+        // Key = value
+        let Some((key, _value)) = line.split_once('=') else {
+            warnings.push(ConfigWarning {
+                line: line_1,
+                message: format!("malformed line (expected key = value): {line}"),
+            });
+            has_errors = true;
+            continue;
+        };
+        let key = key.trim();
+
+        // Skip dynamic sections (models.*, rules.*, agents.*, hooks.*)
+        let base = section.split('.').next().unwrap_or(&section);
+        if matches!(base, "models" | "rules" | "agents" | "hooks" | "idle") {
+            continue;
+        }
+
+        // Check if key is known for this section
+        if let Some(valid_keys) = known_keys(&section) {
+            if !valid_keys.contains(&key) {
+                warnings.push(ConfigWarning {
+                    line: line_1,
+                    message: format!("unknown key \"{key}\" in [{section}]"),
+                });
+            }
+        }
+    }
+
+    (warnings, has_errors)
 }
 
 /// Load hooks from global and project config files.

--- a/src/init.rs
+++ b/src/init.rs
@@ -242,7 +242,7 @@ pub fn run_uninit(project: bool) -> io::Result<()> {
 }
 
 /// Run the init command: write Claude Code hooks into settings.json.
-pub fn run_init(project: bool) -> io::Result<()> {
+pub fn run_init(project: bool, dry_run: bool) -> io::Result<()> {
     let path = settings_path(project);
 
     // Read existing settings or start fresh
@@ -277,13 +277,25 @@ pub fn run_init(project: bool) -> io::Result<()> {
         return Ok(());
     }
 
+    // Merge hooks into settings
+    merge_hooks(&mut settings);
+
+    if dry_run {
+        // Show what would be written without actually writing
+        let json = serde_json::to_string_pretty(&settings)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        println!("Would write to {}:", path.display());
+        println!();
+        println!("{json}");
+        return Ok(());
+    }
+
     // Ensure parent directory exists
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
 
-    // Merge and write
-    merge_hooks(&mut settings);
+    // Write
     let json = serde_json::to_string_pretty(&settings)
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     std::fs::write(&path, format!("{json}\n"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,6 +316,14 @@ pub(crate) struct Cli {
     #[arg(long, help_heading = "History & Diagnostics")]
     pub(crate) config_template: bool,
 
+    /// Validate config files and report unknown keys or malformed values
+    #[arg(long, help_heading = "History & Diagnostics")]
+    pub(crate) config_validate: bool,
+
+    /// Write a sample .claudectl.toml in the current directory
+    #[arg(long, help_heading = "Setup")]
+    pub(crate) config_init: bool,
+
     /// List configured event hooks and exit
     #[arg(long, help_heading = "History & Diagnostics")]
     pub(crate) hooks: bool,
@@ -448,6 +456,14 @@ fn run_main(cli: Cli) -> io::Result<()> {
         return Ok(());
     }
 
+    if cli.config_validate {
+        return commands::validate_config();
+    }
+
+    if cli.config_init {
+        return commands::write_config_init();
+    }
+
     if cli.hooks {
         hook_registry.print_list();
         return Ok(());
@@ -459,7 +475,7 @@ fn run_main(cli: Cli) -> io::Result<()> {
 
     if cli.init {
         let project = cli.scope == "project";
-        return init::run_init(project);
+        return init::run_init(project, cli.dry_run);
     }
 
     if cli.uninstall {

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 
 use crate::transcript::{TranscriptBlock, TranscriptEvent, TranscriptRole, parse_line};
 
+/// Default lookback buffer: capture recent events before record start (~30s of activity).
+const DEFAULT_LOOKBACK_BYTES: u64 = 50_000;
 /// Maximum characters of bash output to include in a frame.
 const MAX_BASH_OUTPUT: usize = 800;
 /// Maximum characters of assistant text to include.
@@ -90,8 +92,31 @@ impl SessionRecorder {
         });
         writeln!(cast_file, "{}", header)?;
 
-        // Start from end of file — only record NEW events going forward
-        let initial_offset = std::fs::metadata(jsonl_path).map(|m| m.len()).unwrap_or(0);
+        // Start with a lookback buffer to capture recent events before record-start.
+        // Seek back DEFAULT_LOOKBACK_BYTES, then scan forward to the next newline
+        // to avoid starting mid-line in the JSONL stream.
+        let file_len = std::fs::metadata(jsonl_path).map(|m| m.len()).unwrap_or(0);
+        let initial_offset = if file_len > DEFAULT_LOOKBACK_BYTES {
+            let raw_offset = file_len - DEFAULT_LOOKBACK_BYTES;
+            // Find next newline after raw_offset to align to a line boundary
+            if let Ok(f) = File::open(jsonl_path) {
+                let mut reader = BufReader::new(f);
+                if reader.seek(SeekFrom::Start(raw_offset)).is_ok() {
+                    let mut discard = String::new();
+                    if reader.read_line(&mut discard).is_ok() {
+                        reader.stream_position().unwrap_or(raw_offset)
+                    } else {
+                        raw_offset
+                    }
+                } else {
+                    raw_offset
+                }
+            } else {
+                raw_offset
+            }
+        } else {
+            0 // File is smaller than lookback — include everything
+        };
 
         Ok(Self {
             jsonl_path: jsonl_path.to_path_buf(),


### PR DESCRIPTION
## Summary

- **#186 Event log retention**: `retention_days` field in `[lifecycle]` config section (default 30), wired to headless auto-prune. Users can now configure retention via `.claudectl.toml`.
- **#73 Session recording UX**: `R` key toggles recording per-session (no longer stops all). Recordings include a ~30-second lookback buffer before record-start. Filenames include timestamps for uniqueness.
- **#74 Config validation & tooling**: `--config-validate` reports unknown keys/sections with line numbers. `--init --dry-run` previews hooks without writing. `--config-init` writes an annotated sample `.claudectl.toml`.
- **#134 False-deny friction**: `--brain-stats false-deny` now shows friction cost (avg override delay, total time). TUI prompts for override reason (1=always safe, 2=one-time, 3=brain is wrong) when accepting a brain denial. `resolved_at` and `override_reason` fields on decision records enable latency analysis.
- Version bumped `0.44.0` -> `0.45.0`.

Closes #186, closes #73, closes #74, closes #134

## Files changed (16)

| Area | Files |
|------|-------|
| Retention config | `config.rs`, `commands.rs`, `brain/engine.rs` |
| Recording UX | `app.rs`, `session_recorder.rs` |
| Config tooling | `config.rs`, `main.rs`, `init.rs`, `commands.rs` |
| False-deny friction | `brain/decisions.rs`, `brain/metrics.rs`, `app.rs`, `brain/engine.rs` |
| Test updates | `brain/preferences.rs`, `brain/pref_store.rs`, `brain/detectors.rs`, `brain/retrieval.rs`, `brain/insights.rs` |
| Metadata | `Cargo.toml`, `CHANGELOG.md` |

## Test plan

- [x] `cargo build` — compiles without features
- [x] `cargo build --features coord,relay` — compiles with all features
- [x] `cargo test --features coord,relay` — 677 tests pass, 0 failures
- [x] `cargo clippy --features coord,relay -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)