### PR TITLE
feat(brain): feed deny reasons back to Claude via continueOnBlock (#249)

### DIFF
--- a/claude-plugin/hooks/scripts/brain-gate.sh
+++ b/claude-plugin/hooks/scripts/brain-gate.sh
@@ -5,8 +5,11 @@
 # Receives tool call JSON on stdin from Claude Code:
 #   {"tool_name": "Bash", "tool_input": {"command": "rm -rf /"}}
 #
-# Outputs a decision:
-#   {"decision": "approve"} or {"decision": "deny", "reason": "..."}
+# Emits a hook response on stdout. For denies we emit both the legacy
+# `{"decision":"deny","reason":...}` field (for older Claude Code) and a
+# `hookSpecificOutput` envelope with `continueOnBlock:true` plus the brain's
+# reasoning as `systemMessage` / `permissionDecisionReason`, so newer runtimes
+# surface *why* the brain blocked into Claude's next turn (#249).
 #
 # Falls through silently (no output) when the brain abstains or is unavailable,
 # letting Claude Code's normal permission flow handle it.
@@ -33,25 +36,45 @@ fi
 # Read the tool call from stdin
 INPUT=$(cat)
 
-TOOL_NAME=$(echo "$INPUT" | sed -n 's/.*"tool_name" *: *"\([^"]*\)".*/\1/p')
+# Minimal JSON-string escaper for the no-jq fallback. Handles the chars that
+# would otherwise break a JSON literal: backslash, double quote, CR/LF, tab.
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+if command -v jq &>/dev/null; then
+    TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')
+    case "$TOOL_NAME" in
+        Bash) COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty') ;;
+        Write|Edit|NotebookEdit)
+            COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty') ;;
+        *) COMMAND=$(printf '%s' "$INPUT" | jq -c '.tool_input // {}' | head -c 200) ;;
+    esac
+else
+    TOOL_NAME=$(echo "$INPUT" | sed -n 's/.*"tool_name" *: *"\([^"]*\)".*/\1/p')
+    COMMAND=""
+    case "$TOOL_NAME" in
+        Bash)
+            COMMAND=$(echo "$INPUT" | sed -n 's/.*"command" *: *"\([^"]*\)".*/\1/p')
+            ;;
+        Write|Edit|NotebookEdit)
+            COMMAND=$(echo "$INPUT" | sed -n 's/.*"file_path" *: *"\([^"]*\)".*/\1/p')
+            ;;
+        *)
+            COMMAND=$(echo "$INPUT" | sed -n 's/.*"tool_input" *: *\({[^}]*}\).*/\1/p' | head -c 200)
+            ;;
+    esac
+fi
+
 if [ -z "$TOOL_NAME" ]; then
     exit 0
 fi
-
-# Extract command/input based on tool type
-COMMAND=""
-case "$TOOL_NAME" in
-    Bash)
-        COMMAND=$(echo "$INPUT" | sed -n 's/.*"command" *: *"\([^"]*\)".*/\1/p')
-        ;;
-    Write|Edit|NotebookEdit)
-        COMMAND=$(echo "$INPUT" | sed -n 's/.*"file_path" *: *"\([^"]*\)".*/\1/p')
-        ;;
-    *)
-        # For other tools, try to extract a reasonable input summary
-        COMMAND=$(echo "$INPUT" | sed -n 's/.*"tool_input" *: *\({[^}]*}\).*/\1/p' | head -c 200)
-        ;;
-esac
 
 # Resolve project name from cwd
 PROJECT=$(basename "${PWD:-unknown}")
@@ -62,29 +85,85 @@ PROJECT=$(basename "${PWD:-unknown}")
 # richer prompt context — see #237.
 RESULT=$(printf '%s' "$INPUT" | claudectl --brain --brain-query --tool "$TOOL_NAME" --tool-input "$COMMAND" --project "$PROJECT" 2>/dev/null) || exit 0
 
