### PR TITLE
Hive: explore CLI and welcome snapshot (#227)

### DIFF
--- a/src/hive/cli.rs
+++ b/src/hive/cli.rs
@@ -194,6 +194,40 @@ pub enum HiveCommand {
         #[arg(long)]
         unfreeze: Option<String>,
     },
+
+    /// Browse what the hive knows before it auto-injects (#227)
+    Explore {
+        /// Filter by category (best_practice, technique, workflow, personal)
+        #[arg(long)]
+        category: Option<String>,
+        /// Filter by scope (universal, language:X, project:X)
+        #[arg(long)]
+        scope: Option<String>,
+        /// Filter by source peer
+        #[arg(long)]
+        peer: Option<String>,
+        /// Minimum effective confidence (0.0 to 1.0)
+        #[arg(long, default_value_t = 0.0)]
+        min_confidence: f64,
+        /// Include shared artifacts (skills/commands/hooks)
+        #[arg(long)]
+        include_artifacts: bool,
+        /// Cap results to top N rows
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+    },
+
+    /// Rank peers by avg confidence in a category (who to learn from)
+    Experts {
+        /// Category to rank by (best_practice, technique, workflow, personal)
+        category: String,
+        /// Cap results to top N peers
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+    },
+
+    /// Preview the curated welcome snapshot a fresh peer would receive
+    Welcome,
 }
 
 /// Dispatch a hive subcommand.
@@ -258,6 +292,24 @@ pub fn dispatch_command(command: &HiveCommand, json_mode: bool) -> io::Result<()
         } => cmd_dead_weight(*min_injected, *max_decided, json_mode),
         HiveCommand::Peers => cmd_peer_effectiveness(json_mode),
         HiveCommand::Review { unfreeze } => cmd_review(unfreeze.as_deref(), json_mode),
+        HiveCommand::Explore {
+            category,
+            scope,
+            peer,
+            min_confidence,
+            include_artifacts,
+            limit,
+        } => cmd_explore(
+            category.as_deref(),
+            scope.as_deref(),
+            peer.as_deref(),
+            *min_confidence,
+            *include_artifacts,
+            *limit,
+            json_mode,
+        ),
+        HiveCommand::Experts { category, limit } => cmd_experts(category, *limit, json_mode),
+        HiveCommand::Welcome => cmd_welcome(json_mode),
     }
 }
 
@@ -332,6 +384,199 @@ fn cmd_review(unfreeze: Option<&str>, json_mode: bool) -> io::Result<()> {
         }
     }
 
