### PR TITLE
feat: hive baselining + variant clusters (#220, #221)

### DIFF
--- a/claude-plugin/hooks/hooks.json
+++ b/claude-plugin/hooks/hooks.json
@@ -10,5 +10,17 @@
         }
       ]
     }
+  ],
+  "PostToolUse": [
+    {
+      "matcher": "Bash|Write|Edit|NotebookEdit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/outcome-record.sh",
+          "timeout": 5
+        }
+      ]
+    }
   ]
 }

--- a/claude-plugin/hooks/scripts/outcome-record.sh
+++ b/claude-plugin/hooks/scripts/outcome-record.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# claudectl outcome-record: PostToolUse hook that captures tool-call outcomes
+# (exit code, stderr tail, session metadata) and writes them to the pending
+# outcomes spool. The brain reaper later attributes each pending outcome to
+# the matching decision and uses it for #220 baselining.
+#
+# Receives the Claude Code PostToolUse payload on stdin, e.g.:
+#   {
+#     "session_id": "...",
+#     "tool_use_id": "...",
+#     "tool_name": "Bash",
+#     "tool_input": {"command": "cargo test"},
+#     "tool_response": {"interrupted": false, "stdout": "...", "stderr": "..."}
+#   }
+#
+# Always exits 0 — never block Claude Code.
+
+set -u  # do not set -e: we tolerate missing fields
+
+if ! command -v claudectl >/dev/null 2>&1; then
+    exit 0
+fi
+
+# Respect brain gate mode; "off" disables outcome capture too so the user gets
+# a single switch.
+GATE_MODE_FILE="$HOME/.claudectl/brain/gate-mode"
+GATE_MODE="on"
+if [ -f "$GATE_MODE_FILE" ]; then
+    GATE_MODE=$(tr -d '[:space:]' < "$GATE_MODE_FILE" 2>/dev/null || echo "on")
+fi
+if [ "$GATE_MODE" = "off" ]; then
+    exit 0
+fi
+
+INPUT=$(cat)
+if [ -z "$INPUT" ]; then
+    exit 0
+fi
+
+# ---- Extract fields with tolerant sed parsing ----------------------------
+# Multi-byte / nested JSON values are best-effort only; the goal is a useful
+# fingerprint, not a perfect parser. Failures fall through silently.
+
+extract() {
+    # $1 = key
+    echo "$INPUT" | sed -n 's/.*"'"$1"'" *: *"\([^"]*\)".*/\1/p' | head -n 1
+}
+
+TOOL_NAME=$(extract "tool_name")
+SESSION_ID=$(extract "session_id")
+TOOL_USE_ID=$(extract "tool_use_id")
+
+# Tool-specific input summary (mirrors brain-gate.sh).
+COMMAND=""
+case "$TOOL_NAME" in
+    Bash)
+        COMMAND=$(echo "$INPUT" | sed -n 's/.*"command" *: *"\([^"]*\)".*/\1/p' | head -n 1)
+        ;;
+    Write|Edit|NotebookEdit)
+        COMMAND=$(echo "$INPUT" | sed -n 's/.*"file_path" *: *"\([^"]*\)".*/\1/p' | head -n 1)
+        ;;
+    *)
+        # No reliable summary for other tools; leave blank so reaper falls
+        # back to (tool, project) matching.
+        COMMAND=""
+        ;;
+esac
+
+# Inferred exit code: prefer explicit numeric exit_code, else infer from
+# `interrupted` / presence of an error string.
+EXIT_CODE=$(echo "$INPUT" | sed -n 's/.*"exit_code" *: *\([0-9-]\+\).*/\1/p' | head -n 1)
+if [ -z "$EXIT_CODE" ]; then
+    INTERRUPTED=$(echo "$INPUT" | sed -n 's/.*"interrupted" *: *\(true\|false\).*/\1/p' | head -n 1)
+    HAS_ERROR=$(echo "$INPUT" | sed -n 's/.*"is_error" *: *\(true\|false\).*/\1/p' | head -n 1)
+    if [ "$INTERRUPTED" = "true" ] || [ "$HAS_ERROR" = "true" ]; then
+        EXIT_CODE="1"
+    else
+        EXIT_CODE="0"
+    fi
+fi
+
+STDERR_TAIL=$(echo "$INPUT" | sed -n 's/.*"stderr" *: *"\([^"]*\)".*/\1/p' | head -n 1)
+PROJECT=$(basename "${PWD:-unknown}")
+TS=$(date +%s)
+
+# ---- Build PendingOutcome JSON and pipe to claudectl ---------------------
+# Shell-escape strings for JSON. We trust the upstream hook payload not to
+# contain attacker-controlled binary data; any bad escapes fall through with
+# claudectl --record-outcome rejecting the JSON and exiting non-zero, which
+# we ignore.
+
+json_escape() {
+    # Escape backslashes and double quotes. Newlines collapsed to spaces.
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n\r\t' '   '
+}
+
+ESCAPED_TOOL=$(json_escape "${TOOL_NAME:-unknown}")
+ESCAPED_PROJECT=$(json_escape "$PROJECT")
+ESCAPED_COMMAND=$(json_escape "$COMMAND")
+ESCAPED_SESSION=$(json_escape "$SESSION_ID")
+ESCAPED_TUID=$(json_escape "$TOOL_USE_ID")
+ESCAPED_STDERR=$(json_escape "$STDERR_TAIL")
+
+PAYLOAD=$(cat <<EOF
+{
+  "tool": "$ESCAPED_TOOL",
+  "command": "$ESCAPED_COMMAND",
+  "project": "$ESCAPED_PROJECT",
+  "session_id": "$ESCAPED_SESSION",
+  "tool_use_id": "$ESCAPED_TUID",
+  "exit_code": $EXIT_CODE,
+  "stderr_tail": "$ESCAPED_STDERR",
+  "ts": $TS
+}
+EOF
+)
+
+echo "$PAYLOAD" | claudectl --record-outcome --json >/dev/null 2>&1 || true
+exit 0

--- a/src/brain/decisions.rs
+++ b/src/brain/decisions.rs
@@ -34,6 +34,8 @@ pub(super) use super::preferences::{save_preferences, save_project_preferences};
 static DECISION_COUNT: AtomicU32 = AtomicU32::new(0);
 /// Guard to prevent concurrent distillation threads.
 static DISTILLING: AtomicBool = AtomicBool::new(false);
+/// Monotonic counter for decision_id uniqueness within a process.
+static DECISION_ID_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// How often to re-distill preferences (every N decisions).
 const DISTILL_INTERVAL: u32 = 10;
@@ -94,6 +96,20 @@ pub struct DecisionRecord {
     pub resolved_at: Option<u64>,
     /// Why the user overrode a brain denial (if applicable).
     pub override_reason: Option<String>,
+    /// Stable id for outcome attribution (#220 baselining). None on records
+    /// written before the field existed; outcomes for those can't be joined.
+    pub decision_id: Option<String>,
+}
+
+/// Generate a unique decision id.
+pub fn gen_decision_id() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let pid = std::process::id();
+    let seq = DECISION_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("dec_{secs}_{pid}_{seq}")
 }
 
 /// Outcome of a decision, backfilled during distillation by looking at
@@ -299,6 +315,7 @@ pub fn log_decision(
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
+    let decision_id = gen_decision_id();
     let mut record = serde_json::json!({
         "ts": timestamp_now(),
         "pid": pid,
@@ -313,6 +330,7 @@ pub fn log_decision(
         "suggested_at": suggestion.suggested_at,
         "resolved_at": resolved_at,
         "override_reason": override_reason,
+        "decision_id": decision_id,
     });
     if let Some(s) = session {
         record["context"] = snapshot_context(s);
@@ -348,6 +366,7 @@ pub fn log_observation(
     observed_action: &str, // "user_approve", "user_input", "rule_approve", "rule_deny", etc.
     session: Option<&crate::session::ClaudeSession>,
 ) {
+    let decision_id = gen_decision_id();
     let mut record = serde_json::json!({
         "ts": timestamp_now(),
         "pid": pid,
@@ -358,6 +377,7 @@ pub fn log_observation(
         "brain_confidence": 0.0,
         "brain_reasoning": "",
         "user_action": observed_action,
+        "decision_id": decision_id,
     });
     if let Some(s) = session {
         record["context"] = snapshot_context(s);
@@ -639,6 +659,10 @@ pub fn read_all_decisions() -> Vec<DecisionRecord> {
                     .get("override_reason")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string()),
+                decision_id: json
+                    .get("decision_id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
             })
         })
         .collect()
@@ -680,6 +704,7 @@ mod tests {
             suggested_at: None,
             resolved_at: None,
             override_reason: None,
+            decision_id: None,
         }
     }
 
@@ -735,6 +760,7 @@ mod tests {
             suggested_at: None,
             resolved_at: None,
             override_reason: None,
+            decision_id: None,
         }
     }
 

--- a/src/brain/detectors.rs
+++ b/src/brain/detectors.rs
@@ -471,6 +471,7 @@ mod tests {
             suggested_at: None,
             resolved_at: None,
             override_reason: None,
+            decision_id: None,
         }
     }
 

--- a/src/brain/insights.rs
+++ b/src/brain/insights.rs
@@ -452,6 +452,7 @@ mod tests {
             suggested_at: None,
             resolved_at: None,
             override_reason: None,
+            decision_id: None,
         }
     }
 

--- a/src/brain/metrics.rs
+++ b/src/brain/metrics.rs
@@ -1917,6 +1917,7 @@ mod tests {
             suggested_at: None,
             resolved_at: None,
             override_reason: None,
+            decision_id: None,
         }
     }
 

--- a/src/brain/mod.rs
+++ b/src/brain/mod.rs
@@ -10,6 +10,7 @@ pub mod evals;
 pub mod insights;
 pub mod mailbox;
 pub mod metrics;
+pub mod outcomes;
 pub mod pref_store;
 pub mod preferences;
 pub mod prompts;