-# Parse the action from the JSON result
-ACTION=$(echo "$RESULT" | sed -n 's/.*"action" *: *"\([^"]*\)".*/\1/p')
-REASONING=$(echo "$RESULT" | sed -n 's/.*"reasoning" *: *"\([^"]*\)".*/\1/p')
-SOURCE=$(echo "$RESULT" | sed -n 's/.*"source" *: *"\([^"]*\)".*/\1/p')
-BELOW=$(echo "$RESULT" | sed -n 's/.*"below_threshold" *: *\(true\|false\).*/\1/p')
+# Parse the action from the JSON result. Prefer jq so multi-line / escaped
+# reasoning round-trips correctly; fall back to the existing sed pattern when
+# jq is missing.
+if command -v jq &>/dev/null; then
+    ACTION=$(printf '%s' "$RESULT" | jq -r '.action // empty')
+    REASONING=$(printf '%s' "$RESULT" | jq -r '.reasoning // empty')
+    SOURCE=$(printf '%s' "$RESULT" | jq -r '.source // empty')
+    BELOW=$(printf '%s' "$RESULT" | jq -r '.below_threshold // false')
+else
+    ACTION=$(echo "$RESULT" | sed -n 's/.*"action" *: *"\([^"]*\)".*/\1/p')
+    REASONING=$(echo "$RESULT" | sed -n 's/.*"reasoning" *: *"\([^"]*\)".*/\1/p')
+    SOURCE=$(echo "$RESULT" | sed -n 's/.*"source" *: *"\([^"]*\)".*/\1/p')
+    BELOW=$(echo "$RESULT" | sed -n 's/.*"below_threshold" *: *\(true\|false\).*/\1/p')
+fi
+
+emit_advisory() {
+    # Below-threshold approval — surface the brain's hesitation as
+    # additionalContext so Claude sees the reasoning even though we let the
+    # tool call proceed. No `decision` field → does not block.
+    local msg="claudectl brain is uncertain: $1"
+    if command -v jq &>/dev/null; then
+        jq -n --arg msg "$msg" '{hookSpecificOutput:{hookEventName:"PreToolUse",additionalContext:$msg}}'
+    else
+        local em
+        em=$(json_escape "$msg")
+        printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"%s"}}\n' "$em"
+    fi
+}
+
+emit_deny() {
+    # Emit both the legacy `decision`/`reason` (for older Claude Code) and the
+    # new `hookSpecificOutput.continueOnBlock` envelope (#249) so the brain's
+    # reasoning surfaces back into Claude's next turn instead of just stopping
+    # the call.
+    local reasoning="$1"
+    local sysmsg="claudectl brain blocked this call: $reasoning"
+    if command -v jq &>/dev/null; then
+        jq -n \
+            --arg r "claudectl: $reasoning" \
+            --arg dr "$reasoning" \
+            --arg sm "$sysmsg" \
+            '{
+                decision: "deny",
+                reason: $r,
+                hookSpecificOutput: {
+                    hookEventName: "PreToolUse",
+                    permissionDecision: "deny",
+                    permissionDecisionReason: $dr,
+                    continueOnBlock: true,
+                    systemMessage: $sm
+                }
+            }'
+    else
+        local er em
+        er=$(json_escape "$reasoning")
+        em=$(json_escape "$sysmsg")
+        printf '{"decision":"deny","reason":"claudectl: %s","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s","continueOnBlock":true,"systemMessage":"%s"}}\n' "$er" "$er" "$em"
+    fi
+}
 
 case "$ACTION" in
     approve)
         # In "on" mode: only auto-approve when confidence is above threshold
         # In "auto" mode: approve all brain approvals regardless of confidence
         if [ "$GATE_MODE" != "auto" ] && [ "$BELOW" = "true" ] && [ "$SOURCE" = "brain" ]; then