+    Ok(())
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Discovery commands (#227)
+// ────────────────────────────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+fn cmd_explore(
+    category: Option<&str>,
+    scope: Option<&str>,
+    peer: Option<&str>,
+    min_confidence: f64,
+    include_artifacts: bool,
+    limit: usize,
+    json_mode: bool,
+) -> io::Result<()> {
+    let store = HiveStore::load();
+    let trust = super::trust::TrustStore::load();
+    let parsed_scope = scope.map(parse_scope);
+    let filter = super::discovery::ExploreFilter {
+        category,
+        scope: parsed_scope.as_ref(),
+        peer,
+        min_confidence,
+        include_artifacts,
+    };
+    let rows = super::discovery::explore(&store, &trust, &filter, limit);
+
+    if json_mode {
+        let arr: Vec<serde_json::Value> = rows
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "id": r.unit.id,
+                    "scope": r.unit.scope.to_string(),
+                    "category": r.unit.category.label(),
+                    "peer": r.unit.source_peer,
+                    "tier": r.tier.label(),
+                    "effective_confidence": r.effective_confidence,
+                    "evidence": r.unit.evidence_count,
+                    "rollout": r.unit.injection_state.label(),
+                    "summary": r.unit.content.summary_line(),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&arr).unwrap());
+        return Ok(());
+    }
+
+    if rows.is_empty() {
+        println!("No knowledge units match the filter.");
+        return Ok(());
+    }
+
+    println!(
+        "{:<12} {:<20} {:<6} {:<20} CONTENT",
+        "ID", "TIER", "CONF", "PEER"
+    );
+    println!("{}", "─".repeat(96));
+    for r in &rows {
+        let id_short = if r.unit.id.len() > 11 {
+            &r.unit.id[..11]
+        } else {
+            &r.unit.id
+        };
+        let peer_short = if r.unit.source_peer.len() > 19 {
+            &r.unit.source_peer[..19]
+        } else {
+            &r.unit.source_peer
+        };
+        println!(
+            "{:<12} {:<20} {:<6.0}% {:<20} {}",
+            id_short,
+            r.tier.label(),
+            r.effective_confidence * 100.0,
+            peer_short,
+            r.unit.content.summary_line(),
+        );
+    }
+    println!();
+    println!("{} units shown", rows.len());
+    Ok(())
+}
+
+fn cmd_experts(category: &str, limit: usize, json_mode: bool) -> io::Result<()> {
+    let store = HiveStore::load();
+    let trust = super::trust::TrustStore::load();
+    let rows = super::discovery::experts(&store, &trust, category, limit);
+
+    if json_mode {
+        let arr: Vec<serde_json::Value> = rows
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "peer_id": r.peer_id,
+                    "category": r.category,
+                    "tier": r.tier.label(),
+                    "unit_count": r.unit_count,
+                    "avg_confidence": r.avg_confidence,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&arr).unwrap());
+        return Ok(());
+    }
+
+    if rows.is_empty() {
+        println!("No peers contribute to category '{category}'.");
+        return Ok(());
+    }
+
+    println!(
+        "{:<24} {:<20} {:<6} {:<6}",
+        "PEER", "TIER", "UNITS", "AVG CONF"
+    );
+    println!("{}", "─".repeat(72));
+    for r in &rows {
+        let peer_short = if r.peer_id.len() > 23 {
+            &r.peer_id[..23]
+        } else {
+            &r.peer_id
+        };
+        println!(
+            "{:<24} {:<20} {:<6} {:<6.0}%",
+            peer_short,
+            r.tier.label(),
+            r.unit_count,
+            r.avg_confidence * 100.0,
+        );
+    }
+    println!();
+    println!("{} peers in category '{category}'", rows.len());
+    Ok(())
+}
+
+fn cmd_welcome(json_mode: bool) -> io::Result<()> {
+    let store = HiveStore::load();
+    let trust = super::trust::TrustStore::load();
+    let units = super::discovery::welcome_snapshot(&store, &trust);
+
+    if json_mode {
+        let arr: Vec<serde_json::Value> = units
+            .iter()
+            .map(|u| {
+                serde_json::json!({
+                    "id": u.id,
+                    "scope": u.scope.to_string(),
+                    "category": u.category.label(),
+                    "peer": u.source_peer,
+                    "confidence": u.confidence,
+                    "summary": u.content.summary_line(),
+                })
+            })
+            .collect();
+        let payload = serde_json::json!({
+            "size": units.len(),
+            "max_units": super::discovery::WELCOME_MAX_UNITS,
+            "min_confidence": super::discovery::WELCOME_MIN_CONFIDENCE,
+            "units": arr,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload).unwrap());
+        return Ok(());
+    }
+
+    println!(
+        "Welcome snapshot ({} units, max {}, min confidence {:.0}%):",
+        units.len(),
+        super::discovery::WELCOME_MAX_UNITS,
+        super::discovery::WELCOME_MIN_CONFIDENCE * 100.0
+    );
+    if units.is_empty() {
+        println!();
+        println!("(empty — no Live units from Suggested+ peers above the confidence floor)");
+        return Ok(());
+    }
+    println!("{}", "─".repeat(96));
+    println!("{:<12} {:<6} {:<20} CONTENT", "ID", "CONF", "PEER");
+    for u in &units {
+        let id_short = if u.id.len() > 11 { &u.id[..11] } else { &u.id };
+        let peer_short = if u.source_peer.len() > 19 {
+            &u.source_peer[..19]
+        } else {
+            &u.source_peer
+        };
+        println!(
+            "{:<12} {:<6.0}% {:<20} {}",
+            id_short,
+            u.confidence * 100.0,
+            peer_short,
+            u.content.summary_line(),
+        );
+    }
     Ok(())
 }
 