--- a/src/brain/outcomes.rs
+++ b/src/brain/outcomes.rs
@@ -1,0 +1,433 @@
+#![allow(dead_code)]
+
+//! Outcome capture for brain decisions (#220 baselining v1).
+//!
+//! A `PostToolUse` hook in Claude Code writes a "pending outcome" file each
+//! time a tool finishes. The reaper periodically attributes each pending
+//! outcome to the most recent matching decision in `decisions.jsonl` and
+//! writes the resolved outcome to `outcomes/<decision_id>.json`. Distillation
+//! reads decisions and outcomes together to build per-approach success
+//! statistics that feed into the hive as `ApproachOutcome` knowledge units.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+use super::decisions::{decisions_dir, read_all_decisions};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Constants
+// ────────────────────────────────────────────────────────────────────────────
+
+/// How recent a decision must be (seconds) to be a candidate for outcome
+/// attribution. Keeps fuzzy matching from binding outcomes to ancient
+/// decisions when many sessions reuse the same command.
+const ATTRIBUTION_WINDOW_SECS: u64 = 600;
+
+/// How long an unattributed pending outcome lives before being marked orphaned.
+const ORPHAN_AFTER_SECS: u64 = 86_400;
+
+/// Cap on stderr_tail bytes stored — protects against runaway log capture.
+pub const MAX_STDERR_TAIL_BYTES: usize = 2_048;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Types
+// ────────────────────────────────────────────────────────────────────────────
+
+/// What the PostToolUse hook saw, written before any decision attribution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingOutcome {
+    /// Tool name (e.g., "Bash", "Edit").
+    pub tool: String,
+    /// Command or input summary captured by the hook.
+    #[serde(default)]
+    pub command: Option<String>,
+    /// Project slug (basename of cwd at hook time).
+    pub project: String,
+    /// Claude Code session id, if the hook payload carried one.
+    #[serde(default)]
+    pub session_id: Option<String>,
+    /// Claude Code tool_use_id, if available — used for stricter joining later.
+    #[serde(default)]
+    pub tool_use_id: Option<String>,
+    /// Tool exit code (0 = success). None when the hook can't infer one.
+    #[serde(default)]
+    pub exit_code: Option<i32>,
+    /// Wall-clock duration of the tool call in milliseconds.
+    #[serde(default)]
+    pub duration_ms: Option<u64>,
+    /// Last MAX_STDERR_TAIL_BYTES of stderr or tool error output.
+    #[serde(default)]
+    pub stderr_tail: Option<String>,
+    /// Epoch seconds when the outcome was captured.
+    pub ts: u64,
+}
+
+/// Resolved outcome: a `PendingOutcome` attributed to a specific decision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolvedOutcome {
+    pub decision_id: String,
+    pub tool: String,
+    #[serde(default)]
+    pub command: Option<String>,
+    pub project: String,
+    #[serde(default)]
+    pub exit_code: Option<i32>,
+    #[serde(default)]
+    pub duration_ms: Option<u64>,
+    #[serde(default)]
+    pub stderr_tail: Option<String>,
+    pub ts: u64,
+}
+
+/// Stats returned by `reap()`.
+#[derive(Debug, Default, Clone)]
+pub struct ReapStats {
+    pub scanned: u32,
+    pub attributed: u32,
+    pub orphaned: u32,
+    pub still_pending: u32,
+    pub errors: u32,
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Path helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Directory where pending PostToolUse outcomes accumulate.
+pub fn pending_dir() -> PathBuf {
+    decisions_dir().join("pending-outcomes")
+}
+
+/// Directory where attributed outcomes live, keyed by `<decision_id>.json`.
+pub fn outcomes_dir() -> PathBuf {
+    decisions_dir().join("outcomes")
+}
+
+/// Directory where pending files that failed attribution after `ORPHAN_AFTER_SECS`
+/// are quarantined for inspection.
+pub fn orphaned_dir() -> PathBuf {
+    decisions_dir().join("outcomes-orphaned")
+}
+
+fn ensure_dir(path: &PathBuf) -> std::io::Result<()> {
+    fs::create_dir_all(path)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// ID generation
+// ────────────────────────────────────────────────────────────────────────────
+
+static OUTCOME_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Generate a unique pending outcome filename stem (no extension).
+fn gen_pending_id() -> String {
+    let epoch = epoch_secs();
+    let seq = OUTCOME_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    format!("po_{epoch}_{pid}_{seq}")
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Write / read
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Truncate stderr to MAX_STDERR_TAIL_BYTES from the tail.
+pub fn truncate_stderr(s: &str) -> String {
+    if s.len() <= MAX_STDERR_TAIL_BYTES {
+        return s.to_string();
+    }
+    // Take the trailing slice on a char boundary.
+    let start = s.len() - MAX_STDERR_TAIL_BYTES;
+    let safe_start = (start..s.len())
+        .find(|i| s.is_char_boundary(*i))
+        .unwrap_or(s.len());
+    s[safe_start..].to_string()
+}
+
+/// Persist a pending outcome to `pending-outcomes/<id>.json`.
+pub fn write_pending(out: &PendingOutcome) -> std::io::Result<PathBuf> {
+    let dir = pending_dir();
+    ensure_dir(&dir)?;
+    let path = dir.join(format!("{}.json", gen_pending_id()));
+    let json = serde_json::to_string(out).map_err(std::io::Error::other)?;
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&path)?;
+    file.write_all(json.as_bytes())?;
+    Ok(path)
+}
+
+/// Read all pending outcomes (path + parsed body).
+pub fn list_pending() -> Vec<(PathBuf, PendingOutcome)> {
+    let dir = pending_dir();
+    let mut out = Vec::new();
+    let entries = match fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        if let Ok(p) = serde_json::from_str::<PendingOutcome>(&content) {
+            out.push((path, p));
+        }
+    }
+    out
+}
+
+/// Load all attributed outcomes keyed by `decision_id`.
+pub fn load_resolved_map() -> std::collections::HashMap<String, ResolvedOutcome> {
+    let mut map = std::collections::HashMap::new();
+    let dir = outcomes_dir();
+    let entries = match fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return map,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        if let Ok(r) = serde_json::from_str::<ResolvedOutcome>(&content) {
+            map.insert(r.decision_id.clone(), r);
+        }
+    }
+    map
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Reaper
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Normalise a command string for fuzzy matching against decision records.
+/// Strips leading/trailing whitespace and collapses internal runs.
+fn normalize_command(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Parse a decision timestamp (currently stored as `"<epoch_secs>"`).
+fn parse_ts(s: &str) -> Option<u64> {
+    s.trim_matches('"').parse::<u64>().ok()
+}
+
+/// Walk pending outcomes, attribute each to a matching decision, and write
+/// resolved outcomes. Pending files older than `ORPHAN_AFTER_SECS` are moved
+/// to `orphaned_dir()` for inspection.
+///
+/// Attribution rule: the most recent decision in `decisions.jsonl` such that
+///   - same tool
+///   - normalized command equals the outcome's normalized command (when both present)
+///   - same project (case-insensitive)
+///   - decision timestamp <= outcome timestamp, within ATTRIBUTION_WINDOW_SECS
+///   - decision has a `decision_id`
+///   - no resolved outcome exists yet for that `decision_id`
+pub fn reap() -> ReapStats {
+    let mut stats = ReapStats::default();
+    let pending = list_pending();
+    if pending.is_empty() {
+        return stats;
+    }
+
+    let _ = ensure_dir(&outcomes_dir());
+    let _ = ensure_dir(&orphaned_dir());
+
+    let decisions = read_all_decisions();
+    let resolved = load_resolved_map();
+    let now = epoch_secs();
+    // Track decisions claimed within this reap pass so a single decision
+    // doesn't get attributed to two pending outcomes when we run before
+    // the resolved map is reloaded.
+    let mut claimed: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for (path, p) in pending {
+        stats.scanned += 1;
+
+        // Try attribution
+        let p_cmd_norm = p.command.as_deref().map(normalize_command);
+        let mut best: Option<(usize, u64)> = None; // (index, ts) — pick most recent
+
+        for (i, d) in decisions.iter().enumerate() {
+            let Some(decision_id) = d.decision_id.as_deref() else {
+                continue;
+            };
+            if resolved.contains_key(decision_id) || claimed.contains(decision_id) {
+                continue;
+            }
+            let Some(d_tool) = d.tool.as_deref() else {
+                continue;
+            };
+            if d_tool != p.tool {
+                continue;
+            }
+            if !d.project.eq_ignore_ascii_case(&p.project) {
+                continue;
+            }
+            // Command match (only enforced if both sides present)
+            if let (Some(pc), Some(dc)) = (&p_cmd_norm, &d.command) {
+                if normalize_command(dc) != *pc {
+                    continue;
+                }
+            }
+            let Some(d_ts) = parse_ts(&d.timestamp) else {
+                continue;
+            };
+            if d_ts > p.ts {
+                continue; // decision must precede outcome
+            }
+            if p.ts.saturating_sub(d_ts) > ATTRIBUTION_WINDOW_SECS {
+                continue;
+            }
+            match best {
+                None => best = Some((i, d_ts)),
+                Some((_, prev_ts)) if d_ts > prev_ts => best = Some((i, d_ts)),
+                _ => {}
+            }
+        }
+
+        if let Some((idx, _)) = best {
+            let d = &decisions[idx];
+            let decision_id = d.decision_id.clone().unwrap();
+            let resolved = ResolvedOutcome {
+                decision_id: decision_id.clone(),
+                tool: p.tool.clone(),
+                command: p.command.clone(),
+                project: p.project.clone(),
+                exit_code: p.exit_code,
+                duration_ms: p.duration_ms,
+                stderr_tail: p.stderr_tail.clone(),
+                ts: p.ts,
+            };
+            let dest = outcomes_dir().join(format!("{decision_id}.json"));
+            match fs::write(&dest, serde_json::to_string(&resolved).unwrap_or_default()) {
+                Ok(_) => {
+                    claimed.insert(decision_id.clone());
+                    let _ = fs::remove_file(&path);
+                    stats.attributed += 1;
+                }
+                Err(_) => stats.errors += 1,
+            }
+        } else if now.saturating_sub(p.ts) > ORPHAN_AFTER_SECS {
+            // Move to orphaned for inspection.
+            let dest = orphaned_dir().join(
+                path.file_name()
+                    .map(|n| n.to_owned())
+                    .unwrap_or_else(|| std::ffi::OsString::from("orphan.json")),
+            );
+            if fs::rename(&path, &dest).is_ok() {
+                stats.orphaned += 1;
+            } else {
+                stats.errors += 1;
+            }
+        } else {
+            stats.still_pending += 1;
+        }
+    }
+
+    stats
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_stderr_short() {
+        assert_eq!(truncate_stderr("hello"), "hello");
+    }
+
+    #[test]
+    fn truncate_stderr_long_keeps_tail() {
+        let s = "a".repeat(MAX_STDERR_TAIL_BYTES * 2);
+        let t = truncate_stderr(&s);
+        assert_eq!(t.len(), MAX_STDERR_TAIL_BYTES);
+        assert!(t.chars().all(|c| c == 'a'));
+    }
+
+    #[test]
+    fn truncate_stderr_respects_char_boundary() {
+        // "é" is two bytes in UTF-8. Construct a string whose tail boundary
+        // would split a multibyte char if we naively sliced.
+        let mut s = String::new();
+        for _ in 0..MAX_STDERR_TAIL_BYTES {
+            s.push('é');
+        }
+        let t = truncate_stderr(&s);
+        // Must be valid UTF-8 (the assertion is implicit in String — we just
+        // verify it didn't panic and produced something <= cap bytes).
+        assert!(t.len() <= MAX_STDERR_TAIL_BYTES);
+    }
+
+    #[test]
+    fn normalize_command_collapses_whitespace() {
+        assert_eq!(normalize_command("  cargo   test  "), "cargo test");
+        assert_eq!(normalize_command("cargo\ttest"), "cargo test");
+    }
+
+    #[test]
+    fn parse_ts_handles_quoted_and_plain() {
+        assert_eq!(parse_ts("123"), Some(123));
+        assert_eq!(parse_ts("\"123\""), Some(123));
+        assert_eq!(parse_ts("not a number"), None);
+    }
+
+    #[test]
+    fn pending_outcome_round_trip_json() {
+        let p = PendingOutcome {
+            tool: "Bash".into(),
+            command: Some("cargo test".into()),
+            project: "claudectl".into(),
+            session_id: Some("sess-1".into()),
+            tool_use_id: Some("tu-1".into()),
+            exit_code: Some(0),
+            duration_ms: Some(1234),
+            stderr_tail: None,
+            ts: 100,
+        };
+        let s = serde_json::to_string(&p).unwrap();
+        let back: PendingOutcome = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.tool, "Bash");
+        assert_eq!(back.command.as_deref(), Some("cargo test"));
+        assert_eq!(back.exit_code, Some(0));
+    }
+
+    #[test]
+    fn pending_outcome_parses_minimal_json() {
+        // Hook scripts may omit optional fields.
+        let s = r#"{"tool":"Bash","project":"p","ts":1}"#;
+        let p: PendingOutcome = serde_json::from_str(s).unwrap();
+        assert_eq!(p.tool, "Bash");
+        assert!(p.command.is_none());
+        assert!(p.exit_code.is_none());
+    }
+
+    #[test]
+    fn gen_pending_id_unique_within_process() {
+        let a = gen_pending_id();
+        let b = gen_pending_id();
+        assert_ne!(a, b);
+    }
+}

--- a/src/brain/pref_store.rs
+++ b/src/brain/pref_store.rs
@@ -255,6 +255,7 @@ mod tests {
             suggested_at: None,
             resolved_at: None,
             override_reason: None,
+            decision_id: None,
         }
     }
 