-            exit 0  # Fall through — let user decide
+            # #249: surface the brain's hesitation without blocking so Claude
+            # picks up the same context a human reviewer would have used.
+            if [ -n "$REASONING" ]; then
+                emit_advisory "$REASONING"
+            fi
+            exit 0
         fi
         echo '{"decision":"approve"}'
         ;;
     deny)
-        # Build reason string
-        if [ -n "$REASONING" ]; then
-            REASON="claudectl: $REASONING"
-        else
-            REASON="claudectl brain denied this action"
+        if [ -z "$REASONING" ]; then
+            REASONING="claudectl brain denied this action"
         fi
-        printf '{"decision":"deny","reason":"%s"}\n' "$REASON"
+        emit_deny "$REASONING"
         ;;
     *)
         # abstain, error, or unknown — fall through

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1519,3 +1519,238 @@ fn reaper_test_failure_respects_fanout_window() {
         "edits outside the fan-out window should not be tagged"
     );
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// #249: brain-gate.sh continueOnBlock envelope
+// ────────────────────────────────────────────────────────────────────────────
+//
+// Each test sets HOME and PATH to a tempdir, drops a stub `claudectl` shell
+// script that emits a scripted JSON response, runs `brain-gate.sh` with a
+// hook payload on stdin, and asserts on the resulting envelope.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+fn hook_script_path() -> std::path::PathBuf {
+    // CARGO_MANIFEST_DIR points at the crate root regardless of where `cargo
+    // test` was invoked from.
+    let manifest = std::env::var("CARGO_MANIFEST_DIR")
+        .expect("CARGO_MANIFEST_DIR is set by cargo when running tests");
+    std::path::PathBuf::from(manifest).join("claude-plugin/hooks/scripts/brain-gate.sh")
+}
+
+/// Drop a stub `claudectl` executable into `dir/bin/`. The stub prints
+/// `stdout_body` verbatim (one line). Returns the bin/ directory to prepend
+/// onto PATH.
+fn install_stub_claudectl(dir: &Path, stdout_body: &str) -> std::path::PathBuf {
+    let bin = dir.join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let stub = bin.join("claudectl");
+    let script = format!("#!/usr/bin/env bash\ncat <<'CTL_EOF'\n{stdout_body}\nCTL_EOF\n");
+    std::fs::write(&stub, script).unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&stub).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&stub, perms).unwrap();
+    bin
+}
+
+/// Run brain-gate.sh with the given stdin payload, returning (stdout, status).
+fn run_brain_gate(
+    home: &Path,
+    stub_bin: Option<&Path>,
+    stdin_payload: &str,
+) -> (String, std::process::ExitStatus) {
+    let mut cmd = Command::new("bash");
+    cmd.arg(hook_script_path());
+    cmd.env("HOME", home);
+    if let Some(bin) = stub_bin {
+        let original_path = std::env::var("PATH").unwrap_or_default();
+        cmd.env("PATH", format!("{}:{original_path}", bin.display()));
+    } else {
+        // Force claudectl off the PATH so the hook exits early.
+        cmd.env("PATH", "/usr/bin:/bin");
+    }
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("spawn bash");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(stdin_payload.as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().expect("hook output");
+    (
+        String::from_utf8(output.stdout).expect("utf8 stdout"),
+        output.status,
+    )
+}
+
+#[test]
+fn brain_gate_deny_emits_continue_on_block_envelope() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = install_stub_claudectl(
+        tmp.path(),
+        r#"{"action":"deny","reasoning":"writes look like an AWS access key","confidence":0.95,"source":"brain","below_threshold":false}"#,
+    );
+
+    let (stdout, status) = run_brain_gate(
+        tmp.path(),
+        Some(&bin),
+        r#"{"tool_name":"Bash","tool_input":{"command":"echo secret"}}"#,
+    );
+    assert!(status.success(), "hook exited non-zero: {status:?}");
+
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("hook stdout not JSON: {e}\n{stdout}"));
+
+    // Legacy fields for older Claude Code runtimes.
+    assert_eq!(v["decision"], "deny");
+    assert!(
+        v["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("AWS access key"),
+        "legacy reason missing brain reasoning: {stdout}",
+    );
+
+    // New continueOnBlock envelope so the reasoning surfaces in Claude's
+    // next turn (#249).
+    let hso = &v["hookSpecificOutput"];
+    assert_eq!(hso["hookEventName"], "PreToolUse");
+    assert_eq!(hso["permissionDecision"], "deny");
+    assert_eq!(hso["continueOnBlock"], serde_json::Value::Bool(true));
+    assert!(
+        hso["permissionDecisionReason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("AWS access key"),
+    );
+    assert!(
+        hso["systemMessage"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("AWS access key"),
+    );
+}
+
+#[test]
+fn brain_gate_confident_approve_uses_legacy_envelope_only() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = install_stub_claudectl(
+        tmp.path(),
+        r#"{"action":"approve","reasoning":"safe read","confidence":0.95,"source":"brain","below_threshold":false}"#,
+    );
+    let (stdout, status) = run_brain_gate(
+        tmp.path(),
+        Some(&bin),
+        r#"{"tool_name":"Bash","tool_input":{"command":"ls"}}"#,
+    );
+    assert!(status.success());
+
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("approve JSON");
+    assert_eq!(v["decision"], "approve");
+    // We don't need hookSpecificOutput on a confident approval — the tool
+    // call sails through with no extra context noise.
+    assert!(v.get("hookSpecificOutput").is_none(), "stdout: {stdout}");
+}
+
+#[test]
+fn brain_gate_below_threshold_emits_advisory_additional_context() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = install_stub_claudectl(
+        tmp.path(),
+        r#"{"action":"approve","reasoning":"writing to .env — confidence low","confidence":0.4,"source":"brain","below_threshold":true}"#,
+    );
+    let (stdout, status) = run_brain_gate(
+        tmp.path(),
+        Some(&bin),
+        r#"{"tool_name":"Write","tool_input":{"file_path":".env"}}"#,
+    );
+    assert!(status.success());
+
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("advisory JSON");
+    // No decision → does not block; just surfaces context to Claude.
+    assert!(v.get("decision").is_none(), "stdout: {stdout}");
+    let ctx = v["hookSpecificOutput"]["additionalContext"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        ctx.contains("uncertain"),
+        "advisory ctx missing prefix: {ctx}"
+    );
+    assert!(
+        ctx.contains("writing to .env"),
+        "advisory ctx missing reasoning: {ctx}"
+    );
+}
+
+#[test]
+fn brain_gate_off_mode_produces_no_output() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = install_stub_claudectl(
+        tmp.path(),
+        r#"{"action":"deny","reasoning":"would have blocked","confidence":0.99,"source":"brain","below_threshold":false}"#,
+    );
+    // Flip gate off.
+    let gate_dir = tmp.path().join(".claudectl/brain");
+    std::fs::create_dir_all(&gate_dir).unwrap();
+    std::fs::write(gate_dir.join("gate-mode"), "off").unwrap();
+
+    let (stdout, status) = run_brain_gate(
+        tmp.path(),
+        Some(&bin),
+        r#"{"tool_name":"Bash","tool_input":{"command":"echo secret"}}"#,
+    );
+    assert!(status.success());
+    assert!(
+        stdout.is_empty(),
+        "gate=off must emit nothing, got: {stdout:?}"
+    );
+}
+
+#[test]
+fn brain_gate_missing_claudectl_falls_through_silently() {
+    let tmp = tempfile::tempdir().unwrap();
+    // No stub installed → claudectl not on PATH.
+    let (stdout, status) = run_brain_gate(
+        tmp.path(),
+        None,
+        r#"{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}"#,
+    );
+    assert!(status.success());
+    assert!(
+        stdout.is_empty(),
+        "missing claudectl must fall through, got: {stdout:?}",
+    );
+}
+
+#[test]
+fn brain_gate_deny_preserves_special_chars_in_reasoning() {
+    // Brain returns reasoning that includes characters that would have broken
+    // the old sed-based extraction or an unescaped printf: embedded double
+    // quotes, a backslash, and a newline.
+    let tmp = tempfile::tempdir().unwrap();
+    // The brain's own JSON escapes the special chars; the stub emits it raw.
+    let stub_output = r#"{"action":"deny","reasoning":"saw \"AKIA\" prefix and a path C:\\Users\\secret\nrejecting","confidence":0.97,"source":"brain","below_threshold":false}"#;
+    let bin = install_stub_claudectl(tmp.path(), stub_output);
+    let (stdout, status) = run_brain_gate(
+        tmp.path(),
+        Some(&bin),
+        r#"{"tool_name":"Bash","tool_input":{"command":"echo k"}}"#,
+    );
+    assert!(status.success());
+
+    // The hook's stdout must still parse as JSON. This is the regression
+    // gate: prior implementation embedded reasoning into a printf format
+    // string and would corrupt output on quotes/newlines.
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("hook stdout not JSON: {e}\n{stdout}"));
+    assert_eq!(v["decision"], "deny");
+    let reason = v["hookSpecificOutput"]["permissionDecisionReason"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(reason.contains("AKIA"), "reason lost content: {reason}");
+}