--- a/src/hive/discovery.rs
+++ b/src/hive/discovery.rs
@@ -1,0 +1,755 @@
+// Discoverability queries (#227) — lets users browse what the hive knows
+// before it auto-injects, and lets new peers receive a curated welcome
+// snapshot rather than the firehose.
+//
+// All functions are pure over a `HiveStore` snapshot and take a separate
+// `TrustStore` reference for tier filtering. No I/O, no mutation.
+
+use std::collections::HashMap;
+
+use super::store::HiveStore;
+use super::trust::{TrustStore, TrustTier};
+use super::{KnowledgeContent, KnowledgeUnit, effective_confidence, epoch_secs};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Welcome snapshot defaults
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Min effective confidence a unit must clear to appear in a welcome snapshot.
+pub const WELCOME_MIN_CONFIDENCE: f64 = 0.7;
+
+/// Cap on how many units appear in a welcome snapshot. Enough to be useful,
+/// small enough that a fresh peer isn't drowned.
+pub const WELCOME_MAX_UNITS: usize = 50;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Explore filter
+// ────────────────────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+pub struct ExploreFilter<'a> {
+    pub category: Option<&'a str>,
+    pub scope: Option<&'a super::KnowledgeScope>,
+    pub peer: Option<&'a str>,
+    pub min_confidence: f64,
+    pub include_artifacts: bool,
+}
+
+impl ExploreFilter<'_> {
+    fn matches(&self, unit: &KnowledgeUnit, eff_conf: f64) -> bool {
+        if !self.include_artifacts
+            && matches!(
+                &unit.content,
+                KnowledgeContent::Skill { .. }
+                    | KnowledgeContent::Command { .. }
+                    | KnowledgeContent::HookConfig { .. }
+            )
+        {
+            return false;
+        }
+        if let Some(c) = self.category {
+            if unit.category.label() != c {
+                return false;
+            }
+        }
+        if let Some(s) = self.scope {
+            if unit.scope != *s {
+                return false;
+            }
+        }
+        if let Some(p) = self.peer {
+            if unit.source_peer != p {
+                return false;
+            }
+        }
+        if eff_conf < self.min_confidence {
+            return false;
+        }
+        true
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Explore — ranked list of available knowledge
+// ────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct ExploreRow<'a> {
+    pub unit: &'a KnowledgeUnit,
+    pub effective_confidence: f64,
+    pub tier: TrustTier,
+}
+
+/// Build a ranked list of knowledge units that match the filter.
+///
+/// Sort order: trust tier desc (Confirmed first), then effective_confidence
+/// desc, then evidence_count desc — matches what a curious user expects.
+pub fn explore<'a>(
+    store: &'a HiveStore,
+    trust: &TrustStore,
+    filter: &ExploreFilter<'_>,
+    limit: usize,
+) -> Vec<ExploreRow<'a>> {
+    let now = epoch_secs();
+    let mut rows: Vec<ExploreRow<'a>> = store
+        .all_units()
+        .into_iter()
+        .filter_map(|unit| {
+            let eff = effective_confidence(unit, now);
+            if !filter.matches(unit, eff) {
+                return None;
+            }
+            let tier = trust
+                .get(&unit.source_peer)
+                .map(|t| t.tier())
+                .unwrap_or(TrustTier::Suggested);
+            Some(ExploreRow {
+                unit,
+                effective_confidence: eff,
+                tier,
+            })
+        })
+        .collect();
+
+    rows.sort_by(|a, b| {
+        tier_rank(b.tier)
+            .cmp(&tier_rank(a.tier))
+            .then_with(|| {
+                b.effective_confidence
+                    .partial_cmp(&a.effective_confidence)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| b.unit.evidence_count.cmp(&a.unit.evidence_count))
+    });
+    if limit > 0 && rows.len() > limit {
+        rows.truncate(limit);
+    }
+    rows
+}
+
+fn tier_rank(tier: TrustTier) -> u8 {
+    match tier {
+        TrustTier::Confirmed => 4,
+        TrustTier::Suggested => 3,
+        TrustTier::Unverified => 2,
+        TrustTier::Ignored => 1,
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Experts — peers ranked by category
+// ────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct ExpertRow {
+    pub peer_id: String,
+    pub category: String,
+    pub unit_count: u32,
+    pub avg_confidence: f64,
+    pub tier: TrustTier,
+}
+
+/// Rank peers by their average effective confidence in a category. Useful
+/// for "who do I learn from about Rust?" questions.
+pub fn experts(
+    store: &HiveStore,
+    trust: &TrustStore,
+    category: &str,
+    limit: usize,
+) -> Vec<ExpertRow> {
+    let now = epoch_secs();
+    let mut by_peer: HashMap<String, (u32, f64)> = HashMap::new();
+    for unit in store.all_units() {
+        if unit.category.label() != category {
+            continue;
+        }
+        // Skip artifact types — they don't contribute to "expertise" ranking.
+        if matches!(
+            &unit.content,
+            KnowledgeContent::Skill { .. }
+                | KnowledgeContent::Command { .. }
+                | KnowledgeContent::HookConfig { .. }
+        ) {
+            continue;
+        }
+        let entry = by_peer.entry(unit.source_peer.clone()).or_insert((0, 0.0));
+        entry.0 += 1;
+        entry.1 += effective_confidence(unit, now);
+    }
+
+    let mut rows: Vec<ExpertRow> = by_peer
+        .into_iter()
+        .map(|(peer_id, (count, sum_conf))| {
+            let tier = trust
+                .get(&peer_id)
+                .map(|t| t.tier())
+                .unwrap_or(TrustTier::Suggested);
+            ExpertRow {
+                peer_id,
+                category: category.to_string(),
+                unit_count: count,
+                avg_confidence: sum_conf / count as f64,
+                tier,
+            }
+        })
+        .collect();
+
+    rows.sort_by(|a, b| {
+        tier_rank(b.tier)
+            .cmp(&tier_rank(a.tier))
+            .then_with(|| {
+                b.avg_confidence
+                    .partial_cmp(&a.avg_confidence)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| b.unit_count.cmp(&a.unit_count))
+    });
+    if limit > 0 && rows.len() > limit {
+        rows.truncate(limit);
+    }
+    rows
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Welcome snapshot — what we'd send a fresh peer
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Build the curated welcome snapshot. Returns units a fresh peer should
+/// receive on first contact: only confidence ≥ WELCOME_MIN_CONFIDENCE,
+/// trust tier ≥ Suggested, in the Live rollout state, capped at
+/// WELCOME_MAX_UNITS sorted by effective_confidence desc.
+///
+/// Skill/Command/HookConfig artifacts are excluded — those go through the
+/// existing `hive shared` / accept flow, not the brain-decision welcome path.
+pub fn welcome_snapshot<'a>(store: &'a HiveStore, trust: &TrustStore) -> Vec<&'a KnowledgeUnit> {
+    let now = epoch_secs();
+    let mut rows: Vec<(&'a KnowledgeUnit, f64)> = store
+        .all_units()
+        .into_iter()
+        .filter(|u| {
+            // Only proven-rollout units make the welcome cut.
+            if !matches!(u.injection_state, super::InjectionState::Live) {
+                return false;
+            }
+            if matches!(
+                &u.content,
+                KnowledgeContent::Skill { .. }
+                    | KnowledgeContent::Command { .. }
+                    | KnowledgeContent::HookConfig { .. }
+            ) {
+                return false;
+            }
+            let tier = trust
+                .get(&u.source_peer)
+                .map(|t| t.tier())
+                .unwrap_or(TrustTier::Suggested);
+            if tier_rank(tier) < tier_rank(TrustTier::Suggested) {
+                return false;
+            }
+            true
+        })
+        .filter_map(|u| {
+            let eff = effective_confidence(u, now);
+            if eff >= WELCOME_MIN_CONFIDENCE {
+                Some((u, eff))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    rows.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.0.evidence_count.cmp(&a.0.evidence_count))
+    });
+    rows.into_iter()
+        .take(WELCOME_MAX_UNITS)
+        .map(|(u, _)| u)
+        .collect()
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hive::{
+        ApproachVariant, InjectionState, InjectionStats, KnowledgeCategory, KnowledgeContent,
+        KnowledgeScope, KnowledgeUnit,
+    };
+
+    #[allow(clippy::too_many_arguments)]
+    fn unit(
+        id: &str,
+        peer: &str,
+        cmd: &str,
+        category: KnowledgeCategory,
+        scope: KnowledgeScope,
+        confidence: f64,
+        evidence: u32,
+        state: InjectionState,
+    ) -> KnowledgeUnit {
+        KnowledgeUnit {
+            id: id.into(),
+            scope,
+            category,
+            content: KnowledgeContent::Pattern {
+                tool: "Bash".into(),
+                command_pattern: Some(cmd.into()),
+                preferred_action: "approve".into(),
+                accept_rate: confidence,
+                sample_count: evidence,
+                conditions: vec![],
+            },
+            evidence_count: evidence,
+            confidence,
+            source_peer: peer.into(),
+            originated_at: 0,
+            last_validated_at: epoch_secs(), // fresh — no decay
+            propagation_count: 0,
+            version: 1,
+            revalidation_interval_secs: 0,
+            injection_state: state,
+            injection_stats: InjectionStats::default(),
+        }
+    }
+
+    fn skill_unit(id: &str, peer: &str, name: &str) -> KnowledgeUnit {
+        KnowledgeUnit {
+            id: id.into(),
+            scope: KnowledgeScope::Universal,
+            category: KnowledgeCategory::Technique,
+            content: KnowledgeContent::Skill {
+                name: name.into(),
+                description: "test".into(),
+                version: "1.0".into(),
+                body: "body".into(),
+                requires: super::super::ArtifactRequires::default(),
+            },
+            evidence_count: 1,
+            confidence: 1.0,
+            source_peer: peer.into(),
+            originated_at: 0,
+            last_validated_at: epoch_secs(),
+            propagation_count: 0,
+            version: 1,
+            revalidation_interval_secs: 0,
+            injection_state: InjectionState::Live,
+            injection_stats: InjectionStats::default(),
+        }
+    }
+
+    fn empty_store() -> HiveStore {
+        HiveStore::load_from(std::path::Path::new("/nonexistent"))
+    }
+
+    fn pop_store(units: Vec<KnowledgeUnit>) -> HiveStore {
+        let mut store = empty_store();
+        for u in units {
+            store.insert(u);
+        }
+        store
+    }
+
+    #[test]
+    fn explore_filters_by_category() {
+        let store = pop_store(vec![
+            unit(
+                "ku_bp",
+                "peer-a",
+                "lsa",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.9,
+                10,
+                InjectionState::Live,
+            ),
+            unit(
+                "ku_tech",
+                "peer-b",
+                "lsb",
+                KnowledgeCategory::Technique,
+                KnowledgeScope::Universal,
+                0.9,
+                10,
+                InjectionState::Live,
+            ),
+        ]);
+        let trust = TrustStore::empty(0.6);
+        let filter = ExploreFilter {
+            category: Some("best_practice"),
+            ..Default::default()
+        };
+        let rows = explore(&store, &trust, &filter, 0);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].unit.id, "ku_bp");
+    }
+
+    #[test]
+    fn explore_filters_by_scope() {
+        let store = pop_store(vec![
+            unit(
+                "ku_uni",
+                "peer-a",
+                "x",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.9,
+                10,
+                InjectionState::Live,
+            ),
+            unit(
+                "ku_rust",
+                "peer-b",
+                "y",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Language("rust".into()),
+                0.9,
+                10,
+                InjectionState::Live,
+            ),
+        ]);
+        let trust = TrustStore::empty(0.6);
+        let scope = KnowledgeScope::Language("rust".into());
+        let filter = ExploreFilter {
+            scope: Some(&scope),
+            ..Default::default()
+        };
+        let rows = explore(&store, &trust, &filter, 0);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].unit.id, "ku_rust");
+    }
+
+    #[test]
+    fn explore_min_confidence() {
+        let store = pop_store(vec![
+            unit(
+                "ku_high",
+                "peer-a",
+                "x",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.9,
+                10,
+                InjectionState::Live,
+            ),
+            unit(
+                "ku_low",
+                "peer-b",
+                "y",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.4,
+                10,
+                InjectionState::Live,
+            ),
+        ]);
+        let trust = TrustStore::empty(0.6);
+        let filter = ExploreFilter {
+            min_confidence: 0.7,
+            ..Default::default()
+        };
+        let rows = explore(&store, &trust, &filter, 0);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].unit.id, "ku_high");
+    }
+
+    #[test]
+    fn explore_excludes_artifacts_by_default() {
+        let store = pop_store(vec![
+            unit(
+                "ku_pat",
+                "peer-a",
+                "x",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.9,
+                10,
+                InjectionState::Live,
+            ),
+            skill_unit("ku_skill", "peer-a", "session-monitoring"),
+        ]);
+        let trust = TrustStore::empty(0.6);
+        let rows = explore(&store, &trust, &ExploreFilter::default(), 0);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].unit.id, "ku_pat");
+    }
+
+    #[test]
+    fn explore_includes_artifacts_when_requested() {
+        let store = pop_store(vec![
+            unit(
+                "ku_pat",
+                "peer-a",
+                "x",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.9,
+                10,
+                InjectionState::Live,
+            ),
+            skill_unit("ku_skill", "peer-a", "session-monitoring"),
+        ]);
+        let trust = TrustStore::empty(0.6);
+        let filter = ExploreFilter {
+            include_artifacts: true,
+            ..Default::default()
+        };
+        let rows = explore(&store, &trust, &filter, 0);
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn explore_sorts_confirmed_before_suggested() {
+        let store = pop_store(vec![
+            unit(
+                "ku_a",
+                "peer-suggested",
+                "x",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.95,
+                10,
+                InjectionState::Live,
+            ),
+            unit(
+                "ku_b",
+                "peer-confirmed",
+                "y",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.7,
+                10,
+                InjectionState::Live,
+            ),
+        ]);
+        let mut trust = TrustStore::empty(0.6);
+        trust.set_trust("peer-confirmed", 0.9);
+        // peer-suggested left at default 0.6 = Suggested
+
+        let rows = explore(&store, &trust, &ExploreFilter::default(), 0);
+        // Even though ku_a has higher confidence, ku_b's Confirmed tier wins.
+        assert_eq!(rows[0].unit.id, "ku_b");
+        assert_eq!(rows[1].unit.id, "ku_a");
+    }
+
+    #[test]
+    fn experts_ranks_by_avg_confidence() {
+        let store = pop_store(vec![
+            unit(
+                "ku_a1",
+                "peer-a",
+                "x",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.9,
+                10,
+                InjectionState::Live,
+            ),
+            unit(
+                "ku_a2",
+                "peer-a",
+                "y",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.85,
+                10,
+                InjectionState::Live,
+            ),
+            unit(
+                "ku_b1",
+                "peer-b",
+                "z",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.6,
+                10,
+                InjectionState::Live,
+            ),
+            unit(
+                "ku_other_cat",
+                "peer-a",
+                "w",
+                KnowledgeCategory::Technique,
+                KnowledgeScope::Universal,
+                0.95,
+                10,
+                InjectionState::Live,
+            ),
+        ]);
+        let trust = TrustStore::empty(0.6);
+        let rows = experts(&store, &trust, "best_practice", 0);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].peer_id, "peer-a");
+        assert_eq!(rows[0].unit_count, 2);
+        assert!((rows[0].avg_confidence - 0.875).abs() < 1e-9);
+        assert_eq!(rows[1].peer_id, "peer-b");
+    }
+
+    #[test]
+    fn experts_skips_artifact_types() {
+        let store = pop_store(vec![skill_unit("ku_skill", "peer-a", "test")]);
+        let trust = TrustStore::empty(0.6);
+        let rows = experts(&store, &trust, "technique", 0);
+        // Skills are excluded from expertise ranking
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn welcome_snapshot_filters_low_confidence() {
+        let store = pop_store(vec![
+            unit(
+                "ku_high",
+                "peer-a",
+                "x",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.9,
+                10,
+                InjectionState::Live,
+            ),
+            unit(
+                "ku_low",
+                "peer-a",
+                "y",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.5, // below WELCOME_MIN_CONFIDENCE
+                10,
+                InjectionState::Live,
+            ),
+        ]);
+        let trust = TrustStore::empty(0.6);
+        let snap = welcome_snapshot(&store, &trust);
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].id, "ku_high");
+    }
+
+    #[test]
+    fn welcome_snapshot_excludes_canary_state() {
+        let store = pop_store(vec![
+            unit(
+                "ku_canary",
+                "peer-a",
+                "x",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.9,
+                10,
+                InjectionState::Canary,
+            ),
+            unit(
+                "ku_live",
+                "peer-a",
+                "y",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.9,
+                10,
+                InjectionState::Live,
+            ),
+        ]);
+        let trust = TrustStore::empty(0.6);
+        let snap = welcome_snapshot(&store, &trust);
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].id, "ku_live");
+    }
+
+    #[test]
+    fn welcome_snapshot_excludes_unverified_peers() {
+        let store = pop_store(vec![unit(
+            "ku_a",
+            "peer-untrusted",
+            "x",
+            KnowledgeCategory::BestPractice,
+            KnowledgeScope::Universal,
+            0.9,
+            10,
+            InjectionState::Live,
+        )]);
+        let mut trust = TrustStore::empty(0.6);
+        trust.set_trust("peer-untrusted", 0.3); // Unverified tier
+        let snap = welcome_snapshot(&store, &trust);
+        assert!(snap.is_empty());
+    }
+
+    #[test]
+    fn welcome_snapshot_caps_at_max_units() {
+        let mut units = Vec::new();
+        for i in 0..(WELCOME_MAX_UNITS + 20) {
+            units.push(unit(
+                &format!("ku_{i}"),
+                "peer-a",
+                &format!("cmd_{i}"),
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.9,
+                10,
+                InjectionState::Live,
+            ));
+        }
+        let store = pop_store(units);
+        let trust = TrustStore::empty(0.6);
+        let snap = welcome_snapshot(&store, &trust);
+        assert_eq!(snap.len(), WELCOME_MAX_UNITS);
+    }
+
+    #[test]
+    fn welcome_snapshot_excludes_artifacts() {
+        let store = pop_store(vec![
+            unit(
+                "ku_pat",
+                "peer-a",
+                "x",
+                KnowledgeCategory::BestPractice,
+                KnowledgeScope::Universal,
+                0.9,
+                10,
+                InjectionState::Live,
+            ),
+            skill_unit("ku_skill", "peer-a", "test"),
+        ]);
+        let trust = TrustStore::empty(0.6);
+        let snap = welcome_snapshot(&store, &trust);
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].id, "ku_pat");
+    }
+
+    #[test]
+    fn explore_with_cluster_units() {
+        // Clusters should appear in explore even though their semantic_key
+        // and content type differ from Pattern. Sanity check.
+        let cluster = KnowledgeUnit {
+            id: "ku_cluster".into(),
+            scope: KnowledgeScope::Universal,
+            category: KnowledgeCategory::Technique,
+            content: KnowledgeContent::ApproachCluster {
+                problem_key: "Bash:test".into(),
+                variants: vec![ApproachVariant {
+                    approach_summary: "approve".into(),
+                    conditions: vec![],
+                    evidence: 5,
+                    contributing_peers: vec!["peer-a".into()],
+                    outcome_ref: None,
+                }],
+            },
+            evidence_count: 5,
+            confidence: 0.8,
+            source_peer: "peer-a".into(),
+            originated_at: 0,
+            last_validated_at: epoch_secs(),
+            propagation_count: 0,
+            version: 1,
+            revalidation_interval_secs: 0,
+            injection_state: InjectionState::Live,
+            injection_stats: InjectionStats::default(),
+        };
+        let store = pop_store(vec![cluster]);
+        let trust = TrustStore::empty(0.6);
+        let rows = explore(&store, &trust, &ExploreFilter::default(), 0);
+        assert_eq!(rows.len(), 1);
+    }
+}