--- a/src/brain/preferences.rs
+++ b/src/brain/preferences.rs
@@ -923,6 +923,7 @@ mod tests {
             suggested_at: None,
             resolved_at: None,
             override_reason: None,
+            decision_id: None,
         }
     }
 
@@ -948,6 +949,7 @@ mod tests {
             suggested_at: None,
             resolved_at: None,
             override_reason: None,
+            decision_id: None,
         }
     }
 
@@ -1008,6 +1010,7 @@ mod tests {
             suggested_at: None,
             resolved_at: None,
             override_reason: None,
+            decision_id: None,
         }
     }
 
@@ -1293,6 +1296,7 @@ mod tests {
                 suggested_at: None,
                 resolved_at: None,
                 override_reason: None,
+                decision_id: None,
             },
             DecisionRecord {
                 timestamp: "2".into(),
@@ -1310,6 +1314,7 @@ mod tests {
                 suggested_at: None,
                 resolved_at: None,
                 override_reason: None,
+                decision_id: None,
             },
         ];
 
@@ -1346,6 +1351,7 @@ mod tests {
                 suggested_at: None,
                 resolved_at: None,
                 override_reason: None,
+                decision_id: None,
             });
         }
         // Then user denies
@@ -1365,6 +1371,7 @@ mod tests {
             suggested_at: None,
             resolved_at: None,
             override_reason: None,
+            decision_id: None,
         });
         // Repeat the streak pattern to reach threshold of 2
         for _ in 0..4 {
@@ -1384,6 +1391,7 @@ mod tests {
                 suggested_at: None,
                 resolved_at: None,
                 override_reason: None,
+                decision_id: None,
             });
         }
         decisions.push(DecisionRecord {
@@ -1402,6 +1410,7 @@ mod tests {
             suggested_at: None,
             resolved_at: None,
             override_reason: None,
+            decision_id: None,
         });
 
         let patterns = detect_temporal_patterns(&decisions);

--- a/src/brain/retrieval.rs
+++ b/src/brain/retrieval.rs
@@ -173,6 +173,7 @@ mod tests {
             suggested_at: None,
             resolved_at: None,
             override_reason: None,
+            decision_id: None,
         }
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1399,7 +1399,7 @@ pub(crate) fn run_brain_outcomes(cli: &Cli) -> io::Result<()> {
         .filter(|o| tool_filter.is_none_or(|t| o.tool == t))
         .filter(|o| project_filter.is_none_or(|p| o.project.eq_ignore_ascii_case(p)))
         .collect();
-    rows.sort_by(|a, b| b.ts.cmp(&a.ts));
+    rows.sort_by_key(|r| std::cmp::Reverse(r.ts));
 
     if let Some(n) = cli.top {
         rows.truncate(n);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1296,6 +1296,284 @@ pub(crate) fn run_insights(cfg: &config::Config, cli: &Cli, arg: &str) -> io::Re
     Ok(())
 }
 
+/// Record a tool-call outcome to the pending-outcomes spool.
+/// Reads PendingOutcome JSON from stdin if present and non-empty;
+/// otherwise builds one from CLI flags (`--tool`, `--exit-code`, …).
+/// Used by the Claude Code PostToolUse hook for #220 baselining.
+pub(crate) fn run_record_outcome(cli: &Cli) -> io::Result<()> {
+    use brain::outcomes::{PendingOutcome, truncate_stderr, write_pending};
+    use std::io::Read;
+
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    // Try stdin first — hook scripts pipe a JSON blob in.
+    let mut stdin_buf = String::new();
+    let stdin_has_data =
+        std::io::stdin().read_to_string(&mut stdin_buf).is_ok() && !stdin_buf.trim().is_empty();
+
+    let outcome = if stdin_has_data {
+        match serde_json::from_str::<PendingOutcome>(&stdin_buf) {
+            Ok(mut p) => {
+                if p.ts == 0 {
+                    p.ts = ts;
+                }
+                if let Some(s) = p.stderr_tail.as_ref() {
+                    p.stderr_tail = Some(truncate_stderr(s));
+                }
+                p
+            }
+            Err(e) => {
+                eprintln!("--record-outcome: invalid JSON on stdin: {e}");
+                std::process::exit(2);
+            }
+        }
+    } else {
+        let tool = cli.tool.clone().unwrap_or_default();
+        if tool.is_empty() {
+            eprintln!("--record-outcome: --tool is required when stdin is empty");
+            std::process::exit(2);
+        }
+        let project = cli.project.clone().unwrap_or_else(|| {
+            std::env::current_dir()
+                .ok()
+                .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+                .unwrap_or_else(|| "unknown".into())
+        });
+        PendingOutcome {
+            tool,
+            command: cli.tool_input.clone().filter(|s| !s.is_empty()),
+            project,
+            session_id: cli.session_id.clone(),
+            tool_use_id: cli.tool_use_id.clone(),
+            exit_code: cli.exit_code,
+            duration_ms: cli.duration_ms,
+            stderr_tail: cli.stderr_tail.as_deref().map(truncate_stderr),
+            ts,
+        }
+    };
+
+    match write_pending(&outcome) {
+        Ok(path) => {
+            if cli.json {
+                let v = serde_json::json!({
+                    "status": "recorded",
+                    "path": path.display().to_string(),
+                });
+                println!("{}", serde_json::to_string(&v).unwrap());
+            }
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("--record-outcome: write failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// List resolved outcomes (joined with their decisions). Filterable by
+/// --tool and --project.
+pub(crate) fn run_brain_outcomes(cli: &Cli) -> io::Result<()> {
+    // Reap first so the freshest data shows up.
+    let _ = brain::outcomes::reap();
+    let resolved = brain::outcomes::load_resolved_map();
+    if resolved.is_empty() {
+        if cli.json {
+            println!("[]");
+        } else {
+            println!(
+                "No attributed outcomes yet. Pending: {}",
+                brain::outcomes::list_pending().len()
+            );
+        }
+        return Ok(());
+    }
+
+    let tool_filter = cli.tool.as_deref();
+    let project_filter = cli.project.as_deref();
+
+    let mut rows: Vec<&brain::outcomes::ResolvedOutcome> = resolved
+        .values()
+        .filter(|o| tool_filter.is_none_or(|t| o.tool == t))
+        .filter(|o| project_filter.is_none_or(|p| o.project.eq_ignore_ascii_case(p)))
+        .collect();
+    rows.sort_by(|a, b| b.ts.cmp(&a.ts));
+
+    if let Some(n) = cli.top {
+        rows.truncate(n);
+    }
+
+    if cli.json {
+        println!(
+            "{}",
+            serde_json::to_string(&rows).unwrap_or_else(|_| "[]".into())
+        );
+    } else {
+        println!(
+            "{:<10} {:<8} {:<10} {:<28} COMMAND",
+            "EXIT", "DURMS", "TOOL", "PROJECT"
+        );
+        for r in rows {
+            let exit = r
+                .exit_code
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "?".into());
+            let dur = r
+                .duration_ms
+                .map(|d| d.to_string())
+                .unwrap_or_else(|| "?".into());
+            let cmd = r.command.as_deref().unwrap_or("");
+            let cmd_short = if cmd.len() > 60 { &cmd[..60] } else { cmd };
+            println!(
+                "{:<10} {:<8} {:<10} {:<28} {}",
+                exit,
+                dur,
+                truncate_col(&r.tool, 10),
+                truncate_col(&r.project, 28),
+                cmd_short
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Rank approaches by outcome data: success_rate * sample_count.
+pub(crate) fn run_brain_baseline(cli: &Cli) -> io::Result<()> {
+    let _ = brain::outcomes::reap();
+    let decisions = brain::decisions::read_all_decisions();
+    let resolved = brain::outcomes::load_resolved_map();
+    let scope = match cli.project.as_deref() {
+        Some(p) => crate::hive::KnowledgeScope::Project(p.to_string()),
+        None => crate::hive::KnowledgeScope::Universal,
+    };
+    let units = crate::hive::distiller::distill_outcomes(
+        &decisions,
+        &resolved,
+        "local",
+        &scope,
+        cli.project.as_deref(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+        // Lower the threshold for the CLI view so users see partial signal.
+        &crate::hive::distiller::ExportThresholds {
+            min_outcome_samples: 1,
+            ..Default::default()
+        },
+    );
+
+    type BaselineRow = (String, f64, u32, Option<f64>, Option<u64>);
+    let mut rows: Vec<BaselineRow> = units
+        .into_iter()
+        .filter_map(|u| {
+            if let crate::hive::KnowledgeContent::ApproachOutcome {
+                approach_ref,
+                success_rate,
+                sample_count,
+                median_cost_usd,
+                median_duration_ms,
+                ..
+            } = u.content
+            {
+                if let Some(t) = cli.tool.as_deref() {
+                    if !approach_ref.contains(&format!(":{t}:")) {
+                        return None;
+                    }
+                }
+                Some((
+                    approach_ref,
+                    success_rate,
+                    sample_count,
+                    median_cost_usd,
+                    median_duration_ms,
+                ))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Rank by success_rate * sample_count, desc.
+    rows.sort_by(|a, b| {
+        let av = a.1 * a.2 as f64;
+        let bv = b.1 * b.2 as f64;
+        bv.partial_cmp(&av).unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    if let Some(n) = cli.top {
+        rows.truncate(n);
+    }
+
+    if cli.json {
+        let arr: Vec<serde_json::Value> = rows
+            .into_iter()
+            .map(|(r, sr, n, c, d)| {
+                serde_json::json!({
+                    "approach_ref": r,
+                    "success_rate": sr,
+                    "sample_count": n,
+                    "median_cost_usd": c,
+                    "median_duration_ms": d,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string(&arr).unwrap());
+    } else if rows.is_empty() {
+        println!("No baseline data yet. Need at least 1 attributed outcome.");
+    } else {
+        println!(
+            "{:<8} {:<6} {:<10} {:<10} APPROACH",
+            "SUCC%", "N", "MED_COST", "MED_MS"
+        );
+        for (r, sr, n, c, d) in rows {
+            let cost = c.map(|x| format!("${x:.4}")).unwrap_or_else(|| "-".into());
+            let dur = d.map(|x| x.to_string()).unwrap_or_else(|| "-".into());
+            println!(
+                "{:<8.0} {:<6} {:<10} {:<10} {}",
+                sr * 100.0,
+                n,
+                cost,
+                dur,
+                r
+            );
+        }
+    }
+    Ok(())
+}
+
+fn truncate_col(s: &str, width: usize) -> String {
+    if s.chars().count() <= width {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(width.saturating_sub(1)).collect();
+        format!("{truncated}…")
+    }
+}
+
+/// Reap pending outcomes and attribute them to decisions.
+pub(crate) fn run_reap_outcomes(cli: &Cli) -> io::Result<()> {
+    let stats = brain::outcomes::reap();
+    if cli.json {
+        let v = serde_json::json!({
+            "scanned": stats.scanned,
+            "attributed": stats.attributed,
+            "orphaned": stats.orphaned,
+            "still_pending": stats.still_pending,
+            "errors": stats.errors,
+        });
+        println!("{}", serde_json::to_string(&v).unwrap());
+    } else {
+        println!(
+            "Outcomes reaped: scanned={} attributed={} orphaned={} still_pending={} errors={}",
+            stats.scanned, stats.attributed, stats.orphaned, stats.still_pending, stats.errors
+        );
+    }
+    Ok(())
+}
+
 /// Standalone brain query: builds a minimal context from CLI args, calls the
 /// local LLM, and prints a JSON decision to stdout. Designed to be called
 /// by Claude Code plugin hooks (PreToolUse) for inline approve/deny.

--- a/src/hive/cli.rs
+++ b/src/hive/cli.rs
@@ -90,6 +90,19 @@ pub enum HiveCommand {
         #[arg(long)]
         show_ignored: bool,
     },
+
+    /// List approach clusters (#221: competing approaches to the same problem).
+    Clusters {
+        /// Filter by problem_key substring
+        #[arg(long)]
+        problem: Option<String>,
+    },
+
+    /// Show one cluster in detail (variants, contributing peers, outcome refs).
+    Cluster {
+        /// problem_key (e.g., "Bash:cargo test")
+        problem_key: String,
+    },
 }
 
 /// Dispatch a hive subcommand.
@@ -120,6 +133,154 @@ pub fn dispatch_command(command: &HiveCommand, json_mode: bool) -> io::Result<()
             content_type,
             show_ignored,
         } => cmd_shared(content_type.as_deref(), *show_ignored, json_mode),
+        HiveCommand::Clusters { problem } => cmd_clusters(problem.as_deref(), json_mode),
+        HiveCommand::Cluster { problem_key } => cmd_cluster_show(problem_key, json_mode),
+    }
+}
+
+/// `claudectl hive clusters [--problem <key>]`
+fn cmd_clusters(problem_filter: Option<&str>, json_mode: bool) -> io::Result<()> {
+    let store = HiveStore::load();
+    let units = store.all_units();
+    let clusters: Vec<&super::KnowledgeUnit> = units
+        .iter()
+        .copied()
+        .filter(|u| matches!(u.content, super::KnowledgeContent::ApproachCluster { .. }))
+        .filter(|u| {
+            let Some(needle) = problem_filter else {
+                return true;
+            };
+            if let super::KnowledgeContent::ApproachCluster { problem_key, .. } = &u.content {
+                problem_key.contains(needle)
+            } else {
+                false
+            }
+        })
+        .collect();
+
+    if json_mode {
+        let arr: Vec<serde_json::Value> = clusters
+            .iter()
+            .map(|u| {
+                if let super::KnowledgeContent::ApproachCluster {
+                    problem_key,
+                    variants,
+                } = &u.content
+                {
+                    serde_json::json!({
+                        "id": u.id,
+                        "problem_key": problem_key,
+                        "variant_count": variants.len(),
+                        "evidence_count": u.evidence_count,
+                        "source_peer": u.source_peer,
+                        "scope": u.scope.to_string(),
+                    })
+                } else {
+                    serde_json::Value::Null
+                }
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&arr).unwrap());
+    } else if clusters.is_empty() {
+        println!("No approach clusters in the hive yet.");
+    } else {
+        println!(
+            "{:<6} {:<8} {:<26} {:<20} PROBLEM",
+            "VRNTS", "EVID", "PEER", "SCOPE"
+        );
+        for u in clusters {
+            if let super::KnowledgeContent::ApproachCluster {
+                problem_key,
+                variants,
+            } = &u.content
+            {
+                println!(
+                    "{:<6} {:<8} {:<26} {:<20} {}",
+                    variants.len(),
+                    u.evidence_count,
+                    truncate_col_cli(&u.source_peer, 26),
+                    truncate_col_cli(&u.scope.to_string(), 20),
+                    problem_key
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `claudectl hive cluster <problem_key>`
+fn cmd_cluster_show(problem_key: &str, json_mode: bool) -> io::Result<()> {
+    let store = HiveStore::load();
+    let units = store.all_units();
+    let cluster = units.iter().find(|u| {
+        if let super::KnowledgeContent::ApproachCluster {
+            problem_key: pk, ..
+        } = &u.content
+        {
+            pk == problem_key
+        } else {
+            false
+        }
+    });
+
+    let Some(unit) = cluster else {
+        if json_mode {
+            println!("null");
+        } else {
+            println!("No cluster with problem_key {problem_key:?}.");
+        }
+        return Ok(());
+    };
+    let super::KnowledgeContent::ApproachCluster {
+        problem_key,
+        variants,
+    } = &unit.content
+    else {
+        unreachable!();
+    };
+
+    if json_mode {
+        let v = serde_json::json!({
+            "id": unit.id,
+            "problem_key": problem_key,
+            "scope": unit.scope.to_string(),
+            "source_peer": unit.source_peer,
+            "evidence_count": unit.evidence_count,
+            "version": unit.version,
+            "variants": variants,
+        });
+        println!("{}", serde_json::to_string_pretty(&v).unwrap());
+    } else {
+        println!("Cluster: {problem_key}");
+        println!("  ID:       {}", unit.id);
+        println!("  Scope:    {}", unit.scope);
+        println!("  Owner:    {}", unit.source_peer);
+        println!("  Version:  {}", unit.version);
+        println!("  Evidence: {}", unit.evidence_count);
+        println!("  Variants:");
+        for (i, v) in variants.iter().enumerate() {
+            let label = (b'A' + i as u8) as char;
+            println!("    ({label}) {} (n={})", v.approach_summary, v.evidence);
+            if !v.conditions.is_empty() {
+                println!("        when: {}", v.conditions.join(", "));
+            }
+            if !v.contributing_peers.is_empty() {
+                println!("        peers: {}", v.contributing_peers.join(", "));
+            }
+            if let Some(ref outcome) = v.outcome_ref {
+                println!("        outcome_ref: {outcome}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn truncate_col_cli(s: &str, width: usize) -> String {
+    if s.chars().count() <= width {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(width.saturating_sub(1)).collect();
+        format!("{truncated}…")
     }
 }
 

--- a/src/hive/distiller.rs
+++ b/src/hive/distiller.rs
@@ -1,5 +1,9 @@
 // Convert DistilledPreferences and Insights into KnowledgeUnits for sharing.
 
+use std::collections::HashMap;
+
+use crate::brain::decisions::{DecisionRecord, read_all_decisions};
+use crate::brain::outcomes::{ResolvedOutcome, load_resolved_map};
 use crate::brain::preferences::{
     DistilledPreferences, PreferencePattern, TemporalPattern, ToolAccuracy,
 };
@@ -18,6 +22,11 @@ pub struct ExportThresholds {
     pub min_tool_decisions: u32,
     /// Minimum temporal pattern strength.
     pub min_temporal_strength: f64,
+    /// Minimum outcomes attributed to an approach before sharing baseline (#220).
+    pub min_outcome_samples: u32,
+    /// Minimum samples on each variant before promoting a divergent group
+    /// into an `ApproachCluster` (#221).
+    pub min_cluster_variant_evidence: u32,
 }
 
 impl Default for ExportThresholds {
@@ -26,6 +35,8 @@ impl Default for ExportThresholds {
             min_pattern_evidence: 5,
             min_tool_decisions: 10,
             min_temporal_strength: 0.7,
+            min_outcome_samples: 5,
+            min_cluster_variant_evidence: 3,
         }
     }
 }
@@ -70,6 +81,24 @@ pub fn distill_to_knowledge(
         }
     }
 
+    // #220 baselining: reap any pending PostToolUse outcomes first so the
+    // freshest data lands in this pass.
+    let _ = crate::brain::outcomes::reap();
+    let decisions = read_all_decisions();
+    let resolved = load_resolved_map();
+    units.extend(distill_outcomes(
+        &decisions,
+        &resolved,
+        source_peer,
+        &scope,
+        project,
+        now,
+        thresholds,
+    ));
+
+    // #221 conflict-aware: detect competing approaches and emit clusters.
+    units.extend(detect_clusters(prefs, source_peer, &scope, now, thresholds));
+
     units
 }
 
@@ -98,6 +127,247 @@ pub fn distill_to_knowledge_stable(
         }
     }
 
+    units
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// #220 baselining: outcome aggregation
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Build the canonical approach reference for a decision. Mirrors the shape
+/// used by `Pattern`'s semantic_key so cluster/outcome views can join on it.
+fn approach_ref_for(decision: &DecisionRecord) -> Option<String> {
+    let tool = decision.tool.as_deref()?;
+    let cmd = decision
+        .command
+        .as_deref()
+        .map(|s| s.split_whitespace().collect::<Vec<_>>().join(" "))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "*".to_string());
+    Some(format!("pattern:{tool}:{cmd}"))
+}
+
+#[derive(Default)]
+struct OutcomeBucket {
+    samples: u32,
+    successes: u32,
+    costs: Vec<f64>,
+    durations_ms: Vec<u64>,
+    project_hits: HashMap<String, u32>,
+}
+
+fn median_f64(mut v: Vec<f64>) -> Option<f64> {
+    if v.is_empty() {
+        return None;
+    }
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = v.len() / 2;
+    Some(if v.len() % 2 == 0 {
+        (v[mid - 1] + v[mid]) / 2.0
+    } else {
+        v[mid]
+    })
+}
+
+fn median_u64(mut v: Vec<u64>) -> Option<u64> {
+    if v.is_empty() {
+        return None;
+    }
+    v.sort();
+    let mid = v.len() / 2;
+    Some(if v.len() % 2 == 0 {
+        (v[mid - 1] + v[mid]) / 2
+    } else {
+        v[mid]
+    })
+}
+
+/// Aggregate decisions + their resolved outcomes into per-approach buckets,
+/// then emit ApproachOutcome KnowledgeUnits that meet `min_outcome_samples`.
+pub fn distill_outcomes(
+    decisions: &[DecisionRecord],
+    resolved: &HashMap<String, ResolvedOutcome>,
+    source_peer: &str,
+    scope: &KnowledgeScope,
+    project_filter: Option<&str>,
+    now: u64,
+    thresholds: &ExportThresholds,
+) -> Vec<KnowledgeUnit> {
+    let mut buckets: HashMap<String, OutcomeBucket> = HashMap::new();
+    for d in decisions {
+        // Optional per-project view
+        if let Some(p) = project_filter {
+            if !d.project.eq_ignore_ascii_case(p) {
+                continue;
+            }
+        }
+        let Some(decision_id) = d.decision_id.as_deref() else {
+            continue;
+        };
+        let Some(outcome) = resolved.get(decision_id) else {
+            continue;
+        };
+        let Some(key) = approach_ref_for(d) else {
+            continue;
+        };
+        let entry = buckets.entry(key).or_default();
+        entry.samples += 1;
+        if outcome.exit_code.unwrap_or(-1) == 0 {
+            entry.successes += 1;
+        }
+        if let Some(ctx) = &d.context {
+            if ctx.cost_usd > 0.0 {
+                entry.costs.push(ctx.cost_usd);
+            }
+        }
+        if let Some(ms) = outcome.duration_ms {
+            entry.durations_ms.push(ms);
+        }
+        *entry.project_hits.entry(d.project.clone()).or_insert(0) += 1;
+    }
+
+    let mut out = Vec::new();
+    for (approach_ref, bucket) in buckets {
+        if bucket.samples < thresholds.min_outcome_samples {
+            continue;
+        }
+        let success_rate = bucket.successes as f64 / bucket.samples as f64;
+        let median_cost_usd = median_f64(bucket.costs);
+        let median_duration_ms = median_u64(bucket.durations_ms);
+
+        // Conditions: list each project that contributed >= 2 samples,
+        // gives the cluster work later something to filter on.
+        let mut conditions: Vec<String> = bucket
+            .project_hits
+            .into_iter()
+            .filter(|(_, n)| *n >= 2)
+            .map(|(p, n)| format!("project:{p} (n={n})"))
+            .collect();
+        conditions.sort();
+
+        out.push(KnowledgeUnit {
+            id: gen_ku_id(),
+            scope: scope.clone(),
+            category: super::KnowledgeCategory::BestPractice,
+            content: KnowledgeContent::ApproachOutcome {
+                approach_ref,
+                success_rate,
+                sample_count: bucket.samples,
+                median_cost_usd,
+                median_duration_ms,
+                conditions,
+            },
+            evidence_count: bucket.samples,
+            confidence: success_rate,
+            source_peer: source_peer.to_string(),
+            originated_at: now,
+            last_validated_at: now,
+            propagation_count: 0,
+            version: 1,
+        });
+    }
+    out
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// #221 conflict-aware: cluster detection
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Build the canonical problem key for a preference pattern.
+/// Patterns sharing this key but differing on `preferred_action` are
+/// candidates for an `ApproachCluster`.
+fn problem_key_for(pattern: &PreferencePattern) -> String {
+    let cmd = pattern.command_pattern.as_deref().unwrap_or("*");
+    let normalized = cmd.split_whitespace().collect::<Vec<_>>().join(" ");
+    format!("{}:{normalized}", pattern.tool)
+}
+
+/// Render a pattern's conditions as human-readable strings for the cluster
+/// variant payload (so peers can reason about *when* a variant tends to win).
+fn condition_labels(pattern: &PreferencePattern) -> Vec<String> {
+    pattern.conditions.iter().map(|c| c.label()).collect()
+}
+
+/// Detect divergent preference patterns and emit `ApproachCluster` units.
+/// A group qualifies when:
+///   - 2+ patterns share the same `problem_key`
+///   - they disagree on `preferred_action`
+///   - each variant has `>= min_cluster_variant_evidence` samples
+pub fn detect_clusters(
+    prefs: &DistilledPreferences,
+    source_peer: &str,
+    scope: &KnowledgeScope,
+    now: u64,
+    thresholds: &ExportThresholds,
+) -> Vec<KnowledgeUnit> {
+    let mut groups: HashMap<String, Vec<&PreferencePattern>> = HashMap::new();
+    for p in &prefs.patterns {
+        groups.entry(problem_key_for(p)).or_default().push(p);
+    }
+
+    let mut units = Vec::new();
+    for (problem_key, patterns) in groups {
+        if patterns.len() < 2 {
+            continue;
+        }
+        // Drop patterns below the per-variant evidence floor before checking
+        // for divergence — a single weak counter-pattern shouldn't promote
+        // an otherwise stable preference into a cluster.
+        let qualifying: Vec<&PreferencePattern> = patterns
+            .into_iter()
+            .filter(|p| p.sample_count >= thresholds.min_cluster_variant_evidence)
+            .collect();
+        if qualifying.len() < 2 {
+            continue;
+        }
+        let mut actions: Vec<&str> = qualifying
+            .iter()
+            .map(|p| p.preferred_action.as_str())
+            .collect();
+        actions.sort();
+        actions.dedup();
+        if actions.len() < 2 {
+            continue; // all variants agree — not really a conflict
+        }
+
+        let outcome_ref = format!("pattern:{problem_key}");
+        let variants: Vec<super::ApproachVariant> = qualifying
+            .iter()
+            .map(|p| super::ApproachVariant {
+                approach_summary: format!(
+                    "{} ({:.0}% accept over {})",
+                    p.preferred_action,
+                    p.accept_rate * 100.0,
+                    p.sample_count
+                ),
+                conditions: condition_labels(p),
+                evidence: p.sample_count,
+                contributing_peers: vec![source_peer.to_string()],
+                outcome_ref: Some(outcome_ref.clone()),
+            })
+            .collect();
+
+        let total_evidence: u32 = variants.iter().map(|v| v.evidence).sum();
+        let mean_confidence =
+            qualifying.iter().map(|p| p.confidence).sum::<f64>() / qualifying.len() as f64;
+
+        units.push(KnowledgeUnit {
+            id: gen_ku_id(),
+            scope: scope.clone(),
+            category: super::KnowledgeCategory::Technique,
+            content: KnowledgeContent::ApproachCluster {
+                problem_key,
+                variants,
+            },
+            evidence_count: total_evidence,
+            confidence: mean_confidence,
+            source_peer: source_peer.to_string(),
+            originated_at: now,
+            last_validated_at: now,
+            propagation_count: 0,
+            version: 1,
+        });
+    }
     units
 }
 
@@ -422,6 +692,333 @@ mod tests {
         }
     }
 
+    fn make_decision_with_id(id: &str, tool: &str, command: &str, project: &str) -> DecisionRecord {
+        use crate::brain::decisions::DecisionType;
+        DecisionRecord {
+            timestamp: "0".into(),
+            pid: 1,
+            project: project.into(),
+            tool: Some(tool.into()),
+            command: Some(command.into()),
+            brain_action: "approve".into(),
+            brain_confidence: 0.9,
+            brain_reasoning: "test".into(),
+            user_action: "accept".into(),
+            context: None,
+            outcome: None,
+            decision_type: DecisionType::Session,
+            suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
+            decision_id: Some(id.into()),
+        }
+    }
+
+    fn make_resolved(
+        id: &str,
+        tool: &str,
+        project: &str,
+        exit: Option<i32>,
+        dur: Option<u64>,
+    ) -> ResolvedOutcome {
+        ResolvedOutcome {
+            decision_id: id.into(),
+            tool: tool.into(),
+            command: Some("cargo test".into()),
+            project: project.into(),
+            exit_code: exit,
+            duration_ms: dur,
+            stderr_tail: None,
+            ts: 0,
+        }
+    }
+
+    #[test]
+    fn distill_outcomes_aggregates_per_approach() {
+        let decisions = vec![
+            make_decision_with_id("d1", "Bash", "cargo test", "p"),
+            make_decision_with_id("d2", "Bash", "cargo test", "p"),
+            make_decision_with_id("d3", "Bash", "cargo test", "p"),
+        ];
+        let mut resolved = HashMap::new();
+        resolved.insert(
+            "d1".into(),
+            make_resolved("d1", "Bash", "p", Some(0), Some(100)),
+        );
+        resolved.insert(
+            "d2".into(),
+            make_resolved("d2", "Bash", "p", Some(0), Some(200)),
+        );
+        resolved.insert(
+            "d3".into(),
+            make_resolved("d3", "Bash", "p", Some(1), Some(300)),
+        );
+
+        let units = distill_outcomes(
+            &decisions,
+            &resolved,
+            "peer",
+            &KnowledgeScope::Universal,
+            None,
+            0,
+            &ExportThresholds {
+                min_outcome_samples: 1,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(units.len(), 1, "all three share the same approach_ref");
+        match &units[0].content {
+            KnowledgeContent::ApproachOutcome {
+                approach_ref,
+                success_rate,
+                sample_count,
+                median_duration_ms,
+                ..
+            } => {
+                assert_eq!(approach_ref, "pattern:Bash:cargo test");
+                assert_eq!(*sample_count, 3);
+                assert!((success_rate - 2.0 / 3.0).abs() < 1e-9);
+                assert_eq!(*median_duration_ms, Some(200));
+            }
+            other => panic!("unexpected content {other:?}"),
+        }
+    }
+
+    #[test]
+    fn distill_outcomes_threshold_filters() {
+        let decisions = vec![make_decision_with_id("d1", "Bash", "ls", "p")];
+        let mut resolved = HashMap::new();
+        resolved.insert("d1".into(), make_resolved("d1", "Bash", "p", Some(0), None));
+
+        let units = distill_outcomes(
+            &decisions,
+            &resolved,
+            "peer",
+            &KnowledgeScope::Universal,
+            None,
+            0,
+            &ExportThresholds {
+                min_outcome_samples: 5,
+                ..Default::default()
+            },
+        );
+        assert!(units.is_empty(), "1 sample below threshold of 5");
+    }
+
+    #[test]
+    fn distill_outcomes_skips_decisions_without_id() {
+        // Old records lack decision_id and can't be joined to outcomes.
+        let mut d = make_decision_with_id("d1", "Bash", "cargo test", "p");
+        d.decision_id = None;
+        let resolved = HashMap::new();
+        let units = distill_outcomes(
+            &[d],
+            &resolved,
+            "peer",
+            &KnowledgeScope::Universal,
+            None,
+            0,
+            &ExportThresholds {
+                min_outcome_samples: 1,
+                ..Default::default()
+            },
+        );
+        assert!(units.is_empty());
+    }
+
+    #[test]
+    fn distill_outcomes_project_filter() {
+        let decisions = vec![
+            make_decision_with_id("d1", "Bash", "cargo test", "alpha"),
+            make_decision_with_id("d2", "Bash", "cargo test", "beta"),
+        ];
+        let mut resolved = HashMap::new();
+        resolved.insert(
+            "d1".into(),
+            make_resolved("d1", "Bash", "alpha", Some(0), None),
+        );
+        resolved.insert(
+            "d2".into(),
+            make_resolved("d2", "Bash", "beta", Some(0), None),
+        );
+
+        let units = distill_outcomes(
+            &decisions,
+            &resolved,
+            "peer",
+            &KnowledgeScope::Project("alpha".into()),
+            Some("alpha"),
+            0,
+            &ExportThresholds {
+                min_outcome_samples: 1,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(units.len(), 1);
+        if let KnowledgeContent::ApproachOutcome { sample_count, .. } = &units[0].content {
+            assert_eq!(*sample_count, 1, "beta decision should be filtered out");
+        } else {
+            panic!("wrong content variant");
+        }
+    }
+
+    fn make_pattern(
+        tool: &str,
+        cmd: &str,
+        action: &str,
+        n: u32,
+        accept: f64,
+        conds: Vec<crate::brain::preferences::PreferenceCondition>,
+    ) -> PreferencePattern {
+        PreferencePattern {
+            tool: tool.into(),
+            command_pattern: Some(cmd.into()),
+            preferred_action: action.into(),
+            sample_count: n,
+            accept_rate: accept,
+            conditions: conds,
+            confidence: accept,
+        }
+    }
+
+    #[test]
+    fn detect_clusters_on_divergent_actions() {
+        use crate::brain::preferences::PreferenceCondition;
+        let prefs = DistilledPreferences {
+            patterns: vec![
+                make_pattern(
+                    "Bash",
+                    "git push",
+                    "approve",
+                    8,
+                    0.9,
+                    vec![PreferenceCondition::CostBelow(1.0)],
+                ),
+                make_pattern(
+                    "Bash",
+                    "git push",
+                    "deny",
+                    5,
+                    0.1,
+                    vec![PreferenceCondition::CostAbove(1.0)],
+                ),
+            ],
+            tool_accuracy: vec![],
+            temporal: vec![],
+            total_decisions: 13,
+            overall_accuracy: 0.0,
+        };
+        let units = detect_clusters(
+            &prefs,
+            "peer-a",
+            &KnowledgeScope::Universal,
+            0,
+            &ExportThresholds::default(),
+        );
+        assert_eq!(
+            units.len(),
+            1,
+            "should produce one cluster for the divergent group"
+        );
+        if let KnowledgeContent::ApproachCluster {
+            problem_key,
+            variants,
+        } = &units[0].content
+        {
+            assert_eq!(problem_key, "Bash:git push");
+            assert_eq!(variants.len(), 2);
+            // Must capture both actions
+            let summaries: Vec<&str> = variants
+                .iter()
+                .map(|v| v.approach_summary.as_str())
+                .collect();
+            assert!(summaries.iter().any(|s| s.starts_with("approve")));
+            assert!(summaries.iter().any(|s| s.starts_with("deny")));
+        } else {
+            panic!("wrong content variant");
+        }
+    }
+
+    #[test]
+    fn detect_clusters_skips_when_actions_agree() {
+        let prefs = DistilledPreferences {
+            patterns: vec![
+                make_pattern("Bash", "ls", "approve", 8, 0.9, vec![]),
+                make_pattern("Bash", "ls", "approve", 5, 0.95, vec![]),
+            ],
+            tool_accuracy: vec![],
+            temporal: vec![],
+            total_decisions: 13,
+            overall_accuracy: 0.0,
+        };
+        let units = detect_clusters(
+            &prefs,
+            "peer-a",
+            &KnowledgeScope::Universal,
+            0,
+            &ExportThresholds::default(),
+        );
+        assert!(units.is_empty(), "no divergence → no cluster");
+    }
+
+    #[test]
+    fn detect_clusters_skips_below_per_variant_threshold() {
+        let prefs = DistilledPreferences {
+            patterns: vec![
+                make_pattern("Bash", "rm -rf", "deny", 8, 0.0, vec![]),
+                // Counter-pattern is too weak to count as a real variant
+                make_pattern("Bash", "rm -rf", "approve", 1, 1.0, vec![]),
+            ],
+            tool_accuracy: vec![],
+            temporal: vec![],
+            total_decisions: 9,
+            overall_accuracy: 0.0,
+        };
+        let units = detect_clusters(
+            &prefs,
+            "peer-a",
+            &KnowledgeScope::Universal,
+            0,
+            &ExportThresholds::default(),
+        );
+        assert!(
+            units.is_empty(),
+            "weak counter-pattern should not promote a cluster"
+        );
+    }
+
+    #[test]
+    fn approach_outcome_semantic_key_stable_across_peers() {
+        // Two units from different peers describing the same approach must
+        // produce the same semantic_key so the merger can dedup them.
+        let unit_a = KnowledgeUnit {
+            id: gen_ku_id(),
+            scope: KnowledgeScope::Universal,
+            category: super::super::KnowledgeCategory::BestPractice,
+            content: KnowledgeContent::ApproachOutcome {
+                approach_ref: "pattern:Bash:cargo test".into(),
+                success_rate: 0.9,
+                sample_count: 10,
+                median_cost_usd: None,
+                median_duration_ms: None,
+                conditions: vec![],
+            },
+            evidence_count: 10,
+            confidence: 0.9,
+            source_peer: "peer-a".into(),
+            originated_at: 0,
+            last_validated_at: 0,
+            propagation_count: 0,
+            version: 1,
+        };
+        let mut unit_b = unit_a.clone();
+        unit_b.source_peer = "peer-b".into();
+        unit_b.id = gen_ku_id();
+        assert_eq!(semantic_key(&unit_a), semantic_key(&unit_b));
+    }
+
     #[test]
     fn custom_thresholds() {
         let prefs = make_prefs();
@@ -429,6 +1026,8 @@ mod tests {
             min_pattern_evidence: 50,
             min_tool_decisions: 100,
             min_temporal_strength: 0.99,
+            min_outcome_samples: u32::MAX,
+            min_cluster_variant_evidence: u32::MAX,
         };
         let units = distill_to_knowledge(&prefs, "test-peer", None, &strict);
         assert_eq!(units.len(), 0); // nothing meets strict thresholds

--- a/src/hive/injection.rs
+++ b/src/hive/injection.rs
@@ -78,6 +78,29 @@ pub fn build_hive_context(
         lines.push(format!(
             "- [{label}] {summary} — {evidence} decisions from {peer}"
         ));
+
+        // #221 conflict-aware: expand cluster variants inline so the LLM
+        // sees the alternatives rather than just a single collapsed pattern.
+        // Cap at top 3 variants ranked by evidence to keep prompt size bounded.
+        if let KnowledgeContent::ApproachCluster { variants, .. } = &unit.content {
+            let mut sorted = variants.clone();
+            sorted.sort_by(|a, b| b.evidence.cmp(&a.evidence));
+            for (i, v) in sorted.iter().take(3).enumerate() {
+                let label_letter = (b'A' + i as u8) as char;
+                let cond = if v.conditions.is_empty() {
+                    String::new()
+                } else {
+                    format!(" [when: {}]", v.conditions.join(", "))
+                };
+                lines.push(format!(
+                    "    ({label_letter}) {} — n={}{cond}",
+                    v.approach_summary, v.evidence
+                ));
+            }
+            if sorted.len() > 3 {
+                lines.push(format!("    (… {} more variants)", sorted.len() - 3));
+            }
+        }
     }
 
     if lines.is_empty() {
@@ -258,6 +281,95 @@ mod tests {
         let ctx = build_hive_context(&store, &trust_store, true, 0);
         assert!(ctx.contains("[hive]")); // 0.9 = Confirmed
         assert!(!ctx.contains("[hive, suggested]"));
+    }
+
+    fn make_cluster_unit(
+        id: &str,
+        peer: &str,
+        problem_key: &str,
+        variants: Vec<super::super::ApproachVariant>,
+    ) -> super::super::KnowledgeUnit {
+        let evidence: u32 = variants.iter().map(|v| v.evidence).sum();
+        super::super::KnowledgeUnit {
+            id: id.into(),
+            scope: super::super::KnowledgeScope::Universal,
+            category: super::super::KnowledgeCategory::Technique,
+            content: super::super::KnowledgeContent::ApproachCluster {
+                problem_key: problem_key.into(),
+                variants,
+            },
+            evidence_count: evidence,
+            confidence: 0.5,
+            source_peer: peer.into(),
+            originated_at: 1000,
+            last_validated_at: 2000,
+            propagation_count: 0,
+            version: 1,
+        }
+    }
+
+    #[test]
+    fn build_context_expands_cluster_variants_inline() {
+        let mut store = empty_store();
+        store.insert(make_cluster_unit(
+            "ku_cluster",
+            "peer-a",
+            "Bash:git push",
+            vec![
+                super::super::ApproachVariant {
+                    approach_summary: "approve (90%)".into(),
+                    conditions: vec!["cost_below(1.0)".into()],
+                    evidence: 12,
+                    contributing_peers: vec!["peer-a".into()],
+                    outcome_ref: None,
+                },
+                super::super::ApproachVariant {
+                    approach_summary: "deny (15%)".into(),
+                    conditions: vec!["cost_above(1.0)".into()],
+                    evidence: 6,
+                    contributing_peers: vec!["peer-b".into()],
+                    outcome_ref: None,
+                },
+            ],
+        ));
+
+        let trust_store = TrustStore::load_with_default(0.5);
+        let ctx = build_hive_context(&store, &trust_store, true, 0);
+        assert!(ctx.contains("cluster: Bash:git push"));
+        assert!(ctx.contains("(A) approve"));
+        assert!(ctx.contains("(B) deny"));
+        // Higher evidence first → approve labelled (A).
+        let approve_idx = ctx.find("(A)").expect("A label present");
+        let deny_idx = ctx.find("(B)").expect("B label present");
+        assert!(
+            approve_idx < deny_idx,
+            "approve must precede deny in label order"
+        );
+        // Conditions are inlined.
+        assert!(ctx.contains("cost_below(1.0)"));
+    }
+
+    #[test]
+    fn build_context_caps_cluster_variants_at_three() {
+        let mut store = empty_store();
+        let variants: Vec<super::super::ApproachVariant> = (0..5)
+            .map(|i| super::super::ApproachVariant {
+                approach_summary: format!("variant {i}"),
+                conditions: vec![],
+                evidence: 5 + i,
+                contributing_peers: vec!["peer".into()],
+                outcome_ref: None,
+            })
+            .collect();
+        store.insert(make_cluster_unit("ku_big", "peer", "Bash:noisy", variants));
+
+        let trust_store = TrustStore::load_with_default(0.5);
+        let ctx = build_hive_context(&store, &trust_store, true, 0);
+        assert!(ctx.contains("(A)"));
+        assert!(ctx.contains("(B)"));
+        assert!(ctx.contains("(C)"));
+        assert!(!ctx.contains("(D)"), "should cap at 3");
+        assert!(ctx.contains("2 more variants"), "should note overflow");
     }
 
     #[test]

--- a/src/hive/injection.rs
+++ b/src/hive/injection.rs
@@ -84,7 +84,7 @@ pub fn build_hive_context(
         // Cap at top 3 variants ranked by evidence to keep prompt size bounded.
         if let KnowledgeContent::ApproachCluster { variants, .. } = &unit.content {
             let mut sorted = variants.clone();
-            sorted.sort_by(|a, b| b.evidence.cmp(&a.evidence));
+            sorted.sort_by_key(|v| std::cmp::Reverse(v.evidence));
             for (i, v) in sorted.iter().take(3).enumerate() {
                 let label_letter = (b'A' + i as u8) as char;
                 let cond = if v.conditions.is_empty() {

--- a/src/hive/merger.rs
+++ b/src/hive/merger.rs
@@ -1,7 +1,7 @@
 // Conflict resolution for merging incoming knowledge units.
 
 use super::store::HiveStore;
-use super::{KnowledgeUnit, semantic_key};
+use super::{ApproachVariant, KnowledgeContent, KnowledgeUnit, semantic_key};
 
 // ────────────────────────────────────────────────────────────────────────────
 // Merge result
@@ -56,6 +56,44 @@ pub fn merge_unit(
                 return MergeResult::Duplicate;
             }
 
+            // #221 conflict-aware: cluster-vs-cluster unions variants instead
+            // of picking a winner. Local clusters still win on existence —
+            // we never overwrite a local cluster with a peer collapse — but
+            // peer variants can be folded in.
+            if let (
+                KnowledgeContent::ApproachCluster {
+                    problem_key: existing_key,
+                    variants: existing_variants,
+                },
+                KnowledgeContent::ApproachCluster {
+                    problem_key: incoming_key,
+                    variants: incoming_variants,
+                },
+            ) = (&existing.content, &incoming.content)
+            {
+                if existing_key == incoming_key {
+                    let merged_variants = union_variants(existing_variants, incoming_variants);
+                    let mut merged = existing.clone();
+                    merged.content = KnowledgeContent::ApproachCluster {
+                        problem_key: existing_key.clone(),
+                        variants: merged_variants,
+                    };
+                    merged.evidence_count =
+                        if let KnowledgeContent::ApproachCluster { ref variants, .. } =
+                            merged.content
+                        {
+                            variants.iter().map(|v| v.evidence).sum()
+                        } else {
+                            merged.evidence_count
+                        };
+                    merged.last_validated_at =
+                        incoming.last_validated_at.max(existing.last_validated_at);
+                    merged.version = existing.version.max(incoming.version) + 1;
+                    store.insert(merged);
+                    return MergeResult::Updated;
+                }
+            }
+
             // Local-originated knowledge always wins
             if existing.source_peer == local_peer_id {
                 super::store::log_conflict(existing, incoming);
@@ -80,6 +118,49 @@ pub fn merge_unit(
             }
         }
     }
+}
+
+/// Union two variant lists. Variants match when their `approach_summary` and
+/// `conditions` are equal (after normalization). Matching variants accumulate
+/// evidence and union their contributing peers.
+pub fn union_variants(
+    existing: &[ApproachVariant],
+    incoming: &[ApproachVariant],
+) -> Vec<ApproachVariant> {
+    fn key(v: &ApproachVariant) -> String {
+        let mut conds = v.conditions.clone();
+        conds.sort();
+        format!("{}|{}", v.approach_summary, conds.join(","))
+    }
+    let mut by_key: std::collections::HashMap<String, ApproachVariant> =
+        existing.iter().cloned().map(|v| (key(&v), v)).collect();
+    for inc in incoming {
+        let k = key(inc);
+        match by_key.get_mut(&k) {
+            Some(existing_v) => {
+                existing_v.evidence = existing_v.evidence.saturating_add(inc.evidence);
+                for peer in &inc.contributing_peers {
+                    if !existing_v.contributing_peers.iter().any(|p| p == peer) {
+                        existing_v.contributing_peers.push(peer.clone());
+                    }
+                }
+                if existing_v.outcome_ref.is_none() {
+                    existing_v.outcome_ref = inc.outcome_ref.clone();
+                }
+            }
+            None => {
+                by_key.insert(k, inc.clone());
+            }
+        }
+    }
+    let mut out: Vec<ApproachVariant> = by_key.into_values().collect();
+    // Stable display order: highest evidence first, then alphabetical summary.
+    out.sort_by(|a, b| {
+        b.evidence
+            .cmp(&a.evidence)
+            .then_with(|| a.approach_summary.cmp(&b.approach_summary))
+    });
+    out
 }
 
 /// Merge a batch of incoming units. Returns aggregate stats.
@@ -228,6 +309,118 @@ mod tests {
         v2.version = 2;
         assert_eq!(merge_unit(&mut store, &v2, "local"), MergeResult::Updated);
         assert_eq!(store.get("ku_1").unwrap().version, 2);
+    }
+
+    fn make_cluster(
+        id: &str,
+        peer: &str,
+        key: &str,
+        variants: Vec<ApproachVariant>,
+    ) -> KnowledgeUnit {
+        let evidence: u32 = variants.iter().map(|v| v.evidence).sum();
+        KnowledgeUnit {
+            id: id.into(),
+            scope: KnowledgeScope::Universal,
+            category: crate::hive::KnowledgeCategory::Technique,
+            content: KnowledgeContent::ApproachCluster {
+                problem_key: key.into(),
+                variants,
+            },
+            evidence_count: evidence,
+            confidence: 0.5,
+            source_peer: peer.into(),
+            originated_at: 1000,
+            last_validated_at: 2000,
+            propagation_count: 0,
+            version: 1,
+        }
+    }
+
+    fn variant(summary: &str, evidence: u32, peer: &str, conds: Vec<&str>) -> ApproachVariant {
+        ApproachVariant {
+            approach_summary: summary.into(),
+            conditions: conds.into_iter().map(|s| s.into()).collect(),
+            evidence,
+            contributing_peers: vec![peer.into()],
+            outcome_ref: None,
+        }
+    }
+
+    #[test]
+    fn cluster_union_merges_variants() {
+        let mut store = empty_store();
+        let local = make_cluster(
+            "ku_local",
+            "peer-a",
+            "Bash:git push",
+            vec![variant(
+                "approve (90%)",
+                8,
+                "peer-a",
+                vec!["cost_below(1.0)"],
+            )],
+        );
+        store.insert(local);
+
+        let incoming = make_cluster(
+            "ku_remote",
+            "peer-b",
+            "Bash:git push",
+            vec![
+                variant("deny (10%)", 5, "peer-b", vec!["cost_above(1.0)"]),
+                // Same variant peer-a already has — peer list should union, evidence sums.
+                variant("approve (90%)", 4, "peer-b", vec!["cost_below(1.0)"]),
+            ],
+        );
+
+        let result = merge_unit(&mut store, &incoming, "local");
+        assert_eq!(result, MergeResult::Updated);
+
+        let unit = store.get("ku_local").unwrap();
+        if let KnowledgeContent::ApproachCluster {
+            problem_key,
+            variants,
+        } = &unit.content
+        {
+            assert_eq!(problem_key, "Bash:git push");
+            assert_eq!(variants.len(), 2, "approve & deny variants both present");
+            let approve = variants
+                .iter()
+                .find(|v| v.approach_summary.starts_with("approve"))
+                .expect("approve variant");
+            assert_eq!(approve.evidence, 12, "8 + 4 evidence");
+            assert!(
+                approve.contributing_peers.iter().any(|p| p == "peer-a")
+                    && approve.contributing_peers.iter().any(|p| p == "peer-b"),
+                "peer list should union",
+            );
+        } else {
+            panic!("merged unit lost ApproachCluster content");
+        }
+    }
+
+    #[test]
+    fn cluster_disjoint_problem_keys_do_not_merge() {
+        let mut store = empty_store();
+        let local = make_cluster(
+            "ku_a",
+            "peer-a",
+            "Bash:git push",
+            vec![variant("approve", 5, "peer-a", vec![])],
+        );
+        store.insert(local);
+
+        // A unit with a *different* problem_key has a different semantic_key,
+        // so the merger sees no existing collision and inserts it fresh.
+        let incoming = make_cluster(
+            "ku_b",
+            "peer-b",
+            "Bash:cargo test",
+            vec![variant("approve", 5, "peer-b", vec![])],
+        );
+        let result = merge_unit(&mut store, &incoming, "local");
+        assert_eq!(result, MergeResult::Accepted);
+        assert_eq!(store.len(), 2);
     }
 
     #[test]

--- a/src/hive/mod.rs
+++ b/src/hive/mod.rs
@@ -195,6 +195,48 @@ pub enum KnowledgeContent {
         #[serde(default)]
         requires: ArtifactRequires,
     },
+    /// Outcome statistics for a recurring approach (#220 baselining).
+    /// `approach_ref` matches the semantic_key of the underlying Pattern/Rule/Skill
+    /// so outcomes can be joined back to the approach they describe and shared
+    /// across peers as evidence — not as a new approach itself.
+    ApproachOutcome {
+        approach_ref: String,
+        success_rate: f64,
+        sample_count: u32,
+        #[serde(default)]
+        median_cost_usd: Option<f64>,
+        #[serde(default)]
+        median_duration_ms: Option<u64>,
+        #[serde(default)]
+        conditions: Vec<String>,
+    },
+    /// A cluster of competing approaches to the same problem (#221).
+    /// `problem_key` is a stable identifier (typically the underlying tool
+    /// or canonical task name) that groups variants. Variants are not
+    /// collapsed during merge — they are unioned across peers so the gate
+    /// can present alternatives instead of one winning answer.
+    ApproachCluster {
+        problem_key: String,
+        variants: Vec<ApproachVariant>,
+    },
+}
+
+/// One competing approach within an `ApproachCluster`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApproachVariant {
+    /// Free-text summary the gate-time prompt shows to the LLM.
+    pub approach_summary: String,
+    /// When this variant tends to win (project, language, time-of-day, …).
+    #[serde(default)]
+    pub conditions: Vec<String>,
+    /// How many decisions back this variant.
+    pub evidence: u32,
+    /// Peers that have contributed evidence for this variant.
+    #[serde(default)]
+    pub contributing_peers: Vec<String>,
+    /// Optional pointer to an `ApproachOutcome` semantic_key for ranking.
+    #[serde(default)]
+    pub outcome_ref: Option<String>,
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -246,6 +288,12 @@ pub fn semantic_key(unit: &KnowledgeUnit) -> String {
         }
         KnowledgeContent::HookConfig { event, matcher, .. } => {
             format!("hook:{}:{}", event.to_lowercase(), matcher.to_lowercase())
+        }
+        KnowledgeContent::ApproachOutcome { approach_ref, .. } => {
+            format!("outcome:{approach_ref}")
+        }
+        KnowledgeContent::ApproachCluster { problem_key, .. } => {
+            format!("cluster:{problem_key}")
         }
     };
     format!("{scope_part}/{content_part}")
@@ -936,6 +984,23 @@ impl KnowledgeContent {
                 ..
             } => {
                 format!("hook: {event}[{matcher}] — {description}")
+            }
+            Self::ApproachOutcome {
+                approach_ref,
+                success_rate,
+                sample_count,
+                ..
+            } => {
+                format!(
+                    "outcome: {approach_ref} — {:.0}% over {sample_count}",
+                    success_rate * 100.0
+                )
+            }
+            Self::ApproachCluster {
+                problem_key,
+                variants,
+            } => {
+                format!("cluster: {problem_key} ({} variants)", variants.len())
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,6 +241,54 @@ pub(crate) struct Cli {
     #[arg(long, help_heading = "Brain (Local LLM)")]
     pub(crate) mode: Option<String>,
 
+    /// Record a tool-call outcome to the pending-outcomes spool.
+    /// Used by the Claude Code PostToolUse hook for #220 baselining.
+    /// Reads pending-outcome JSON from stdin (preferred) or builds one from
+    /// --tool, --tool-input, --project, --exit-code, --duration-ms, --stderr-tail.
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    pub(crate) record_outcome: bool,
+
+    /// Tool exit code for --record-outcome (0 = success).
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    pub(crate) exit_code: Option<i32>,
+
+    /// Tool wall-clock duration in milliseconds for --record-outcome.
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    pub(crate) duration_ms: Option<u64>,
+
+    /// Tail of stderr / tool error output for --record-outcome
+    /// (truncated to MAX_STDERR_TAIL_BYTES).
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    pub(crate) stderr_tail: Option<String>,
+
+    /// Claude Code session id (passed through hook payload), optional.
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    pub(crate) session_id: Option<String>,
+
+    /// Claude Code tool_use_id (passed through hook payload), optional.
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    pub(crate) tool_use_id: Option<String>,
+
+    /// Reap pending outcomes: attribute each to a matching decision and
+    /// archive orphans older than 24h. Exits with the reap stats as JSON
+    /// when --json is set, otherwise human-readable.
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    pub(crate) reap_outcomes: bool,
+
+    /// List resolved tool-call outcomes attributed to brain decisions.
+    /// Filterable by --tool and --project. Honours --json.
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    pub(crate) brain_outcomes: bool,
+
+    /// Rank approaches by outcome data (success_rate * sample_count).
+    /// Filterable by --tool and --project. Honours --json.
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    pub(crate) brain_baseline: bool,
+
+    /// Limit baseline ranking output to top N rows.
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    pub(crate) top: Option<usize>,
+
     /// Show auto-generated insights, or set mode (on/off/status).
     /// Requires --brain or brain.enabled in config.
     /// Without argument: show current insights.
@@ -529,6 +577,22 @@ fn run_main(cli: Cli) -> io::Result<()> {
 
     if cli.brain_query {
         return commands::run_brain_query(&cfg, &cli);
+    }
+
+    if cli.record_outcome {
+        return commands::run_record_outcome(&cli);
+    }
+
+    if cli.reap_outcomes {
+        return commands::run_reap_outcomes(&cli);
+    }
+
+    if cli.brain_outcomes {
+        return commands::run_brain_outcomes(&cli);
+    }
+
+    if cli.brain_baseline {
+        return commands::run_brain_baseline(&cli);
     }
 
     if let Some(ref mode) = cli.mode {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1075,3 +1075,241 @@ fn resolve_jsonl_telemetry_available_after_resolution() {
     assert!(s.usage_metrics_available);
     assert!(s.own_output_tokens > 0, "should have parsed output tokens");
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// #220 baselining — reaper attribution tests
+// ────────────────────────────────────────────────────────────────────────────
+//
+// Each test isolates a tempdir HOME (under HOME_LOCK), seeds a decisions.jsonl
+// and a pending-outcome file, runs the reaper, then asserts on the resulting
+// outcomes/ and pending-outcomes/ directories. HOME is restored on teardown.
+
+use claudectl::brain::outcomes;
+
+struct HomeGuard {
+    original: Option<String>,
+    _tempdir: tempfile::TempDir,
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        match self.original.take() {
+            Some(h) => unsafe { std::env::set_var("HOME", h) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+}
+
+fn isolated_home() -> HomeGuard {
+    let original = std::env::var("HOME").ok();
+    let dir = tempfile::tempdir().unwrap();
+    unsafe { std::env::set_var("HOME", dir.path()) };
+    HomeGuard {
+        original,
+        _tempdir: dir,
+    }
+}
+
+fn write_decision_jsonl(line: &str) {
+    let path = std::env::var("HOME").unwrap();
+    let dir = std::path::PathBuf::from(path).join(".claudectl/brain");
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join("decisions.jsonl"))
+        .unwrap();
+    writeln!(f, "{line}").unwrap();
+}
+
+fn write_pending_file(p: &outcomes::PendingOutcome) {
+    let path = outcomes::write_pending(p).unwrap();
+    assert!(path.exists());
+}
+
+#[test]
+fn reaper_attributes_outcome_to_recent_decision() {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _home = isolated_home();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let dec_ts = now - 30;
+    let decision_id = format!("dec_{dec_ts}_42_0");
+
+    write_decision_jsonl(&format!(
+        r#"{{"ts":"{dec_ts}","pid":42,"project":"alpha","tool":"Bash","command":"cargo test","brain_action":"approve","brain_confidence":0.9,"brain_reasoning":"safe","user_action":"accept","decision_type":"session","decision_id":"{decision_id}"}}"#
+    ));
+
+    write_pending_file(&outcomes::PendingOutcome {
+        tool: "Bash".into(),
+        command: Some("cargo test".into()),
+        project: "alpha".into(),
+        session_id: None,
+        tool_use_id: None,
+        exit_code: Some(0),
+        duration_ms: Some(2_400),
+        stderr_tail: None,
+        ts: now,
+    });
+
+    let stats = outcomes::reap();
+    assert_eq!(stats.attributed, 1, "exactly one outcome should attribute");
+    assert_eq!(stats.still_pending, 0);
+    assert_eq!(stats.orphaned, 0);
+
+    let resolved = outcomes::load_resolved_map();
+    assert_eq!(resolved.len(), 1);
+    let r = resolved.get(&decision_id).expect("resolved by decision_id");
+    assert_eq!(r.exit_code, Some(0));
+    assert_eq!(r.duration_ms, Some(2_400));
+}
+
+#[test]
+fn reaper_leaves_orphaned_outcome_pending_within_window() {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _home = isolated_home();
+
+    // No decisions written at all → outcome can't attribute, but isn't old
+    // enough to be orphaned either.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    write_pending_file(&outcomes::PendingOutcome {
+        tool: "Bash".into(),
+        command: Some("ls".into()),
+        project: "p".into(),
+        session_id: None,
+        tool_use_id: None,
+        exit_code: Some(0),
+        duration_ms: None,
+        stderr_tail: None,
+        ts: now,
+    });
+
+    let stats = outcomes::reap();
+    assert_eq!(stats.attributed, 0);
+    assert_eq!(stats.still_pending, 1);
+    assert_eq!(stats.orphaned, 0);
+    assert!(outcomes::load_resolved_map().is_empty());
+}
+
+#[test]
+fn reaper_orphans_old_unattributed_outcome() {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _home = isolated_home();
+
+    // Outcome older than ORPHAN_AFTER_SECS (24h) with no matching decision.
+    let stale_ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        - 90_000; // 25h ago
+
+    write_pending_file(&outcomes::PendingOutcome {
+        tool: "Bash".into(),
+        command: Some("rm -rf /tmp/stale".into()),
+        project: "p".into(),
+        session_id: None,
+        tool_use_id: None,
+        exit_code: Some(0),
+        duration_ms: None,
+        stderr_tail: None,
+        ts: stale_ts,
+    });
+
+    let stats = outcomes::reap();
+    assert_eq!(stats.attributed, 0);
+    assert_eq!(stats.orphaned, 1);
+
+    // The pending dir is empty; the orphaned dir has the file.
+    let pending: Vec<_> = std::fs::read_dir(outcomes::pending_dir())
+        .unwrap()
+        .collect();
+    assert!(pending.is_empty(), "pending dir should be drained");
+    let orphaned: Vec<_> = std::fs::read_dir(outcomes::orphaned_dir())
+        .unwrap()
+        .collect();
+    assert_eq!(orphaned.len(), 1);
+}
+
+#[test]
+fn reaper_will_not_double_attribute_one_decision() {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _home = isolated_home();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let dec_ts = now - 5;
+    let decision_id = format!("dec_{dec_ts}_7_0");
+    write_decision_jsonl(&format!(
+        r#"{{"ts":"{dec_ts}","pid":7,"project":"p","tool":"Bash","command":"echo hi","brain_action":"approve","brain_confidence":1.0,"brain_reasoning":"","user_action":"accept","decision_type":"session","decision_id":"{decision_id}"}}"#
+    ));
+
+    // Two pending outcomes for the same approach.
+    write_pending_file(&outcomes::PendingOutcome {
+        tool: "Bash".into(),
+        command: Some("echo hi".into()),
+        project: "p".into(),
+        session_id: None,
+        tool_use_id: None,
+        exit_code: Some(0),
+        duration_ms: Some(1),
+        stderr_tail: None,
+        ts: now,
+    });
+    write_pending_file(&outcomes::PendingOutcome {
+        tool: "Bash".into(),
+        command: Some("echo hi".into()),
+        project: "p".into(),
+        session_id: None,
+        tool_use_id: None,
+        exit_code: Some(0),
+        duration_ms: Some(2),
+        stderr_tail: None,
+        ts: now + 1,
+    });
+
+    let stats = outcomes::reap();
+    // Only one attributes; the other stays pending until a future decision
+    // is logged.
+    assert_eq!(stats.attributed, 1);
+    assert_eq!(stats.still_pending, 1);
+    assert_eq!(outcomes::load_resolved_map().len(), 1);
+}
+
+#[test]
+fn reaper_skips_decisions_lacking_decision_id() {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _home = isolated_home();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    // Old-style record (no decision_id field) — must be skipped.
+    write_decision_jsonl(&format!(
+        r#"{{"ts":"{}","pid":1,"project":"p","tool":"Bash","command":"ls","brain_action":"approve","brain_confidence":0.9,"brain_reasoning":"","user_action":"accept","decision_type":"session"}}"#,
+        now - 5
+    ));
+    write_pending_file(&outcomes::PendingOutcome {
+        tool: "Bash".into(),
+        command: Some("ls".into()),
+        project: "p".into(),
+        session_id: None,
+        tool_use_id: None,
+        exit_code: Some(0),
+        duration_ms: None,
+        stderr_tail: None,
+        ts: now,
+    });
+
+    let stats = outcomes::reap();
+    assert_eq!(stats.attributed, 0);
+    assert_eq!(stats.still_pending, 1);
+}


### PR DESCRIPTION
## Summary

Implements [#220](https://github.com/mercurialsolo/claudectl/issues/220) (outcome-based baselining) and [#221](https://github.com/mercurialsolo/claudectl/issues/221) (preserve conflicting approaches as variant clusters) end-to-end. Closes #220, closes #221.

### #220 — outcome-based baselining

The brain learned what users *accept* but never measured whether the accepted action *worked*. This change closes that loop with passive outcome capture.

- New `src/brain/outcomes.rs` module: `PendingOutcome` / `ResolvedOutcome` types, pending spool under `~/.claudectl/brain/pending-outcomes/`, claim-tracking reaper that attributes outcomes to recent decisions by `(tool, command, project)` within a 10-min window.
- `decision_id` now stamped onto every `DecisionRecord` and emitted in `decisions.jsonl` for forward-compat stronger attribution.
- New PostToolUse hook `claude-plugin/hooks/scripts/outcome-record.sh` captures `exit_code` + `stderr` tail and pipes a `PendingOutcome` JSON into `claudectl --record-outcome`.
- New `KnowledgeContent::ApproachOutcome { approach_ref, success_rate, sample_count, median_cost_usd, median_duration_ms, conditions }` variant. `distill_outcomes` aggregates per-approach success rate + medians.
- New CLI: `--record-outcome`, `--reap-outcomes`, `--brain-outcomes`, `--brain-baseline` (with `--top`, `--tool`, `--project`, `--json`).

### #221 — variant clusters

The merger used to collapse divergent peer patterns by picking a higher-confidence winner — destroying signal when the disagreement was context-dependent. Clusters preserve the alternatives.

- New `KnowledgeContent::ApproachCluster { problem_key, variants }` and `ApproachVariant` struct. `semantic_key` is `cluster:<problem_key>` so peers dedup on the cluster, not its variants.
- `detect_clusters` in distiller emits clusters when the same `(tool, command)` has divergent `preferred_action` values each backed by ≥`min_cluster_variant_evidence` samples (default 3). Single weak counter-patterns are filtered out so a fluke doesn't promote a stable preference into a cluster.
- `merger.rs`: cluster-vs-cluster path unions variants instead of picking a winner — peer lists merge, evidence sums, version bumps. Disjoint `problem_key`s never merge.
- Brain prompt injection (`build_hive_context`) expands cluster variants inline (top 3 by evidence, with `(A)` / `(B)` / `(C)` labels and inline conditions) so the gate-time LLM sees the alternatives.
- CLI: `claudectl hive clusters [--problem <key>]` and `claudectl hive cluster <key>`.

### Test coverage

22 new tests across 4 modules:

| Module | Tests |
|---|---|
| `brain::outcomes` (unit) | 8 — types round-trip, stderr truncate (incl. UTF-8), id uniqueness, pending parse |
| `tests/integration_tests` (reaper) | 5 — successful attribution, in-window pending, stale → orphaned, no-double-attribute, missing decision_id skip |
| `hive::distiller` | 5 — `ApproachOutcome` aggregation / threshold / project filter / no-id skip; semantic-key stability |
| `hive::distiller` (clusters) | 3 — divergent → cluster, agreement → skip, weak counter → skip |
| `hive::merger` | 2 — variant union (peer lists merge), disjoint keys do not merge |
| `hive::injection` | 2 — cluster expansion inline, top-3 variant cap with overflow note |

`cargo test`: **464 lib + 67 integration + 8 unit, all green.** `cargo clippy --tests -- -D warnings` clean. `cargo fmt` applied.

## Test plan

- [ ] `cargo test --all`
- [ ] `cargo clippy --tests -- -D warnings`
- [ ] Plugin hooks load: install plugin into a test Claude session and verify `outcome-record.sh` fires on Bash/Write/Edit
- [ ] `claudectl --reap-outcomes` reports sane counts after a session
- [ ] `claudectl --brain-baseline` ranks expected approaches after seed data
- [ ] `claudectl hive clusters` lists clusters once a divergent project has accumulated samples; `claudectl hive cluster <key>` shows variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)