### PR TITLE
chore: ignore the entire outputs/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ social/
 .claude/worktrees/
 docs/reddit*
 site/
-outputs/reddit-outreach-20260421/
+outputs/
 gws-credentials.json


### PR DESCRIPTION
## Summary

Broadens \`.gitignore\` to ignore all of \`outputs/\` instead of the dated subfolder \`outputs/reddit-outreach-20260421/\`. Future social-tracking and generated artifacts won't need a per-folder line each time.

## Test plan

- [x] \`git status\` clean on a working tree containing \`outputs/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)