--- a/src/hive/mod.rs
+++ b/src/hive/mod.rs
@@ -3,6 +3,7 @@
 pub mod accept;
 pub mod archive;
 pub mod cli;
+pub mod discovery;
 pub mod distiller;
 pub mod effectiveness;
 pub mod exposure;


### PR DESCRIPTION
Closes #227.

Makes the hive discoverable. Today the only way to see what the network knows is to wait for auto-injection — fine when it works, opaque when you're trying to understand or audit. This PR adds three pure-query commands and a curated welcome snapshot for fresh peers.

## What lands

**\`hive explore\`** — ranked list of units with filters:
\`\`\`
claudectl hive explore [--category X] [--scope Y] [--peer Z]
                       [--min-confidence 0.7] [--include-artifacts]
                       [--limit 50]
\`\`\`
Sort: trust tier desc → effective_confidence desc → evidence_count desc.

**\`hive experts <category>\`** — peers ranked by avg effective confidence in a category. \"Who do I learn from about Rust?\"

**\`hive welcome\`** — preview the curated subset a fresh peer would receive: Live rollout state, Suggested+ tier, confidence ≥ 0.7, capped at 50 units. Lets operators see what their node would push before any handshake.

All three support the global \`--json\` flag.

## Design

- New \`hive::discovery\` module: pure queries over \`HiveStore\` + \`TrustStore\` snapshots. No I/O, no mutation.
- Welcome snapshot deliberately excludes Skill/Command/HookConfig artifacts — those go through the existing \`hive shared\`/accept flow, not the brain-decision welcome path.
- The actual gossip-handshake integration (auto-send welcome on first peer contact) is left for a follow-up so the relay layer doesn't change in this PR.

## Test plan

- [ ] \`cargo build --all-features\`
- [ ] \`cargo test --all-features\` (693 passing, +14 new)
- [ ] \`cargo clippy --all-targets -- -D warnings\` (CI default-features mode)
- [ ] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [ ] \`cargo fmt --check\`
- [ ] Smoke-test: \`hive explore --limit 5\`, \`hive experts best_practice\`, \`hive welcome\`, \`--json\` variants

## Out of scope (follow-ups)

- Auto-send \`welcome_snapshot\` on first peer handshake (gossip layer)
- #228 Merger transparency — preserve clusters and emit MergeResolution events
- #229 Gossip convergence + epidemic dampening
- #230 Per-unit sharing consent

🤖 Generated with [Claude Code](https://claude.com/claude-code)