### PR TITLE
feat: hive toggle, outbound curation, inbound auto-accept

### DIFF
--- a/src/brain/decisions.rs
+++ b/src/brain/decisions.rs
@@ -440,7 +440,8 @@ fn maybe_distill_background() {
             #[cfg(feature = "hive")]
             {
                 let cfg = crate::config::Config::load();
-                if let Some(hive_cfg) = cfg.hive.filter(|h| h.enabled) {
+                if crate::hive::is_active(cfg.hive.as_ref()) {
+                    let hive_cfg = cfg.hive.clone().unwrap_or_default();
                     let thresholds = crate::hive::distiller::ExportThresholds {
                         min_pattern_evidence: hive_cfg.export_min_evidence,
                         min_tool_decisions: hive_cfg.export_min_tool_decisions,

--- a/src/brain/engine.rs
+++ b/src/brain/engine.rs
@@ -375,7 +375,8 @@ impl BrainEngine {
         #[cfg(feature = "hive")]
         {
             let cfg = crate::config::Config::load();
-            if let Some(hive_cfg) = cfg.hive.filter(|h| h.enabled) {
+            if crate::hive::is_active(cfg.hive.as_ref()) {
+                let hive_cfg = cfg.hive.clone().unwrap_or_default();
                 let store = crate::hive::store::HiveStore::load();
                 let trust_store =
                     crate::hive::trust::TrustStore::load_with_default(hive_cfg.default_trust);

--- a/src/config.rs
+++ b/src/config.rs
@@ -235,6 +235,9 @@ pub struct HiveConfig {
     pub max_prompt_units: usize,
     /// Days after which a peer's knowledge is pruned if the peer hasn't been seen.
     pub stale_peer_days: u32,
+    /// Outbound exposure mode: "auto" gossips everything that passes filters;
+    /// "manual" keeps new units hidden until the user runs `claudectl hive expose`.
+    pub share_mode: String,
 }
 
 impl Default for HiveConfig {
@@ -255,6 +258,7 @@ impl Default for HiveConfig {
             max_units: 500,
             max_prompt_units: 20,
             stale_peer_days: 90,
+            share_mode: "auto".into(),
         }
     }
 }
@@ -347,6 +351,7 @@ struct RawHiveConfig {
     max_units: Option<usize>,
     max_prompt_units: Option<usize>,
     stale_peer_days: Option<u32>,
+    share_mode: Option<String>,
 }
 
 #[derive(Debug, Default)]
@@ -563,6 +568,11 @@ impl Config {
             }
             if let Some(v) = raw_hive.stale_peer_days {
                 hive.stale_peer_days = v;
+            }
+            if let Some(v) = raw_hive.share_mode {
+                if crate::hive::exposure::ShareMode::parse(&v).is_some() {
+                    hive.share_mode = v.trim().to_lowercase();
+                }
             }
         }
         if let Some(lc) = raw.lifecycle {
@@ -913,6 +923,7 @@ impl Config {
 # export_min_tool_decisions = 10
 # knowledge_ttl_days = 30
 # inject_unverified = true
+# share_mode = "auto"           # "auto" = expose by default, "manual" = pre-flight curation
 
 # ── External Agents ─────────────────────────────────────────────────
 #
@@ -1234,6 +1245,9 @@ fn parse_config_file(path: &PathBuf) -> Option<RawConfig> {
                     "stale_peer_days" => {
                         hive.stale_peer_days = value.parse().ok();
                     }
+                    "share_mode" => {
+                        hive.share_mode = Some(unquote(value));
+                    }
                     _ => {}
                 }
             }
@@ -1358,6 +1372,7 @@ fn known_keys(section: &str) -> Option<&'static [&'static str]> {
             "max_units",
             "max_prompt_units",
             "stale_peer_days",
+            "share_mode",
         ]),
         _ => None,
     }

--- a/src/hive/accept.rs
+++ b/src/hive/accept.rs
@@ -1,0 +1,165 @@
+// Inbound accept controls — install received skills/commands automatically or
+// hold them in a pending queue for explicit approval.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AcceptMode {
+    /// Hold all incoming artifacts; user must `claudectl hive accept <id>`.
+    Manual,
+    /// Auto-install only when source peer is in the Confirmed trust tier.
+    Trusted,
+    /// Auto-install every received skill/command (hooks always require manual).
+    All,
+}
+
+impl AcceptMode {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_lowercase().as_str() {
+            "manual" => Some(Self::Manual),
+            "trusted" | "auto-trusted" => Some(Self::Trusted),
+            "all" | "auto" | "auto-all" => Some(Self::All),
+            _ => None,
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::Trusted => "trusted",
+            Self::All => "all",
+        }
+    }
+}
+
+fn accept_mode_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    PathBuf::from(home)
+        .join(".claudectl")
+        .join("hive")
+        .join("accept-mode")
+}
+
+/// Read the accept mode override file. Falls back to `default_mode` on absence
+/// or invalid content.
+pub fn read_mode(default_mode: AcceptMode) -> AcceptMode {
+    fs::read_to_string(accept_mode_path())
+        .ok()
+        .and_then(|s| AcceptMode::parse(&s))
+        .unwrap_or(default_mode)
+}
+
+pub fn write_mode(mode: AcceptMode) -> io::Result<()> {
+    let path = accept_mode_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&path, mode.label())
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Installed tracker
+// ────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstallRecord {
+    pub installed_at: u64,
+    pub mode: String,
+    pub source_peer: String,
+}
+
+fn installed_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    PathBuf::from(home)
+        .join(".claudectl")
+        .join("hive")
+        .join("installed.json")
+}
+
+#[derive(Default)]
+pub struct InstalledTracker {
+    entries: HashMap<String, InstallRecord>,
+}
+
+impl InstalledTracker {
+    pub fn load() -> Self {
+        Self::load_from(&installed_path())
+    }
+
+    pub fn load_from(path: &std::path::Path) -> Self {
+        let entries = fs::read_to_string(path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<HashMap<String, InstallRecord>>(&s).ok())
+            .unwrap_or_default();
+        InstalledTracker { entries }
+    }
+
+    pub fn save(&self) -> io::Result<()> {
+        self.save_to(&installed_path())
+    }
+
+    pub fn save_to(&self, path: &std::path::Path) -> io::Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(&self.entries)
+            .map_err(|e| io::Error::other(format!("serialize installed: {e}")))?;
+        fs::write(path, json)
+    }
+
+    pub fn is_installed(&self, unit_id: &str) -> bool {
+        self.entries.contains_key(unit_id)
+    }
+
+    pub fn record(&mut self, unit_id: &str, source_peer: &str, mode: AcceptMode) {
+        self.entries.insert(
+            unit_id.to_string(),
+            InstallRecord {
+                installed_at: super::epoch_secs(),
+                mode: mode.label().to_string(),
+                source_peer: source_peer.to_string(),
+            },
+        );
+    }
+
+    pub fn entries(&self) -> &HashMap<String, InstallRecord> {
+        &self.entries
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn parse_modes() {
+        assert_eq!(AcceptMode::parse("manual"), Some(AcceptMode::Manual));
+        assert_eq!(AcceptMode::parse("Trusted"), Some(AcceptMode::Trusted));
+        assert_eq!(AcceptMode::parse("auto"), Some(AcceptMode::All));
+        assert_eq!(AcceptMode::parse("auto-all"), Some(AcceptMode::All));
+        assert_eq!(AcceptMode::parse("nope"), None);
+    }
+
+    #[test]
+    fn tracker_roundtrip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("installed.json");
+
+        let mut tracker = InstalledTracker::default();
+        tracker.record("ku_a", "peer-x", AcceptMode::Trusted);
+        tracker.save_to(&path).unwrap();
+
+        let loaded = InstalledTracker::load_from(&path);
+        assert!(loaded.is_installed("ku_a"));
+        assert!(!loaded.is_installed("ku_missing"));
+        let entry = loaded.entries().get("ku_a").unwrap();
+        assert_eq!(entry.source_peer, "peer-x");
+        assert_eq!(entry.mode, "trusted");
+    }
+}