### PR DESCRIPTION
## Summary
Closes #249. The brain stops being a wall and starts being a teacher: when it denies a tool call, the brain's actual reasoning now flows back into Claude's next turn instead of leaving Claude to guess why.

- `brain-gate.sh` emits both the legacy `{decision, reason}` (older Claude Code) and the new `hookSpecificOutput` envelope with `permissionDecision: "deny"`, `permissionDecisionReason: <reasoning>`, `continueOnBlock: true`, and `systemMessage` carrying a prefixed version of the reasoning.
- Below-threshold approvals — which previously fell through silently — now emit an advisory `additionalContext` so Claude still sees the brain's hesitation without being blocked.
- The hook now prefers `jq` for both parsing `--brain-query` output and constructing its envelope, with a manual JSON-escape fallback. This also fixes a latent bug where reasoning containing quotes, backslashes, or newlines could corrupt the hook's stdout (the old code embedded reasoning into a `printf` format string).

## Backwards compatibility
- Claude Code < 2.1.138 ignores `hookSpecificOutput` and uses the legacy `{decision, reason}` field — same behaviour as today.
- Claude Code ≥ 2.1.138 surfaces `permissionDecisionReason` / `systemMessage` to the model.
- `jq` is preferred but not required; the script keeps working on minimal envs via the bash fallback.

## Test plan
- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` — all suites green (575 bin + 579 lib + 78 integration + 8 unit = 1240 tests; 6 new tests for this PR)
- [x] Manual smoke test of all three paths (confident deny, confident approve, below-threshold advisory) via a stub `claudectl` on PATH; output is well-formed JSON parseable by `serde_json`.

New tests:
- **`brain_gate_deny_emits_continue_on_block_envelope`** — asserts both legacy `{decision:deny, reason}` and `hookSpecificOutput.{permissionDecision, permissionDecisionReason, continueOnBlock:true, systemMessage}` are present with the brain's reasoning embedded.
- **`brain_gate_confident_approve_uses_legacy_envelope_only`** — confident approvals stay as the minimal `{decision:approve}` line to avoid context noise.
- **`brain_gate_below_threshold_emits_advisory_additional_context`** — uncertain approvals emit `hookSpecificOutput.additionalContext` without a `decision` field.
- **`brain_gate_off_mode_produces_no_output`** — `gate-mode=off` is fully silent.
- **`brain_gate_missing_claudectl_falls_through_silently`** — no `claudectl` on PATH → no output, never blocks Claude Code.
- **`brain_gate_deny_preserves_special_chars_in_reasoning`** — regression gate: reasoning with embedded quotes, backslashes, and newlines round-trips into valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)