--- a/src/hive/cli.rs
+++ b/src/hive/cli.rs
@@ -9,6 +9,33 @@ use super::store::HiveStore;
 
 #[derive(Subcommand)]
 pub enum HiveCommand {
+    /// Turn the hive on (overrides config; broadcasts and brain injection enabled)
+    On,
+
+    /// Turn the hive off (overrides config; nothing broadcasts, no injection)
+    Off,
+
+    /// List local units that would be broadcast on the next gossip tick
+    Preview,
+
+    /// Mark units as exposed (broadcast outbound). Pass a unit ID or `--all`.
+    Expose {
+        /// Unit ID to expose
+        unit_id: Option<String>,
+        /// Expose every locally-originated unit currently in the store
+        #[arg(long)]
+        all: bool,
+    },
+
+    /// Hide units from outbound broadcast. Pass a unit ID or `--all`.
+    Hide {
+        /// Unit ID to hide
+        unit_id: Option<String>,
+        /// Hide every locally-originated unit currently in the store
+        #[arg(long)]
+        all: bool,
+    },
+
     /// Show knowledge store overview
     Status,
 
@@ -90,11 +117,41 @@ pub enum HiveCommand {
         #[arg(long)]
         show_ignored: bool,
     },
+
+    /// Accept (install) a received artifact and record it as installed
+    Accept {
+        /// Knowledge unit ID to accept
+        unit_id: String,
+        /// Target directory (default: ~/.claude)
+        #[arg(long)]
+        target: Option<String>,
+        /// Force accept even if compatibility checks fail
+        #[arg(long)]
+        force: bool,
+    },
+
+    /// Show or set the inbound accept mode (manual, trusted, all)
+    AcceptMode {
+        /// Mode value (omit to show current)
+        mode: Option<String>,
+    },
+
+    /// List shared artifacts that haven't been accepted yet
+    Pending {
+        /// Filter by type: skill, command, hook
+        #[arg(long, name = "type")]
+        content_type: Option<String>,
+    },
 }
 
 /// Dispatch a hive subcommand.
 pub fn dispatch_command(command: &HiveCommand, json_mode: bool) -> io::Result<()> {
     match command {
+        HiveCommand::On => cmd_set_mode("on", json_mode),
+        HiveCommand::Off => cmd_set_mode("off", json_mode),
+        HiveCommand::Preview => cmd_preview(json_mode),
+        HiveCommand::Expose { unit_id, all } => cmd_expose(unit_id.as_deref(), *all, json_mode),
+        HiveCommand::Hide { unit_id, all } => cmd_hide(unit_id.as_deref(), *all, json_mode),
         HiveCommand::Status => cmd_status(json_mode),
         HiveCommand::Knowledge { from, scope } => {
             cmd_knowledge(from.as_deref(), scope.as_deref(), json_mode)
@@ -120,7 +177,264 @@ pub fn dispatch_command(command: &HiveCommand, json_mode: bool) -> io::Result<()
             content_type,
             show_ignored,
         } => cmd_shared(content_type.as_deref(), *show_ignored, json_mode),
+        HiveCommand::Accept {
+            unit_id,
+            target,
+            force,
+        } => cmd_install(unit_id, target.as_deref(), *force, json_mode),
+        HiveCommand::AcceptMode { mode } => cmd_accept_mode(mode.as_deref(), json_mode),
+        HiveCommand::Pending { content_type } => cmd_pending(content_type.as_deref(), json_mode),
     }
+}
+
+/// `claudectl hive on|off`
+fn cmd_set_mode(mode: &str, json_mode: bool) -> io::Result<()> {
+    super::write_mode_override(mode)?;
+    let cfg = crate::config::Config::load();
+    let active = super::is_active(cfg.hive.as_ref());
+
+    if json_mode {
+        let output = serde_json::json!({
+            "mode_override": mode,
+            "active": active,
+            "config_enabled": cfg.hive.as_ref().map(|h| h.enabled).unwrap_or(false),
+        });
+        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+    } else {
+        let label = if active { "active" } else { "inactive" };
+        println!("Hive override: {mode} (currently {label})");
+        if mode == "off" {
+            println!("  Outbound gossip and brain injection paused.");
+            println!("  Local store is preserved.");
+        } else {
+            println!("  Outbound gossip and brain injection enabled.");
+        }
+        println!();
+        println!(
+            "Tip: edit ~/.claudectl/hive/mode (or rerun) to change this; the file overrides config."
+        );
+    }
+    Ok(())
+}
+
+/// `claudectl hive preview` — what would broadcast on the next gossip tick.
+fn cmd_preview(json_mode: bool) -> io::Result<()> {
+    let store = HiveStore::load();
+    let cfg = crate::config::Config::load();
+    let hive_cfg = cfg.hive.clone().unwrap_or_default();
+    let active = super::is_active(cfg.hive.as_ref());
+
+    let mode = super::exposure::ShareMode::parse(&hive_cfg.share_mode)
+        .unwrap_or(super::exposure::ShareMode::Auto);
+    let exposure = super::exposure::ExposureStore::load();
+    let filter = super::SharingFilter::from_config(&hive_cfg);
+
+    #[cfg(feature = "relay")]
+    let local_id = crate::relay::load_or_create_identity().0;
+    #[cfg(not(feature = "relay"))]
+    let local_id = super::local_identity();
+
+    // Partition local units into ready / hidden / blocked
+    let mut ready = Vec::new();
+    let mut hidden = Vec::new();
+    let mut blocked: Vec<(&super::KnowledgeUnit, &'static str)> = Vec::new();
+
+    for unit in store.all_units() {
+        if unit.source_peer != local_id {
+            continue;
+        }
+        if !unit.category.is_shareable() {
+            blocked.push((unit, "personal"));
+            continue;
+        }
+        if !filter.allows(unit) {
+            blocked.push((unit, "filter"));
+            continue;
+        }
+        let ttl_secs = hive_cfg.knowledge_ttl_days as u64 * 86400;
+        let age = super::epoch_secs().saturating_sub(unit.last_validated_at);
+        if age > ttl_secs {
+            blocked.push((unit, "expired"));
+            continue;
+        }
+        if unit.propagation_count >= hive_cfg.max_propagation {
+            blocked.push((unit, "max-prop"));
+            continue;
+        }
+        if exposure.is_exposed(&unit.id, mode) {
+            ready.push(unit);
+        } else {
+            hidden.push(unit);
+        }
+    }
+
+    if json_mode {
+        let to_json = |units: &[&super::KnowledgeUnit]| -> Vec<serde_json::Value> {
+            units
+                .iter()
+                .map(|u| {
+                    serde_json::json!({
+                        "id": u.id,
+                        "scope": u.scope.to_string(),
+                        "category": u.category.label(),
+                        "summary": u.content.summary_line(),
+                    })
+                })
+                .collect()
+        };
+        let output = serde_json::json!({
+            "active": active,
+            "share_mode": mode.label(),
+            "ready": to_json(&ready),
+            "hidden": to_json(&hidden),
+            "blocked": blocked
+                .iter()
+                .map(|(u, reason)| serde_json::json!({
+                    "id": u.id,
+                    "summary": u.content.summary_line(),
+                    "reason": reason,
+                }))
+                .collect::<Vec<_>>(),
+        });
+        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+        return Ok(());
+    }
+
+    let active_label = if active { "active" } else { "inactive" };
+    println!(
+        "Outbound preview ({} mode, hive {active_label})",
+        mode.label()
+    );
+    println!();
+
+    if ready.is_empty() && hidden.is_empty() && blocked.is_empty() {
+        println!("  No locally-originated units yet.");
+        return Ok(());
+    }
+
+    if !ready.is_empty() {
+        println!("Ready to broadcast ({}):", ready.len());
+        for u in &ready {
+            print_preview_row(u);
+        }
+        println!();
+    }
+    if !hidden.is_empty() {
+        println!("Hidden — won't broadcast ({}):", hidden.len());
+        for u in &hidden {
+            print_preview_row(u);
+        }
+        println!();
+        println!("  Expose with: claudectl hive expose <id>  (or --all)");
+        println!();
+    }
+    if !blocked.is_empty() {
+        println!("Blocked by config or rules ({}):", blocked.len());
+        for (u, reason) in &blocked {
+            let id_short = short_id(&u.id);
+            println!("  {id_short}  [{reason}]  {}", u.content.summary_line());
+        }
+    }
+
+    Ok(())
+}
+
+fn print_preview_row(u: &super::KnowledgeUnit) {
+    let id_short = short_id(&u.id);
+    println!(
+        "  {id_short}  {:<10}  {}",
+        u.category.label(),
+        u.content.summary_line()
+    );
+}
+
+fn short_id(id: &str) -> &str {
+    if id.len() > 12 { &id[..12] } else { id }
+}
+
+/// `claudectl hive expose [unit_id] [--all]`
+fn cmd_expose(unit_id: Option<&str>, all: bool, json_mode: bool) -> io::Result<()> {
+    apply_exposure(
+        unit_id,
+        all,
+        super::exposure::ExposureState::Expose,
+        json_mode,
+    )
+}
+
+/// `claudectl hive hide [unit_id] [--all]`
+fn cmd_hide(unit_id: Option<&str>, all: bool, json_mode: bool) -> io::Result<()> {
+    apply_exposure(
+        unit_id,
+        all,
+        super::exposure::ExposureState::Hide,
+        json_mode,
+    )
+}
+
+fn apply_exposure(
+    unit_id: Option<&str>,
+    all: bool,
+    state: super::exposure::ExposureState,
+    json_mode: bool,
+) -> io::Result<()> {
+    if unit_id.is_none() && !all {
+        return Err(io::Error::other("specify a unit ID or --all".to_string()));
+    }
+
+    let store = HiveStore::load();
+    let mut exposure = super::exposure::ExposureStore::load();
+
+    #[cfg(feature = "relay")]
+    let local_id = crate::relay::load_or_create_identity().0;
+    #[cfg(not(feature = "relay"))]
+    let local_id = super::local_identity();
+
+    let mut affected: Vec<String> = Vec::new();
+
+    if all {
+        for u in store.all_units() {
+            if u.source_peer == local_id {
+                exposure.set(&u.id, state);
+                affected.push(u.id.clone());
+            }
+        }
+    } else if let Some(id) = unit_id {
+        let unit = store
+            .get(id)
+            .ok_or_else(|| io::Error::other(format!("unknown unit: {id}")))?;
+        if unit.source_peer != local_id {
+            return Err(io::Error::other(
+                "exposure only applies to locally-originated units".to_string(),
+            ));
+        }
+        exposure.set(id, state);
+        affected.push(id.to_string());
+    }
+
+    exposure
+        .save()
+        .map_err(|e| io::Error::other(format!("save exposure: {e}")))?;
+
+    let action = match state {
+        super::exposure::ExposureState::Expose => "exposed",
+        super::exposure::ExposureState::Hide => "hidden",
+    };
+
+    if json_mode {
+        let output = serde_json::json!({
+            "action": action,
+            "count": affected.len(),
+            "unit_ids": affected,
+        });
+        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+    } else if affected.is_empty() {
+        println!("No locally-originated units matched.");
+    } else {
+        println!("{} {} unit(s).", action, affected.len());
+    }
+
+    Ok(())
 }
 
 /// `claudectl hive status`
@@ -128,7 +442,9 @@ fn cmd_status(json_mode: bool) -> io::Result<()> {
     let store = HiveStore::load();
     let all = store.all_units();
     let cfg = crate::config::Config::load();
-    let hive_cfg = cfg.hive.unwrap_or_default();
+    let hive_cfg = cfg.hive.clone().unwrap_or_default();
+    let active = super::is_active(cfg.hive.as_ref());
+    let mode_override = super::read_mode_override();
 
     // Count by source
     let mut sources: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
@@ -152,6 +468,10 @@ fn cmd_status(json_mode: bool) -> io::Result<()> {
     if json_mode {
         #[allow(unused_mut)]
         let mut output = serde_json::json!({
+            "active": active,
+            "mode_override": mode_override,
+            "share_mode": hive_cfg.share_mode,
+            "config_enabled": cfg.hive.as_ref().map(|h| h.enabled).unwrap_or(false),
             "total_units": all.len(),
             "max_units": hive_cfg.max_units,
             "sources": sources,
@@ -166,11 +486,24 @@ fn cmd_status(json_mode: bool) -> io::Result<()> {
         }
         println!("{}", serde_json::to_string_pretty(&output).unwrap());
     } else {
-        println!("Hive Knowledge Store");
+        let state_label = if active { "ON" } else { "OFF" };
+        let source_label = match mode_override.as_deref() {
+            Some(s) => format!("override: {s}"),
+            None => format!(
+                "config: {}",
+                if cfg.hive.as_ref().map(|h| h.enabled).unwrap_or(false) {
+                    "enabled"
+                } else {
+                    "disabled"
+                }
+            ),
+        };
+        println!("Hive Knowledge Store [{state_label}]  ({source_label})");
         println!();
         if let Some(ref id) = relay_identity {
             println!("  Identity: {}", id);
         }
+        println!("  Share mode: {}", hive_cfg.share_mode);
         println!("  Total units: {} / {} max", all.len(), hive_cfg.max_units);
         if !by_category.is_empty() {
             println!("  Categories:");
@@ -644,6 +977,86 @@ fn cmd_share(content_type: &str, path: &str, scope_str: &str, json_mode: bool) -
     Ok(())
 }
 
+/// Outcome of an artifact write — used by both interactive install and auto-accept.
+pub enum InstallOutcome {
+    Skill {
+        name: String,
+        version: String,
+        path: std::path::PathBuf,
+    },
+    Command {
+        name: String,
+        args: Option<String>,
+        path: std::path::PathBuf,
+    },
+    /// Hooks are never auto-installed; we surface the config for the user to review.
+    HookConfig {
+        event: String,
+        matcher: String,
+        description: String,
+        config_json: String,
+    },
+}
+
+/// Write a skill or command to disk. Hooks are returned as config-only —
+/// callers decide how to present them. Returns None for non-artifact units.
+pub fn write_artifact_files(
+    unit: &super::KnowledgeUnit,
+    base_dir: &std::path::Path,
+) -> io::Result<Option<InstallOutcome>> {
+    match &unit.content {
+        super::KnowledgeContent::Skill {
+            name,
+            version,
+            body,
+            ..
+        } => {
+            let slug = name.to_lowercase().replace(' ', "-");
+            let skill_dir = base_dir.join("skills").join(&slug);
+            std::fs::create_dir_all(&skill_dir)?;
+            let file_path = skill_dir.join("SKILL.md");
+            std::fs::write(&file_path, body)?;
+            Ok(Some(InstallOutcome::Skill {
+                name: name.clone(),
+                version: version.clone(),
+                path: file_path,
+            }))
+        }
+        super::KnowledgeContent::Command {
+            name, body, args, ..
+        } => {
+            let cmds_dir = base_dir.join("commands");
+            std::fs::create_dir_all(&cmds_dir)?;
+            let file_path = cmds_dir.join(format!("{name}.md"));
+            std::fs::write(&file_path, body)?;
+            Ok(Some(InstallOutcome::Command {
+                name: name.clone(),
+                args: args.clone(),
+                path: file_path,
+            }))
+        }
+        super::KnowledgeContent::HookConfig {
+            event,
+            matcher,
+            description,
+            config_json,
+            ..
+        } => Ok(Some(InstallOutcome::HookConfig {
+            event: event.clone(),
+            matcher: matcher.clone(),
+            description: description.clone(),
+            config_json: config_json.clone(),
+        })),
+        _ => Ok(None),
+    }
+}
+
+/// Default `~/.claude` install root.
+pub fn default_install_dir() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    std::path::PathBuf::from(home).join(".claude")
+}
+
 /// `claudectl hive install <unit_id> [--target dir] [--force]`
 fn cmd_install(
     unit_id: &str,
@@ -693,93 +1106,85 @@ fn cmd_install(
 
     let base_dir = match target {
         Some(t) => std::path::PathBuf::from(t),
-        None => {
-            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-            std::path::PathBuf::from(home).join(".claude")
-        }
+        None => default_install_dir(),
     };
 
-    match &unit.content {
-        super::KnowledgeContent::Skill {
+    let outcome = write_artifact_files(unit, &base_dir)?.ok_or_else(|| {
+        io::Error::other(format!("unit {unit_id} is not a skill, command, or hook"))
+    })?;
+
+    let unverified_warning = if tier == super::trust::TrustTier::Unverified {
+        Some(format!(
+            "Warning: source peer '{}' is unverified. Review before use.",
+            unit.source_peer
+        ))
+    } else {
+        None
+    };
+
+    let mut tracker = super::accept::InstalledTracker::load();
+    let mut record_install = || {
+        tracker.record(
+            unit_id,
+            &unit.source_peer,
+            super::accept::AcceptMode::Manual,
+        );
+        let _ = tracker.save();
+    };
+
+    match outcome {
+        InstallOutcome::Skill {
             name,
             version,
-            body,
-            ..
+            path,
         } => {
-            let slug = name.to_lowercase().replace(' ', "-");
-            let skill_dir = base_dir.join("skills").join(&slug);
-            std::fs::create_dir_all(&skill_dir)?;
-            let file_path = skill_dir.join("SKILL.md");
-            std::fs::write(&file_path, body)?;
-
-            if tier == super::trust::TrustTier::Unverified {
-                eprintln!(
-                    "Warning: source peer '{}' is unverified (trust < 0.5). \
-                     Review the installed skill before relying on it.",
-                    unit.source_peer
-                );
+            if let Some(w) = unverified_warning {
+                eprintln!("{w}");
             }
-
+            record_install();
             if json_mode {
                 let output = serde_json::json!({
                     "action": "installed",
                     "content_type": "skill",
                     "name": name,
                     "version": version,
-                    "path": file_path.display().to_string(),
+                    "path": path.display().to_string(),
                     "trust_tier": tier.label(),
                 });
                 println!("{}", serde_json::to_string_pretty(&output).unwrap());
             } else {
-                println!(
-                    "Installed skill '{name}' v{version} to {}",
-                    file_path.display()
-                );
+                println!("Installed skill '{name}' v{version} to {}", path.display());
             }
         }
-        super::KnowledgeContent::Command {
-            name, body, args, ..
-        } => {
-            let cmds_dir = base_dir.join("commands");
-            std::fs::create_dir_all(&cmds_dir)?;
-            let file_path = cmds_dir.join(format!("{name}.md"));
-            std::fs::write(&file_path, body)?;
-
-            if tier == super::trust::TrustTier::Unverified {
-                eprintln!(
-                    "Warning: source peer '{}' is unverified. Review before use.",
-                    unit.source_peer
-                );
+        InstallOutcome::Command { name, args, path } => {
+            if let Some(w) = unverified_warning {
+                eprintln!("{w}");
             }
-
+            record_install();
             if json_mode {
                 let output = serde_json::json!({
                     "action": "installed",
                     "content_type": "command",
                     "name": name,
                     "args": args,
-                    "path": file_path.display().to_string(),
+                    "path": path.display().to_string(),
                     "trust_tier": tier.label(),
                 });
                 println!("{}", serde_json::to_string_pretty(&output).unwrap());
             } else {
-                println!("Installed command '/{name}' to {}", file_path.display());
+                println!("Installed command '/{name}' to {}", path.display());
             }
         }
-        super::KnowledgeContent::HookConfig {
+        InstallOutcome::HookConfig {
             event,
             matcher,
             description,
             config_json,
-            ..
         } => {
-            if tier == super::trust::TrustTier::Unverified {
-                eprintln!(
-                    "Warning: source peer '{}' is unverified. Review the hook config carefully.",
-                    unit.source_peer
-                );
+            if let Some(w) = unverified_warning {
+                eprintln!("{w}");
             }
-
+            // Hooks aren't recorded as installed — user pastes config manually.
             if json_mode {
                 let output = serde_json::json!({
                     "action": "installed",
@@ -800,11 +1205,6 @@ fn cmd_install(
                 println!();
                 println!("Note: You must create the hook script implementation yourself.");
             }
-        }
-        _ => {
-            return Err(io::Error::other(format!(
-                "unit {unit_id} is not a skill, command, or hook"
-            )));
         }
     }
 
@@ -1056,4 +1456,208 @@ fn cmd_curriculum(json_mode: bool) -> io::Result<()> {
     println!("{} units in curriculum", curriculum.len());
 
     Ok(())
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Inbound accept controls
+// ────────────────────────────────────────────────────────────────────────────
+
+/// `claudectl hive accept-mode [manual|trusted|all]`
+fn cmd_accept_mode(mode: Option<&str>, json_mode: bool) -> io::Result<()> {
+    use super::accept::AcceptMode;
+
+    match mode {
+        None => {
+            let current = super::accept::read_mode(AcceptMode::Manual);
+            if json_mode {
+                let output = serde_json::json!({
+                    "accept_mode": current.label(),
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            } else {
+                println!("Accept mode: {}", current.label());
+                println!();
+                println!("Modes:");
+                println!("  manual  — hold all incoming artifacts; user accepts each (default)");
+                println!("  trusted — auto-install from peers in the Confirmed trust tier");
+                println!(
+                    "  all     — auto-install every received skill/command (hooks always manual)"
+                );
+            }
+        }
+        Some(m) => {
+            let parsed = AcceptMode::parse(m).ok_or_else(|| {
+                io::Error::other(format!("invalid accept mode: {m} (manual|trusted|all)"))
+            })?;
+            super::accept::write_mode(parsed)?;
+            println!("Accept mode set to: {}", parsed.label());
+            if parsed != AcceptMode::Manual {
+                println!("  Newly received skills/commands will be installed automatically.");
+                println!("  Hooks always require manual review.");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `claudectl hive pending [--type X]` — list shared artifacts not yet accepted.
+fn cmd_pending(content_type_filter: Option<&str>, json_mode: bool) -> io::Result<()> {
+    let store = HiveStore::load();
+    let trust_store = super::trust::TrustStore::load();
+    let tracker = super::accept::InstalledTracker::load();
+
+    let pending: Vec<(&super::KnowledgeUnit, super::trust::TrustTier)> = store
+        .all_units()
+        .into_iter()
+        .filter_map(|unit| {
+            let type_label = match &unit.content {
+                super::KnowledgeContent::Skill { .. } => "skill",
+                super::KnowledgeContent::Command { .. } => "command",
+                super::KnowledgeContent::HookConfig { .. } => "hook",
+                _ => return None,
+            };
+            if let Some(filter) = content_type_filter {
+                if type_label != filter {
+                    return None;
+                }
+            }
+            if tracker.is_installed(&unit.id) {
+                return None;
+            }
+            let tier = trust_store
+                .get(&unit.source_peer)
+                .map(|t| t.tier())
+                .unwrap_or(super::trust::TrustTier::Suggested);
+            if tier == super::trust::TrustTier::Ignored {
+                return None;
+            }
+            Some((unit, tier))
+        })
+        .collect();
+
+    if json_mode {
+        let items: Vec<serde_json::Value> = pending
+            .iter()
+            .map(|(unit, tier)| {
+                serde_json::json!({
+                    "id": unit.id,
+                    "type": content_type_label(&unit.content),
+                    "name": content_name(&unit.content),
+                    "source_peer": unit.source_peer,
+                    "trust_tier": tier.label(),
+                    "summary": unit.content.summary_line(),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&items).unwrap());
+        return Ok(());
+    }
+
+    if pending.is_empty() {
+        println!("No pending artifacts. Run `claudectl hive shared` to see all received items.");
+        return Ok(());
+    }
+
+    println!(
+        "{:<12} {:<8} {:<16} {:<14} CONTENT",
+        "ID", "TYPE", "SOURCE", "TRUST"
+    );
+    println!("{}", "─".repeat(80));
+    for (unit, tier) in &pending {
+        let id_short = if unit.id.len() > 11 {
+            &unit.id[..11]
+        } else {
+            &unit.id
+        };
+        println!(
+            "{:<12} {:<8} {:<16} {:<14} {}",
+            id_short,
+            content_type_label(&unit.content),
+            unit.source_peer,
+            tier.label(),
+            unit.content.summary_line(),
+        );
+    }
+    println!();
+    println!(
+        "{} pending. Accept with: claudectl hive accept <id>",
+        pending.len()
+    );
+
+    Ok(())
+}
+
+/// Auto-install eligible artifacts after a gossip merge. Skills/commands only.
+/// Returns the number of units installed. Errors are logged but never fatal.
+pub fn auto_accept_units(
+    units: &[super::KnowledgeUnit],
+    base_dir: Option<&std::path::Path>,
+) -> usize {
+    use super::accept::AcceptMode;
+
+    let mode = super::accept::read_mode(AcceptMode::Manual);
+    if mode == AcceptMode::Manual {
+        return 0;
+    }
+
+    let trust_store = super::trust::TrustStore::load();
+    let mut tracker = super::accept::InstalledTracker::load();
+    let owned_dir = base_dir.map(std::path::PathBuf::from);
+    let dir = owned_dir.unwrap_or_else(default_install_dir);
+    let mut installed = 0;
+
+    for unit in units {
+        // Don't reinstall.
+        if tracker.is_installed(&unit.id) {
+            continue;
+        }
+
+        // Only auto-install skills and commands; hooks always require manual review.
+        let is_artifact = matches!(
+            &unit.content,
+            super::KnowledgeContent::Skill { .. } | super::KnowledgeContent::Command { .. }
+        );
+        if !is_artifact {
+            continue;
+        }
+
+        // Compatibility check — skip on blocking issues.
+        if let Some(requires) = super::get_requires(&unit.content) {
+            let issues = super::check_compatibility(requires);
+            if issues.iter().any(|i| i.is_blocking()) {
+                continue;
+            }
+        }
+
+        // Trust gate.
+        let tier = trust_store
+            .get(&unit.source_peer)
+            .map(|t| t.tier())
+            .unwrap_or(super::trust::TrustTier::Suggested);
+
+        let allow = match mode {
+            AcceptMode::Manual => false,
+            AcceptMode::Trusted => tier == super::trust::TrustTier::Confirmed,
+            AcceptMode::All => tier != super::trust::TrustTier::Ignored,
+        };
+        if !allow {
+            continue;
+        }
+
+        match write_artifact_files(unit, &dir) {
+            Ok(Some(_)) => {
+                tracker.record(&unit.id, &unit.source_peer, mode);
+                installed += 1;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                crate::logger::log("HIVE", &format!("auto-accept failed for {}: {e}", unit.id));
+            }
+        }
+    }
+
+    if installed > 0 {
+        let _ = tracker.save();
+    }
+    installed
 }

--- a/src/hive/exposure.rs
+++ b/src/hive/exposure.rs
@@ -1,0 +1,172 @@
+// Per-unit exposure: which knowledge units the user has chosen to broadcast.
+//
+// Stored separately from the unit JSONL so the wire format and store schema
+// stay unchanged. Two-mode model:
+//   - `share_mode = "auto"`   → missing entry means exposed (current behavior).
+//   - `share_mode = "manual"` → missing entry means hidden; user opts in per unit.
+// Explicit `expose` / `hide` entries always win regardless of mode.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExposureState {
+    Expose,
+    Hide,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShareMode {
+    Auto,
+    Manual,
+}
+
+impl ShareMode {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_lowercase().as_str() {
+            "auto" => Some(ShareMode::Auto),
+            "manual" => Some(ShareMode::Manual),
+            _ => None,
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Manual => "manual",
+        }
+    }
+
+    pub fn default_exposed(&self) -> bool {
+        matches!(self, Self::Auto)
+    }
+}
+
+fn exposure_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    PathBuf::from(home)
+        .join(".claudectl")
+        .join("hive")
+        .join("exposure.json")
+}
+
+#[derive(Default)]
+pub struct ExposureStore {
+    entries: HashMap<String, ExposureState>,
+}
+
+impl ExposureStore {
+    pub fn load() -> Self {
+        Self::load_from(&exposure_path())
+    }
+
+    pub fn load_from(path: &std::path::Path) -> Self {
+        let entries = fs::read_to_string(path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<HashMap<String, ExposureState>>(&s).ok())
+            .unwrap_or_default();
+        ExposureStore { entries }
+    }
+
+    pub fn save(&self) -> io::Result<()> {
+        self.save_to(&exposure_path())
+    }
+
+    pub fn save_to(&self, path: &std::path::Path) -> io::Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(&self.entries)
+            .map_err(|e| io::Error::other(format!("serialize exposure: {e}")))?;
+        fs::write(path, json)
+    }
+
+    pub fn get(&self, id: &str) -> Option<ExposureState> {
+        self.entries.get(id).copied()
+    }
+
+    pub fn set(&mut self, id: &str, state: ExposureState) {
+        self.entries.insert(id.to_string(), state);
+    }
+
+    pub fn clear(&mut self, id: &str) {
+        self.entries.remove(id);
+    }
+
+    pub fn is_exposed(&self, id: &str, mode: ShareMode) -> bool {
+        match self.entries.get(id) {
+            Some(ExposureState::Expose) => true,
+            Some(ExposureState::Hide) => false,
+            None => mode.default_exposed(),
+        }
+    }
+
+    pub fn entries(&self) -> &HashMap<String, ExposureState> {
+        &self.entries
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn share_mode_parse() {
+        assert_eq!(ShareMode::parse("auto"), Some(ShareMode::Auto));
+        assert_eq!(ShareMode::parse("Manual"), Some(ShareMode::Manual));
+        assert_eq!(ShareMode::parse(" auto "), Some(ShareMode::Auto));
+        assert_eq!(ShareMode::parse("nope"), None);
+    }
+
+    #[test]
+    fn auto_mode_defaults_to_exposed() {
+        let store = ExposureStore::default();
+        assert!(store.is_exposed("ku_unknown", ShareMode::Auto));
+    }
+
+    #[test]
+    fn manual_mode_defaults_to_hidden() {
+        let store = ExposureStore::default();
+        assert!(!store.is_exposed("ku_unknown", ShareMode::Manual));
+    }
+
+    #[test]
+    fn explicit_state_overrides_mode() {
+        let mut store = ExposureStore::default();
+        store.set("ku_a", ExposureState::Hide);
+        store.set("ku_b", ExposureState::Expose);
+
+        assert!(!store.is_exposed("ku_a", ShareMode::Auto));
+        assert!(store.is_exposed("ku_b", ShareMode::Manual));
+    }
+
+    #[test]
+    fn save_load_roundtrip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("exposure.json");
+
+        let mut store = ExposureStore::default();
+        store.set("ku_1", ExposureState::Expose);
+        store.set("ku_2", ExposureState::Hide);
+        store.save_to(&path).unwrap();
+
+        let loaded = ExposureStore::load_from(&path);
+        assert_eq!(loaded.get("ku_1"), Some(ExposureState::Expose));
+        assert_eq!(loaded.get("ku_2"), Some(ExposureState::Hide));
+        assert_eq!(loaded.get("ku_missing"), None);
+    }
+
+    #[test]
+    fn clear_removes_entry() {
+        let mut store = ExposureStore::default();
+        store.set("ku_a", ExposureState::Hide);
+        store.clear("ku_a");
+        assert_eq!(store.get("ku_a"), None);
+    }
+}

--- a/src/hive/gossip.rs
+++ b/src/hive/gossip.rs
@@ -35,6 +35,7 @@ pub struct GossipEngine {
     knowledge_ttl_days: u32,
     local_peer_id: String,
     sharing_filter: super::SharingFilter,
+    share_mode: super::exposure::ShareMode,
 }
 
 impl GossipEngine {
@@ -46,12 +47,18 @@ impl GossipEngine {
             knowledge_ttl_days,
             local_peer_id: local_peer_id.to_string(),
             sharing_filter: super::SharingFilter::default(),
+            share_mode: super::exposure::ShareMode::Auto,
         }
     }
 
     /// Set the user's sharing filter (from HiveConfig).
     pub fn set_sharing_filter(&mut self, filter: super::SharingFilter) {
         self.sharing_filter = filter;
+    }
+
+    /// Set the share mode (auto = expose by default, manual = hide by default).
+    pub fn set_share_mode(&mut self, mode: super::exposure::ShareMode) {
+        self.share_mode = mode;
     }
 
     /// Create a fresh engine with no persisted sync state (for testing).
@@ -63,6 +70,7 @@ impl GossipEngine {
             knowledge_ttl_days,
             local_peer_id: local_peer_id.to_string(),
             sharing_filter: super::SharingFilter::default(),
+            share_mode: super::exposure::ShareMode::Auto,
         }
     }
 
@@ -81,6 +89,8 @@ impl GossipEngine {
         let ttl_secs = self.knowledge_ttl_days as u64 * 86400;
         let identity = self.local_peer_id.clone();
         let filter = self.sharing_filter.clone();
+        let exposure = super::exposure::ExposureStore::load();
+        let share_mode = self.share_mode;
 
         for peer in connected_peers {
             let peer_id = peer.0.clone();
@@ -101,6 +111,7 @@ impl GossipEngine {
                     !sync_state.units_sent.contains(&u.id)
                         && u.source_peer != peer_id // don't echo back
                         && is_propagatable_static(u, max_prop, ttl_secs, &filter)
+                        && is_exposed_for_peer(u, &identity, &exposure, share_mode)
                 })
                 .collect();
 
@@ -191,12 +202,21 @@ impl GossipEngine {
             .collect()
     }
 
-    /// Handle an incoming KnowledgeSnapshot.
-    pub fn handle_snapshot(&mut self, store: &mut HiveStore, msg: &RelayMessage) -> MergeStats {
+    /// Handle an incoming KnowledgeSnapshot. Returns merge stats and the units
+    /// that were merged (so callers can run auto-accept on artifacts).
+    pub fn handle_snapshot(
+        &mut self,
+        store: &mut HiveStore,
+        msg: &RelayMessage,
+    ) -> (MergeStats, Vec<KnowledgeUnit>) {
         let units = parse_units_from_payload(msg);
         let stats = merger::merge_batch(store, &units, &self.local_peer_id);
+        let merged: Vec<KnowledgeUnit> = units
+            .into_iter()
+            .filter(|u| store.get(&u.id).is_some())
+            .collect();
         let _ = store.save();
-        stats
+        (stats, merged)
     }
 
     /// Build a KnowledgeRequest message for requesting a snapshot from a peer.
@@ -289,6 +309,21 @@ impl GossipEngine {
     pub fn all_sync_states(&self) -> &HashMap<String, PeerSyncState> {
         &self.sync_states
     }
+}
+
+/// True if this unit is allowed to leave the local node, given the user's
+/// outbound exposure choices. Only locally-originated units consult the
+/// exposure store; peer-originated units flow through (relay role).
+pub fn is_exposed_for_peer(
+    unit: &KnowledgeUnit,
+    local_peer_id: &str,
+    exposure: &super::exposure::ExposureStore,
+    mode: super::exposure::ShareMode,
+) -> bool {
+    if unit.source_peer != local_peer_id {
+        return true;
+    }
+    exposure.is_exposed(&unit.id, mode)
 }
 
 /// Check propagation eligibility without borrowing self.
@@ -455,6 +490,44 @@ mod tests {
     }
 
     #[test]
+    fn is_exposed_local_units_respect_mode() {
+        let local_unit = make_unit("ku_local", "Bash", "local");
+        let peer_unit = make_unit("ku_peer", "Bash", "peer-a");
+        let exposure = crate::hive::exposure::ExposureStore::default();
+
+        // Auto mode: local units exposed by default; peer units always exposed
+        assert!(is_exposed_for_peer(
+            &local_unit,
+            "local",
+            &exposure,
+            crate::hive::exposure::ShareMode::Auto
+        ));
+        assert!(is_exposed_for_peer(
+            &peer_unit,
+            "local",
+            &exposure,
+            crate::hive::exposure::ShareMode::Manual
+        ));
+
+        // Manual mode: local unit hidden until explicitly exposed
+        assert!(!is_exposed_for_peer(
+            &local_unit,
+            "local",
+            &exposure,
+            crate::hive::exposure::ShareMode::Manual
+        ));
+
+        let mut exposure_explicit = exposure;
+        exposure_explicit.set("ku_local", crate::hive::exposure::ExposureState::Expose);
+        assert!(is_exposed_for_peer(
+            &local_unit,
+            "local",
+            &exposure_explicit,
+            crate::hive::exposure::ShareMode::Manual
+        ));
+    }
+
+    #[test]
     fn dont_echo_back_to_source() {
         let mut store = empty_store();
         // Unit originated from peer-a
@@ -519,8 +592,9 @@ mod tests {
         let units = vec![make_unit("ku_1", "Bash", "peer-a")];
         let msg = build_snapshot_message(&units, "peer-a", 1, 1);
 
-        let stats = engine.handle_snapshot(&mut store, &msg);
+        let (stats, merged) = engine.handle_snapshot(&mut store, &msg);
         assert_eq!(stats.accepted, 1);
+        assert_eq!(merged.len(), 1);
         assert_eq!(store.len(), 1);
     }
 

--- a/src/hive/mod.rs
+++ b/src/hive/mod.rs
@@ -1,8 +1,10 @@
 #![allow(dead_code)]
 
+pub mod accept;
 pub mod archive;
 pub mod cli;
 pub mod distiller;
+pub mod exposure;
 #[cfg(feature = "relay")]
 pub mod gossip;
 pub mod injection;
@@ -363,6 +365,58 @@ pub fn epoch_secs() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// On/off override (mirrors brain's gate-mode pattern)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Path to the hive mode override file (`~/.claudectl/hive/mode`).
+pub fn mode_path() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    std::path::PathBuf::from(home)
+        .join(".claudectl")
+        .join("hive")
+        .join("mode")
+}
+
+/// Read the mode override. Returns `Some("on")`, `Some("off")`, or `None` when
+/// the file is absent (i.e., fall back to config).
+pub fn read_mode_override() -> Option<String> {
+    let path = mode_path();
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let trimmed = raw.trim().to_lowercase();
+    if trimmed == "on" || trimmed == "off" {
+        Some(trimmed)
+    } else {
+        None
+    }
+}
+
+/// Set the mode override. Pass `"on"` or `"off"` to force; `"clear"` removes the
+/// override and falls back to the config flag.
+pub fn write_mode_override(mode: &str) -> std::io::Result<()> {
+    let path = mode_path();
+    if mode == "clear" {
+        if path.exists() {
+            std::fs::remove_file(&path)?;
+        }
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, mode)
+}
+
+/// True if the hive should be active. The mode file (when present) overrides
+/// the config flag. When both are absent, hive is inactive.
+pub fn is_active(cfg: Option<&crate::config::HiveConfig>) -> bool {
+    match read_mode_override().as_deref() {
+        Some("on") => true,
+        Some("off") => false,
+        _ => cfg.map(|c| c.enabled).unwrap_or(false),
+    }
 }
 
 /// Local identity for hive knowledge (used when relay feature is not enabled).

--- a/src/relay/cli.rs
+++ b/src/relay/cli.rs
@@ -212,7 +212,7 @@ fn cmd_serve(port: u16, http_port: Option<u16>, auth_token: Option<&str>) -> io:
     // Initialize hive gossip engine (only when hive feature is enabled)
     #[cfg(feature = "hive")]
     let (mut hive_store, mut gossip, broadcast_rx) = {
-        let hive_enabled = hive_cfg.enabled;
+        let hive_enabled = crate::hive::is_active(Some(&hive_cfg));
         let store = hive_enabled.then(crate::hive::store::HiveStore::load);
         let gossip_engine = hive_enabled.then(|| {
             let mut engine = crate::hive::gossip::GossipEngine::new(
@@ -221,6 +221,9 @@ fn cmd_serve(port: u16, http_port: Option<u16>, auth_token: Option<&str>) -> io:
                 hive_cfg.knowledge_ttl_days,
             );
             engine.set_sharing_filter(crate::hive::SharingFilter::from_config(&hive_cfg));
+            if let Some(mode) = crate::hive::exposure::ShareMode::parse(&hive_cfg.share_mode) {
+                engine.set_share_mode(mode);
+            }
             engine
         });
         let rx = if hive_enabled {
@@ -318,6 +321,13 @@ fn cmd_serve(port: u16, http_port: Option<u16>, auth_token: Option<&str>) -> io:
                                 stats.accepted,
                                 stats.rejected
                             );
+                            let installed = crate::hive::cli::auto_accept_units(&accepted, None);
+                            if installed > 0 {
+                                println!(
+                                    "[{}] Auto-installed {installed} artifact(s)",
+                                    crate::logger::timestamp_now()
+                                );
+                            }
                             if !accepted.is_empty() {
                                 let connected = reg.connected_peers();
                                 let prop_msgs = gossip.propagate(&accepted, &from_peer, &connected);
@@ -343,13 +353,20 @@ fn cmd_serve(port: u16, http_port: Option<u16>, auth_token: Option<&str>) -> io:
                         if let (Some(gossip), Some(hive_store)) =
                             (gossip.as_mut(), hive_store.as_mut())
                         {
-                            let stats = gossip.handle_snapshot(hive_store, &msg);
+                            let (stats, merged) = gossip.handle_snapshot(hive_store, &msg);
                             println!(
                                 "[{}] KnowledgeSnapshot from {}: {} accepted",
                                 crate::logger::timestamp_now(),
                                 from_peer,
                                 stats.accepted
                             );
+                            let installed = crate::hive::cli::auto_accept_units(&merged, None);
+                            if installed > 0 {
+                                println!(
+                                    "[{}] Auto-installed {installed} artifact(s)",
+                                    crate::logger::timestamp_now()
+                                );
+                            }
                         }
                     }
                     _ => {


### PR DESCRIPTION
## Summary

Three layers of user control over the hive without editing TOML:

- **On/off toggle** — `claudectl hive on|off` writes `~/.claudectl/hive/mode` (mirrors the brain gate-mode pattern). Brain injection, distillation export, and relay startup all consult `hive::is_active()`, so flipping the override stops both broadcast and inbound gossip. Local store is preserved when off.
- **Pre-flight outbound curation** — new `[hive].share_mode = \"auto\"|\"manual\"` config + per-unit expose/hide tracked in `~/.claudectl/hive/exposure.json`. New commands: `hive preview` (Ready/Hidden/Blocked partition), `hive expose <id|--all>`, `hive hide <id|--all>`. Locally-originated units gate through the exposure store; peer-relayed knowledge still passes through.
- **Inbound accept controls** — symmetric. `hive accept <id>` installs and records to `~/.claudectl/hive/installed.json`. `hive accept-mode manual|trusted|all` controls auto-install on gossip receipt. Skills/commands install per trust gate; hooks always require manual review. `hive pending` lists unaccepted artifacts.

## What changed

- `src/hive/mod.rs` — `mode_path`, `read_mode_override`, `write_mode_override`, `is_active`
- `src/hive/exposure.rs` (new) — `ShareMode`, `ExposureStore` (JSON-backed)
- `src/hive/accept.rs` (new) — `AcceptMode`, `InstalledTracker`
- `src/hive/cli.rs` — new subcommands (`On`, `Off`, `Preview`, `Expose`, `Hide`, `Accept`, `AcceptMode`, `Pending`); `cmd_install` refactored around shared `write_artifact_files` helper; `auto_accept_units` exported for the relay loop
- `src/hive/gossip.rs` — gossip filter consults exposure store; `handle_snapshot` now returns merged units so callers can auto-accept
- `src/relay/cli.rs` — relay startup uses `is_active`; `KnowledgeSync`/`KnowledgeSnapshot` handlers run `auto_accept_units` post-merge
- `src/brain/{engine,decisions}.rs` — gate sites switch from `cfg.hive.filter(|h| h.enabled)` to `hive::is_active(...)`
- `src/config.rs` — adds `share_mode` to `HiveConfig` (default `\"auto\"`, preserves existing behavior)

## Test plan

- [x] \`cargo build\` (default + \`--features hive,relay\`) clean
- [x] \`cargo clippy --features hive,relay --all-targets -- -D warnings\` clean
- [x] \`cargo test --features hive,relay\` — 1140 tests pass (added: exposure unit tests, accept tracker roundtrip, gossip exposure filter)
- [x] CLI smoke tests against a temp \`HOME\`: \`hive on/off/status\`, \`hive preview\`, \`hive accept-mode\` (read/set/invalid), \`hive pending\`, \`hive --help\`
- [ ] Manual: two peers connected, flip share/accept modes, verify gossip respects exposure and auto-install fires only when trust gate passes
- [ ] Manual: confirm \`hive off\` halts brain prompt injection and outbound gossip without touching the local store

🤖 Generated with [Claude Code](https://claude.com/claude-code)