### PR TITLE
feat(tui): Skills & Hive — full-screen mode for discovering, sharing, and managing hives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.49.1] - 2026-05-27
+
+### Changed
+- **Skills & Hive is now a full-screen mode**, not a centered overlay. Pressing `K` swaps the entire frame from the session table to the Skills & Hive view; `Esc` / `K` / `q` returns to the table. Same two tabs (Skills, Hive) and same hotkeys as before.
+- **`K:skills` hint added to the bottom footer** of the session table so the shortcut is discoverable. Empty-state hint (no sessions) also calls out `K`.
+
 ## [0.49.0] - 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.49.0] - 2026-05-27
+
+### Added
+- **Skills & Hive TUI overlay** — press `K` from the TUI to open a Skills & Hive panel. Two tabs (Tab to switch):
+  - **Skills tab** lists every Claude Code skill on disk (scans `~/.claude/skills`, `~/.claude/plugins/*/skills`, and `<cwd>/.claude/skills`). A `✓` marker shows which skills are already shared with the local hive; `s` shares the highlighted skill via the existing hive pipeline. Honours the 32 KiB skill-share limit and surfaces a warning when a skill exceeds it.
+  - **Hive tab** shows local identity, listener status, and known peers (read from `~/.claudectl/relay/peers/`). Hotkeys: `h` start hive listener (spawns detached `claudectl relay serve`), `i` generate an invite (relay code, word phrase, and invite link, shown inline), `J` join a hive via pasted code/link/words (detached `claudectl relay join`), `r` refresh peers.
+- **`hive::cli::share_artifact_from_path()`** — public wrapper around the previously private CLI-only `cmd_share` so callers outside the dispatch table (the new TUI overlay) can share skills/commands/hooks without reimplementing frontmatter + scope parsing.
+- **`src/skills.rs`** — new skill discovery module with YAML frontmatter parsing, source classification (user / plugin / project), and a shared-key lookup that aligns with the hive's `skill:<lowercased-name>` semantic key.
+
+### Technical details
+- Detached subprocess spawning for `relay serve` and `relay join` keeps the TUI event loop responsive; the invite generator shells out to `claudectl --json relay invite --words` and parses the JSON envelope.
+- New module wired into `src/lib.rs`, `src/main.rs`, and `src/ui/mod.rs`; help overlay (`?`) gains a `K` entry.
+- 585 tests passing (5 new: 3 for the skills module, 2 for the overlay rendering).
+
 ## [0.48.0] - 2026-05-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.49.2] - 2026-05-27
+
+### Fixed
+- **Skills & Hive footer now sticks to the bottom** of the screen. The previous version reserved 9 rows for the footer but only filled 3–4, leaving a band of empty space above the bottom border. Restructured so the body uses `Min` and the hint strip is a tight 1–2 rows pinned at the bottom; selected-skill detail (path + status) moves into the body section above the hint.
+
 ## [0.49.1] - 2026-05-27
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2024"
 description = "Mission control for Claude Code — supervise, orchestrate, and connect coding agents with a local LLM brain and hive mind"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2024"
 description = "Mission control for Claude Code — supervise, orchestrate, and connect coding agents with a local LLM brain and hive mind"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.49.1"
+version = "0.49.2"
 edition = "2024"
 description = "Mission control for Claude Code — supervise, orchestrate, and connect coding agents with a local LLM brain and hive mind"
 license = "MIT"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1926,15 +1926,13 @@ impl App {
 
     fn handle_skills_tab_key(&mut self, key: KeyEvent) {
         match (key.code, key.modifiers) {
-            (KeyCode::Char('j'), _) | (KeyCode::Down, _) => {
-                if !self.skills.is_empty() && self.skills_selected + 1 < self.skills.len() {
-                    self.skills_selected += 1;
-                }
+            (KeyCode::Char('j'), _) | (KeyCode::Down, _)
+                if !self.skills.is_empty() && self.skills_selected + 1 < self.skills.len() =>
+            {
+                self.skills_selected += 1;
             }
-            (KeyCode::Char('k'), _) | (KeyCode::Up, _) => {
-                if self.skills_selected > 0 {
-                    self.skills_selected -= 1;
-                }
+            (KeyCode::Char('k'), _) | (KeyCode::Up, _) if self.skills_selected > 0 => {
+                self.skills_selected -= 1;
             }
             (KeyCode::Char('r'), _) => {
                 self.refresh_skills();
@@ -2001,10 +1999,8 @@ impl App {
             KeyCode::Backspace => {
                 self.hive_join_buffer.pop();
             }
-            KeyCode::Char(c) => {
-                if self.hive_join_buffer.len() < 256 {
-                    self.hive_join_buffer.push(c);
-                }
+            KeyCode::Char(c) if self.hive_join_buffer.len() < 256 => {
+                self.hive_join_buffer.push(c);
             }
             _ => {}
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -344,6 +344,54 @@ pub struct App {
     /// Remote sessions received from connected worker peers (relay heartbeats).
     #[cfg(feature = "relay")]
     pub remote_sessions: Vec<crate::session::ClaudeSession>,
+
+    // ── Skills & Hive overlay state ────────────────────────────────────────
+    /// Whether the skills/hive overlay is open.
+    pub show_skills: bool,
+    /// Which tab is currently active inside the overlay.
+    pub skills_tab: SkillsTab,
+    /// Currently selected index into `skills`.
+    pub skills_selected: usize,
+    /// Discovered skills (refreshed when the overlay opens or `r` is pressed).
+    pub skills: Vec<crate::skills::DiscoveredSkill>,
+    /// Semantic keys (`skill:<name>`) for skills already present in the hive store.
+    pub shared_skill_keys: std::collections::HashSet<String>,
+    /// Transient status message shown in the overlay footer.
+    pub skills_status_msg: Option<String>,
+    /// True when a `claudectl relay serve` subprocess has been started from the TUI.
+    pub hive_listener_running: bool,
+    /// Local peer identity, populated when the Hive tab is opened.
+    pub hive_identity: Option<String>,
+    /// Known peers from the local relay state (peer id, optional last address).
+    pub hive_known_peers: Vec<(String, Option<String>)>,
+    /// Last invite generated from the TUI (held in memory only).
+    pub hive_last_invite: Option<HiveInvite>,
+    /// When true, the overlay captures text input for a join code.
+    pub hive_join_input_mode: bool,
+    /// Buffer for the join input.
+    pub hive_join_buffer: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillsTab {
+    Skills,
+    Hive,
+}
+
+impl SkillsTab {
+    pub fn toggle(self) -> Self {
+        match self {
+            Self::Skills => Self::Hive,
+            Self::Hive => Self::Skills,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HiveInvite {
+    pub relay_code: String,
+    pub invite_link: String,
+    pub word_phrase: String,
 }
 
 #[derive(Default, Clone)]
@@ -482,6 +530,18 @@ impl App {
             relay_peers: Vec::new(),
             #[cfg(feature = "relay")]
             remote_sessions: Vec::new(),
+            show_skills: false,
+            skills_tab: SkillsTab::Skills,
+            skills_selected: 0,
+            skills: Vec::new(),
+            shared_skill_keys: std::collections::HashSet::new(),
+            skills_status_msg: None,
+            hive_listener_running: false,
+            hive_identity: None,
+            hive_known_peers: Vec::new(),
+            hive_last_invite: None,
+            hive_join_input_mode: false,
+            hive_join_buffer: String::new(),
         };
         #[cfg(feature = "coord")]
         app.coord_refresh();
@@ -1711,6 +1771,12 @@ impl App {
             return true;
         }
 
+        // Skills overlay: dedicated keymap (j/k navigate, s share, h serve, r rescan, Esc/K close)
+        if self.show_skills {
+            self.handle_skills_key(key);
+            return true;
+        }
+
         // Override reason prompt: waiting for 1/2/3/Esc
         if self.pending_override_reason.is_some() {
             match key.code {
@@ -1807,6 +1873,209 @@ impl App {
         }
     }
 
+    pub fn open_skills_overlay(&mut self) {
+        self.refresh_skills();
+        self.refresh_hive_view();
+        self.skills_selected = 0;
+        self.skills_status_msg = None;
+        self.hive_join_input_mode = false;
+        self.hive_join_buffer.clear();
+        self.show_skills = true;
+    }
+
+    pub fn refresh_skills(&mut self) {
+        let cwd = std::env::current_dir().ok();
+        self.skills = crate::skills::discover(cwd.as_deref());
+        self.shared_skill_keys = load_shared_skill_keys();
+        if self.skills_selected >= self.skills.len() {
+            self.skills_selected = self.skills.len().saturating_sub(1);
+        }
+    }
+
+    pub fn refresh_hive_view(&mut self) {
+        let snapshot = load_hive_view_snapshot();
+        self.hive_identity = snapshot.identity;
+        self.hive_known_peers = snapshot.peers;
+    }
+
+    fn handle_skills_key(&mut self, key: KeyEvent) {
+        if self.hive_join_input_mode {
+            self.handle_hive_join_input(key);
+            return;
+        }
+
+        match (key.code, key.modifiers) {
+            (KeyCode::Esc, _) | (KeyCode::Char('K'), _) | (KeyCode::Char('q'), _) => {
+                self.show_skills = false;
+                self.skills_status_msg = None;
+                return;
+            }
+            (KeyCode::Tab, _) | (KeyCode::BackTab, _) => {
+                self.skills_tab = self.skills_tab.toggle();
+                self.skills_status_msg = None;
+                return;
+            }
+            _ => {}
+        }
+
+        match self.skills_tab {
+            SkillsTab::Skills => self.handle_skills_tab_key(key),
+            SkillsTab::Hive => self.handle_hive_tab_key(key),
+        }
+    }
+
+    fn handle_skills_tab_key(&mut self, key: KeyEvent) {
+        match (key.code, key.modifiers) {
+            (KeyCode::Char('j'), _) | (KeyCode::Down, _) => {
+                if !self.skills.is_empty() && self.skills_selected + 1 < self.skills.len() {
+                    self.skills_selected += 1;
+                }
+            }
+            (KeyCode::Char('k'), _) | (KeyCode::Up, _) => {
+                if self.skills_selected > 0 {
+                    self.skills_selected -= 1;
+                }
+            }
+            (KeyCode::Char('r'), _) => {
+                self.refresh_skills();
+                self.skills_status_msg = Some(format!("Rescanned: {} skills", self.skills.len()));
+            }
+            (KeyCode::Char('s'), _) => {
+                self.share_selected_skill();
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_hive_tab_key(&mut self, key: KeyEvent) {
+        match (key.code, key.modifiers) {
+            (KeyCode::Char('h'), _) => {
+                self.start_hive_listener();
+                self.refresh_hive_view();
+            }
+            (KeyCode::Char('i'), _) => {
+                self.generate_hive_invite();
+            }
+            (KeyCode::Char('J'), _) => {
+                self.hive_join_input_mode = true;
+                self.hive_join_buffer.clear();
+                self.skills_status_msg =
+                    Some("Paste invite (relay code, link, or word phrase); Enter to join".into());
+            }
+            (KeyCode::Char('r'), _) => {
+                self.refresh_hive_view();
+                self.skills_status_msg =
+                    Some(format!("Known peers: {}", self.hive_known_peers.len()));
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_hive_join_input(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Enter => {
+                let code = self.hive_join_buffer.trim().to_string();
+                self.hive_join_input_mode = false;
+                if code.is_empty() {
+                    self.skills_status_msg = Some("Join cancelled (empty)".into());
+                    return;
+                }
+                match spawn_relay_join(&code) {
+                    Ok(()) => {
+                        self.skills_status_msg = Some(format!(
+                            "Join started (claudectl relay join {} detached)",
+                            short_id(&code)
+                        ));
+                    }
+                    Err(e) => {
+                        self.skills_status_msg = Some(format!("Join failed: {e}"));
+                    }
+                }
+                self.hive_join_buffer.clear();
+            }
+            KeyCode::Esc => {
+                self.hive_join_input_mode = false;
+                self.hive_join_buffer.clear();
+                self.skills_status_msg = Some("Join cancelled".into());
+            }
+            KeyCode::Backspace => {
+                self.hive_join_buffer.pop();
+            }
+            KeyCode::Char(c) => {
+                if self.hive_join_buffer.len() < 256 {
+                    self.hive_join_buffer.push(c);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn generate_hive_invite(&mut self) {
+        match generate_invite_via_cli() {
+            Ok(invite) => {
+                self.skills_status_msg = Some(format!("Invite: {}", invite.relay_code));
+                self.hive_last_invite = Some(invite);
+            }
+            Err(e) => {
+                self.skills_status_msg = Some(format!("Invite failed: {e}"));
+            }
+        }
+    }
+
+    fn share_selected_skill(&mut self) {
+        let Some(skill) = self.skills.get(self.skills_selected).cloned() else {
+            self.skills_status_msg = Some("No skill selected".into());
+            return;
+        };
+        if !cfg!(feature = "hive") {
+            self.skills_status_msg = Some("hive feature disabled in this build".into());
+            return;
+        }
+        if !skill.within_share_limit() {
+            self.skills_status_msg = Some("Skill exceeds 32kb share limit".into());
+            return;
+        }
+        if self.shared_skill_keys.contains(&skill.semantic_key()) {
+            self.skills_status_msg = Some("Already shared".into());
+            return;
+        }
+        match share_skill_to_hive(&skill) {
+            Ok(unit_id) => {
+                self.shared_skill_keys.insert(skill.semantic_key());
+                self.skills_status_msg = Some(format!(
+                    "Shared '{}' → unit {}",
+                    skill.name,
+                    short_id(&unit_id)
+                ));
+            }
+            Err(e) => {
+                self.skills_status_msg = Some(format!("Share failed: {e}"));
+            }
+        }
+    }
+
+    fn start_hive_listener(&mut self) {
+        if !cfg!(feature = "relay") {
+            self.skills_status_msg =
+                Some("relay feature not built — rebuild with --features relay,hive".into());
+            return;
+        }
+        if self.hive_listener_running {
+            self.skills_status_msg = Some("Hive listener already running".into());
+            return;
+        }
+        match spawn_relay_serve() {
+            Ok(()) => {
+                self.hive_listener_running = true;
+                self.skills_status_msg =
+                    Some("Hive listener started (claudectl relay serve detached)".into());
+            }
+            Err(e) => {
+                self.skills_status_msg = Some(format!("Start failed: {e}"));
+            }
+        }
+    }
+
     fn handle_normal_key(&mut self, key: KeyEvent) {
         match (key.code, key.modifiers) {
             (KeyCode::Char('q'), _) | (KeyCode::Esc, _) => {
@@ -1873,6 +2142,11 @@ impl App {
                 self.cancel_pending_kill();
                 self.cancel_pending_auto_approve();
                 self.show_help = !self.show_help;
+            }
+            (KeyCode::Char('K'), _) => {
+                self.cancel_pending_kill();
+                self.cancel_pending_auto_approve();
+                self.open_skills_overlay();
             }
             (KeyCode::Char('s'), _) => {
                 self.cancel_pending_kill();
@@ -2451,6 +2725,173 @@ impl App {
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
         result
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Skills overlay helpers — kept at module scope so the App methods stay short.
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Collect semantic keys for skills already in the local hive store.
+///
+/// The hive `semantic_key` is `<scope>/skill:<lowered-name>`; we strip the
+/// scope prefix here because `DiscoveredSkill::semantic_key()` is scope-less.
+fn load_shared_skill_keys() -> std::collections::HashSet<String> {
+    #[cfg(feature = "hive")]
+    {
+        let store = crate::hive::store::HiveStore::load();
+        let mut out = std::collections::HashSet::new();
+        for unit in store.all_units() {
+            if let crate::hive::KnowledgeContent::Skill { name, .. } = &unit.content {
+                out.insert(format!("skill:{}", name.to_lowercase().replace(' ', "-")));
+            }
+        }
+        out
+    }
+    #[cfg(not(feature = "hive"))]
+    {
+        std::collections::HashSet::new()
+    }
+}
+
+/// Share a discovered skill into the local hive store. Returns the new unit ID.
+fn share_skill_to_hive(skill: &crate::skills::DiscoveredSkill) -> Result<String, String> {
+    #[cfg(feature = "hive")]
+    {
+        let path_str = skill.path.to_string_lossy().to_string();
+        crate::hive::cli::share_artifact_from_path("skill", &path_str, "universal")
+            .map(|(unit_id, _summary)| unit_id)
+            .map_err(|e| e.to_string())
+    }
+    #[cfg(not(feature = "hive"))]
+    {
+        let _ = skill;
+        Err("hive feature disabled".into())
+    }
+}
+
+/// Detach a `claudectl relay serve` child so the TUI keeps running.
+#[cfg(feature = "relay")]
+fn spawn_relay_serve() -> Result<(), String> {
+    use std::process::{Command, Stdio};
+    Command::new(std::env::current_exe().unwrap_or_else(|_| "claudectl".into()))
+        .args(["relay", "serve"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(not(feature = "relay"))]
+fn spawn_relay_serve() -> Result<(), String> {
+    Err("relay feature not built".into())
+}
+
+/// Detach a `claudectl relay join <code>` child so the TUI keeps running.
+#[cfg(feature = "relay")]
+fn spawn_relay_join(code: &str) -> Result<(), String> {
+    use std::process::{Command, Stdio};
+    Command::new(std::env::current_exe().unwrap_or_else(|_| "claudectl".into()))
+        .args(["relay", "join", code])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(not(feature = "relay"))]
+fn spawn_relay_join(_code: &str) -> Result<(), String> {
+    Err("relay feature not built".into())
+}
+
+/// Snapshot of local hive state the overlay reads to render the Hive tab.
+pub struct HiveViewSnapshot {
+    pub identity: Option<String>,
+    /// (peer_id, optional last-known address)
+    pub peers: Vec<(String, Option<String>)>,
+}
+
+#[cfg(feature = "relay")]
+fn load_hive_view_snapshot() -> HiveViewSnapshot {
+    let identity = Some(crate::relay::load_or_create_identity().as_str().to_string());
+    let peers = crate::relay::list_known_peers()
+        .into_iter()
+        .map(|id| {
+            let addr = crate::relay::load_peer_meta(&id).and_then(|v| {
+                v.get("addr")
+                    .and_then(|a| a.as_str())
+                    .map(|s| s.to_string())
+            });
+            (id, addr)
+        })
+        .collect();
+    HiveViewSnapshot { identity, peers }
+}
+
+#[cfg(not(feature = "relay"))]
+fn load_hive_view_snapshot() -> HiveViewSnapshot {
+    HiveViewSnapshot {
+        identity: None,
+        peers: Vec::new(),
+    }
+}
+
+/// Shell out to `claudectl relay invite --json` and parse the result. We use
+/// the existing CLI path rather than re-implementing because invite generation
+/// has multiple components (crypto, LAN-IP detection, encoding) that already
+/// live there.
+#[cfg(feature = "relay")]
+fn generate_invite_via_cli() -> Result<HiveInvite, String> {
+    use std::process::Command;
+    let bin = std::env::current_exe().map_err(|e| e.to_string())?;
+    let output = Command::new(bin)
+        .args(["--json", "relay", "invite", "--words"])
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).map_err(|e| e.to_string())?;
+    let relay_code = parsed
+        .get("relay_code")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let invite_link = parsed
+        .get("invite_link")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let word_phrase = parsed
+        .get("word_phrase")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if relay_code.is_empty() {
+        return Err("invite payload missing relay_code".into());
+    }
+    Ok(HiveInvite {
+        relay_code,
+        invite_link,
+        word_phrase,
+    })
+}
+
+#[cfg(not(feature = "relay"))]
+fn generate_invite_via_cli() -> Result<HiveInvite, String> {
+    Err("relay feature not built".into())
+}
+
+fn short_id(id: &str) -> String {
+    if id.len() <= 12 {
+        id.to_string()
+    } else {
+        format!("{}…", &id[..11])
     }
 }
 

--- a/src/hive/cli.rs
+++ b/src/hive/cli.rs
@@ -1864,8 +1864,38 @@ fn build_requires(
     }
 }
 
+/// Share a skill, command, or hook from disk into the local hive store.
+///
+/// Public wrapper around the internal `cmd_share` so callers outside the CLI
+/// dispatch (e.g. the TUI) can share artifacts without duplicating the
+/// frontmatter/scope plumbing. Returns the new unit ID and its summary line.
+pub fn share_artifact_from_path(
+    content_type: &str,
+    path: &str,
+    scope_str: &str,
+) -> io::Result<(String, String)> {
+    share_inner(content_type, path, scope_str)
+}
+
 /// `claudectl hive share <type> <path> [--scope X]`
 fn cmd_share(content_type: &str, path: &str, scope_str: &str, json_mode: bool) -> io::Result<()> {
+    let (unit_id, summary) = share_inner(content_type, path, scope_str)?;
+    if json_mode {
+        let output = serde_json::json!({
+            "action": "shared",
+            "unit_id": unit_id,
+            "content_type": content_type,
+            "summary": summary,
+        });
+        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+    } else {
+        println!("Shared {content_type}: {summary}");
+        println!("  Unit ID: {unit_id}");
+    }
+    Ok(())
+}
+
+fn share_inner(content_type: &str, path: &str, scope_str: &str) -> io::Result<(String, String)> {
     let body =
         std::fs::read_to_string(path).map_err(|e| io::Error::other(format!("read {path}: {e}")))?;
 
@@ -2024,20 +2054,7 @@ fn cmd_share(content_type: &str, path: &str, scope_str: &str, json_mode: bool) -
     #[cfg(feature = "relay")]
     super::signal_new_knowledge(1);
 
-    if json_mode {
-        let output = serde_json::json!({
-            "action": "shared",
-            "unit_id": unit_id,
-            "content_type": content_type,
-            "summary": summary,
-        });
-        println!("{}", serde_json::to_string_pretty(&output).unwrap());
-    } else {
-        println!("Shared {content_type}: {summary}");
-        println!("  Unit ID: {unit_id}");
-    }
-
-    Ok(())
+    Ok((unit_id, summary))
 }
 
 /// Outcome of an artifact write — used by both interactive install and auto-accept.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod relay;
 pub mod rules;
 pub mod session;
 pub mod session_recorder;
+pub mod skills;
 pub mod terminals;
 pub mod theme;
 pub mod transcript;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod relay;
 mod rules;
 mod session;
 mod session_recorder;
+mod skills;
 mod terminals;
 mod theme;
 mod transcript;

--- a/src/main.rs
+++ b/src/main.rs
@@ -872,6 +872,12 @@ fn run_tui<W: io::Write>(
         terminal.draw(|frame| {
             let area = frame.area();
 
+            // Full-screen mode: Skills & Hive takes over the entire frame.
+            if app.show_skills {
+                ui::skills::render_skills_screen(frame, area, &app);
+                return;
+            }
+
             #[cfg(feature = "relay")]
             let main_area = if app.show_peers_panel {
                 let chunks = ratatui::layout::Layout::default()

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,0 +1,288 @@
+// Skill discovery: scans the standard Claude Code skill locations and returns
+// metadata parsed from each skill's YAML frontmatter.
+//
+// Skills can live in three shapes:
+//   1. ~/.claude/skills/<name>/SKILL.md            (user-installed)
+//   2. ~/.claude/plugins/<plugin>/skills/<name>/   (shipped by a plugin)
+//   3. <cwd>/.claude/skills/<name>/SKILL.md        (project-local)
+//
+// We also accept the flat form ~/.claude/skills/<name>.md for compatibility
+// with older skill layouts.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::helpers::dirs_home;
+
+/// Where a discovered skill came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillSource {
+    /// `~/.claude/skills/...`
+    User,
+    /// `~/.claude/plugins/<plugin>/skills/...`
+    Plugin,
+    /// `<cwd>/.claude/skills/...`
+    Project,
+}
+
+impl SkillSource {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Plugin => "plugin",
+            Self::Project => "project",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscoveredSkill {
+    /// Skill name (from frontmatter `name`, falls back to directory name).
+    pub name: String,
+    /// One-line description from frontmatter (empty if not present).
+    pub description: String,
+    /// Path to the skill's markdown file (the one we'd share).
+    pub path: PathBuf,
+    /// Where it was discovered.
+    pub source: SkillSource,
+    /// Plugin name, if `source == Plugin`.
+    pub plugin: Option<String>,
+    /// File size in bytes.
+    pub size_bytes: u64,
+}
+
+impl DiscoveredSkill {
+    /// Stable key used to compare against shared knowledge units. Matches
+    /// the semantic key shape in src/hive/mod.rs (`skill:<lowercased-name>`).
+    pub fn semantic_key(&self) -> String {
+        format!("skill:{}", self.name.to_lowercase().replace(' ', "-"))
+    }
+
+    /// True if the skill body is small enough to fit in a hive `Skill` unit.
+    pub fn within_share_limit(&self) -> bool {
+        // Mirrors crate::hive::MAX_SKILL_BYTES (32 KiB) but we keep this module
+        // free of the hive feature gate so the TUI can list skills even when
+        // hive is disabled.
+        self.size_bytes <= 32 * 1024
+    }
+}
+
+/// Scan all known skill locations.
+///
+/// `project_root` is the directory used for project-local skills — pass the
+/// current working directory (or None to skip the project sweep).
+pub fn discover(project_root: Option<&Path>) -> Vec<DiscoveredSkill> {
+    let mut out = Vec::new();
+    let home = dirs_home();
+
+    scan_skill_root(
+        &home.join(".claude/skills"),
+        SkillSource::User,
+        None,
+        &mut out,
+    );
+
+    let plugins_root = home.join(".claude/plugins");
+    if let Ok(entries) = fs::read_dir(&plugins_root) {
+        for entry in entries.flatten() {
+            let plugin_dir = entry.path();
+            if !plugin_dir.is_dir() {
+                continue;
+            }
+            let plugin_name = plugin_dir
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("")
+                .to_string();
+            scan_skill_root(
+                &plugin_dir.join("skills"),
+                SkillSource::Plugin,
+                Some(plugin_name),
+                &mut out,
+            );
+        }
+    }
+
+    if let Some(root) = project_root {
+        scan_skill_root(
+            &root.join(".claude/skills"),
+            SkillSource::Project,
+            None,
+            &mut out,
+        );
+    }
+
+    out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    out
+}
+
+fn scan_skill_root(
+    root: &Path,
+    source: SkillSource,
+    plugin: Option<String>,
+    out: &mut Vec<DiscoveredSkill>,
+) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            // Conventional layout: <dir>/SKILL.md (or skill.md)
+            let candidates = [path.join("SKILL.md"), path.join("skill.md")];
+            for candidate in &candidates {
+                if candidate.exists() {
+                    if let Some(skill) = load_skill(candidate, source, plugin.clone(), Some(&path))
+                    {
+                        out.push(skill);
+                    }
+                    break;
+                }
+            }
+        } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
+            // Flat form: ~/.claude/skills/<name>.md
+            if let Some(skill) = load_skill(&path, source, plugin.clone(), None) {
+                out.push(skill);
+            }
+        }
+    }
+}
+
+fn load_skill(
+    path: &Path,
+    source: SkillSource,
+    plugin: Option<String>,
+    dir_for_fallback_name: Option<&Path>,
+) -> Option<DiscoveredSkill> {
+    let body = fs::read_to_string(path).ok()?;
+    let fm = parse_frontmatter(&body);
+
+    let fallback_name = dir_for_fallback_name
+        .and_then(|d| d.file_name())
+        .or_else(|| path.file_stem())
+        .and_then(|n| n.to_str())
+        .unwrap_or("(unnamed)")
+        .to_string();
+
+    let name = fm.get("name").cloned().unwrap_or(fallback_name);
+    let description = fm.get("description").cloned().unwrap_or_default();
+
+    let size_bytes = fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+
+    Some(DiscoveredSkill {
+        name,
+        description,
+        path: path.to_path_buf(),
+        source,
+        plugin,
+        size_bytes,
+    })
+}
+
+/// Lightweight YAML frontmatter parser. Mirrors hive::cli::parse_frontmatter but
+/// kept local so this module has no feature-gated dependencies.
+fn parse_frontmatter(content: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return map;
+    }
+    let after_open = &trimmed[3..].trim_start_matches('\r');
+    let after_open = after_open.strip_prefix('\n').unwrap_or(after_open);
+    let Some(close_pos) = after_open.find("\n---") else {
+        return map;
+    };
+    let yaml = &after_open[..close_pos];
+    for line in yaml.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((k, v)) = line.split_once(':') {
+            let key = k.trim().to_string();
+            let value = v.trim().trim_matches('"').trim_matches('\'').to_string();
+            if !key.is_empty() && !value.is_empty() {
+                map.insert(key, value);
+            }
+        }
+    }
+    map
+}
+
+/// Shared-status lookup against a set of semantic keys already present in the
+/// local hive store. Caller passes in the keys (lowercased) for skills that are
+/// already shared so we don't take a hive dependency here.
+pub fn is_shared(skill: &DiscoveredSkill, shared_keys: &std::collections::HashSet<String>) -> bool {
+    shared_keys.contains(&skill.semantic_key())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_skill(dir: &Path, name: &str, frontmatter: &str, body: &str) -> PathBuf {
+        let skill_dir = dir.join(name);
+        fs::create_dir_all(&skill_dir).unwrap();
+        let path = skill_dir.join("SKILL.md");
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "---\n{frontmatter}\n---").unwrap();
+        writeln!(f, "{body}").unwrap();
+        path
+    }
+
+    #[test]
+    fn parses_frontmatter_and_falls_back_to_dir_name() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("skills");
+        fs::create_dir_all(&root).unwrap();
+        write_skill(
+            &root,
+            "demo-skill",
+            "name: Demo Skill\ndescription: A demo.\nversion: 1.0",
+            "body",
+        );
+        write_skill(&root, "no-frontmatter", "", "just body");
+
+        let mut out = Vec::new();
+        scan_skill_root(&root, SkillSource::User, None, &mut out);
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].name, "Demo Skill");
+        assert_eq!(out[0].description, "A demo.");
+        assert_eq!(out[0].source, SkillSource::User);
+        assert_eq!(out[1].name, "no-frontmatter");
+        assert_eq!(out[1].description, "");
+    }
+
+    #[test]
+    fn semantic_key_matches_hive_shape() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("skills");
+        fs::create_dir_all(&root).unwrap();
+        write_skill(&root, "x", "name: Session Monitoring\n", "");
+        let mut out = Vec::new();
+        scan_skill_root(&root, SkillSource::User, None, &mut out);
+        assert_eq!(out[0].semantic_key(), "skill:session-monitoring");
+    }
+
+    #[test]
+    fn within_share_limit_respects_32k() {
+        let mut skill = DiscoveredSkill {
+            name: "a".into(),
+            description: String::new(),
+            path: PathBuf::new(),
+            source: SkillSource::User,
+            plugin: None,
+            size_bytes: 0,
+        };
+        assert!(skill.within_share_limit());
+        skill.size_bytes = 32 * 1024;
+        assert!(skill.within_share_limit());
+        skill.size_bytes = 32 * 1024 + 1;
+        assert!(!skill.within_share_limit());
+    }
+}

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -113,7 +113,7 @@ pub fn discover(project_root: Option<&Path>) -> Vec<DiscoveredSkill> {
         );
     }
 
-    out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    out.sort_by_key(|a| a.name.to_lowercase());
     out
 }
 

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -111,6 +111,10 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
             Span::raw("  Force refresh"),
         ]),
         Line::from(vec![
+            Span::styled("  K              ", Style::default().fg(t.highlight_key)),
+            Span::raw("  Skills & Hive — list skills, share to hive, start/invite/join"),
+        ]),
+        Line::from(vec![
             Span::styled("  ?              ", Style::default().fg(t.highlight_key)),
             Span::raw("  Toggle this help"),
         ]),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,5 +2,6 @@ pub mod detail;
 pub mod help;
 #[cfg(feature = "relay")]
 pub mod peers;
+pub mod skills;
 pub mod status_bar;
 pub mod table;

--- a/src/ui/skills.rs
+++ b/src/ui/skills.rs
@@ -22,9 +22,7 @@ pub fn render_skills_screen(frame: &mut Frame, area: Rect, app: &App) {
         Span::styled(" claudectl ", Style::default().fg(t.text_primary)),
         Span::styled(
             "│ Skills & Hive ",
-            Style::default()
-                .fg(t.header)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(t.header).add_modifier(Modifier::BOLD),
         ),
     ]);
     let block = Block::default()
@@ -384,9 +382,7 @@ fn render_footer(frame: &mut Frame, area: Rect, app: &App) {
         if !msg.is_empty() {
             lines.push(Line::from(Span::styled(
                 format!(" {msg}"),
-                Style::default()
-                    .fg(t.success)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(t.success).add_modifier(Modifier::BOLD),
             )));
         }
     }

--- a/src/ui/skills.rs
+++ b/src/ui/skills.rs
@@ -1,0 +1,402 @@
+// TUI overlay: lists Claude Code skills discovered on disk and, on its second
+// tab, exposes hive controls (identity, peers, invite, join, start). All
+// hive-side actions resolve to `claudectl relay …` subprocesses so the TUI
+// event loop stays responsive.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
+
+use crate::app::{App, SkillsTab};
+use crate::skills::DiscoveredSkill;
+use crate::theme::Theme;
+
+use super::help::centered_rect;
+
+pub fn render_skills_overlay(frame: &mut Frame, area: Rect, app: &App) {
+    let t = &app.theme;
+    let popup = centered_rect(82, 82, area);
+
+    frame.render_widget(Clear, popup);
+
+    let title = match app.skills_tab {
+        SkillsTab::Skills => " Skills & Hive — Skills ",
+        SkillsTab::Hive => " Skills & Hive — Hive ",
+    };
+    let outer = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(t.header));
+    let inner = outer.inner(popup);
+    frame.render_widget(outer, popup);
+
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2), // tab row
+            Constraint::Length(2), // header
+            Constraint::Min(3),    // body
+            Constraint::Length(8), // footer
+        ])
+        .split(inner);
+
+    render_tab_row(frame, layout[0], app);
+    render_status_header(frame, layout[1], app);
+    match app.skills_tab {
+        SkillsTab::Skills => render_skills_body(frame, layout[2], app),
+        SkillsTab::Hive => render_hive_body(frame, layout[2], app),
+    }
+    render_footer(frame, layout[3], app);
+}
+
+fn render_tab_row(frame: &mut Frame, area: Rect, app: &App) {
+    let t = &app.theme;
+    let mk = |label: &str, active: bool| {
+        let style = if active {
+            Style::default()
+                .fg(t.header)
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+        } else {
+            Style::default().fg(t.text_muted)
+        };
+        Span::styled(format!("  {label}  "), style)
+    };
+    let line = Line::from(vec![
+        mk("Skills", app.skills_tab == SkillsTab::Skills),
+        Span::raw("│"),
+        mk("Hive", app.skills_tab == SkillsTab::Hive),
+        Span::styled("    Tab to switch", Style::default().fg(t.text_muted)),
+    ]);
+    frame.render_widget(Paragraph::new(line), area);
+}
+
+fn render_status_header(frame: &mut Frame, area: Rect, app: &App) {
+    let t = &app.theme;
+    let hive_status = if cfg!(feature = "hive") {
+        "hive: on"
+    } else {
+        "hive: disabled (build feature off)"
+    };
+    let relay_status = if cfg!(feature = "relay") {
+        if app.hive_listener_running {
+            "relay: serving"
+        } else {
+            "relay: idle"
+        }
+    } else {
+        "relay: not built"
+    };
+
+    let body = match app.skills_tab {
+        SkillsTab::Skills => Line::from(vec![
+            Span::styled(
+                format!("{} skills discovered  ", app.skills.len()),
+                Style::default()
+                    .fg(t.text_primary)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("· {}  ", hive_status),
+                Style::default().fg(t.text_muted),
+            ),
+            Span::styled(
+                format!("· {}", relay_status),
+                Style::default().fg(t.text_muted),
+            ),
+        ]),
+        SkillsTab::Hive => {
+            let identity = app
+                .hive_identity
+                .as_deref()
+                .unwrap_or("(unknown — relay not built)");
+            Line::from(vec![
+                Span::styled("Identity: ", Style::default().fg(t.text_muted)),
+                Span::styled(
+                    identity,
+                    Style::default()
+                        .fg(t.text_primary)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled("    · ", Style::default().fg(t.text_muted)),
+                Span::styled(relay_status, Style::default().fg(t.text_muted)),
+            ])
+        }
+    };
+
+    frame.render_widget(Paragraph::new(vec![body, Line::from("")]), area);
+}
+
+fn render_skills_body(frame: &mut Frame, area: Rect, app: &App) {
+    let t = &app.theme;
+    if app.skills.is_empty() {
+        let para = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(Span::styled(
+                "  No skills found in ~/.claude/skills, ~/.claude/plugins/*/skills, or ./.claude/skills.",
+                Style::default().fg(t.text_muted),
+            )),
+        ])
+        .wrap(Wrap { trim: false });
+        frame.render_widget(para, area);
+        return;
+    }
+
+    let items: Vec<ListItem> = app
+        .skills
+        .iter()
+        .map(|s| ListItem::new(skill_line(s, app, t)))
+        .collect();
+
+    let mut state = ListState::default();
+    state.select(Some(
+        app.skills_selected.min(app.skills.len().saturating_sub(1)),
+    ));
+
+    let list = List::new(items)
+        .highlight_style(Style::default().fg(t.header).add_modifier(Modifier::BOLD))
+        .highlight_symbol("▶ ");
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn render_hive_body(frame: &mut Frame, area: Rect, app: &App) {
+    let t = &app.theme;
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Peers
+    lines.push(Line::from(Span::styled(
+        format!("Known peers ({})", app.hive_known_peers.len()),
+        Style::default().fg(t.header).add_modifier(Modifier::BOLD),
+    )));
+    if app.hive_known_peers.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  None yet. Press i for an invite, or J to join one.",
+            Style::default().fg(t.text_muted),
+        )));
+    } else {
+        for (id, addr) in &app.hive_known_peers {
+            let addr_str = addr.clone().unwrap_or_else(|| "(no last addr)".into());
+            lines.push(Line::from(vec![
+                Span::styled("  • ", Style::default().fg(t.text_muted)),
+                Span::styled(
+                    format!("{:<24}", id),
+                    Style::default()
+                        .fg(t.text_primary)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(addr_str, Style::default().fg(t.text_muted)),
+            ]));
+        }
+    }
+
+    // Last invite
+    if let Some(inv) = &app.hive_last_invite {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Last invite (share with peer)",
+            Style::default().fg(t.header).add_modifier(Modifier::BOLD),
+        )));
+        lines.push(kv_line(t, "  code:  ", &inv.relay_code));
+        if !inv.word_phrase.is_empty() {
+            lines.push(kv_line(t, "  words: ", &inv.word_phrase));
+        }
+        if !inv.invite_link.is_empty() {
+            lines.push(kv_line(t, "  link:  ", &inv.invite_link));
+        }
+    }
+
+    // Join input field
+    if app.hive_join_input_mode {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Join code (Enter to confirm, Esc to cancel):",
+            Style::default().fg(t.header).add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(vec![
+            Span::styled("  ▶ ", Style::default().fg(t.highlight_key)),
+            Span::styled(
+                app.hive_join_buffer.clone(),
+                Style::default().fg(t.text_primary),
+            ),
+            Span::styled("█", Style::default().fg(t.highlight_key)),
+        ]));
+    }
+
+    let para = Paragraph::new(lines).wrap(Wrap { trim: false });
+    frame.render_widget(para, area);
+}
+
+fn kv_line<'a>(t: &'a Theme, key: &'a str, value: &'a str) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(key, Style::default().fg(t.text_muted)),
+        Span::styled(value, Style::default().fg(t.text_primary)),
+    ])
+}
+
+fn skill_line<'a>(skill: &'a DiscoveredSkill, app: &'a App, t: &'a Theme) -> Line<'a> {
+    let shared = crate::skills::is_shared(skill, &app.shared_skill_keys);
+    let marker = if shared { "✓" } else { "·" };
+    let marker_color = if shared { t.success } else { t.text_muted };
+
+    let source_text = if let Some(p) = &skill.plugin {
+        format!("{}:{}", skill.source.label(), p)
+    } else {
+        skill.source.label().to_string()
+    };
+
+    let size_kb = (skill.size_bytes as f64) / 1024.0;
+    let too_big = !skill.within_share_limit();
+    let size_color = if too_big {
+        t.context_warning
+    } else {
+        t.text_muted
+    };
+
+    let desc = if skill.description.is_empty() {
+        "(no description)".to_string()
+    } else if skill.description.len() > 60 {
+        format!("{}…", &skill.description[..59])
+    } else {
+        skill.description.clone()
+    };
+
+    Line::from(vec![
+        Span::styled(format!(" {} ", marker), Style::default().fg(marker_color)),
+        Span::styled(
+            format!("{:<28}", truncate(&skill.name, 28)),
+            Style::default()
+                .fg(t.text_primary)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("{:<18}", truncate(&source_text, 18)),
+            Style::default().fg(t.text_muted),
+        ),
+        Span::styled(
+            format!("{:>6.1}kb  ", size_kb),
+            Style::default().fg(size_color),
+        ),
+        Span::styled(desc, Style::default().fg(t.text_muted)),
+    ])
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let cut: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{cut}…")
+    }
+}
+
+fn render_footer(frame: &mut Frame, area: Rect, app: &App) {
+    let t = &app.theme;
+    let mut lines = Vec::new();
+
+    match app.skills_tab {
+        SkillsTab::Skills => {
+            if let Some(s) = app.skills.get(app.skills_selected) {
+                let shared = crate::skills::is_shared(s, &app.shared_skill_keys);
+                lines.push(Line::from(vec![
+                    Span::styled("Path: ", Style::default().fg(t.text_muted)),
+                    Span::styled(
+                        s.path.display().to_string(),
+                        Style::default().fg(t.text_primary),
+                    ),
+                ]));
+                let status = if shared {
+                    "✓ already shared with hive"
+                } else if !s.within_share_limit() {
+                    "⚠ too large to share (>32kb)"
+                } else if !cfg!(feature = "hive") {
+                    "hive feature disabled in this build"
+                } else {
+                    "press s to share with hive"
+                };
+                lines.push(Line::from(vec![
+                    Span::styled("Status: ", Style::default().fg(t.text_muted)),
+                    Span::styled(status, Style::default().fg(t.text_primary)),
+                ]));
+            } else {
+                lines.push(Line::from(Span::styled(
+                    "Select a skill with j/k.",
+                    Style::default().fg(t.text_muted),
+                )));
+            }
+            lines.push(Line::from(""));
+            lines.push(Line::from(vec![
+                Span::styled("  j/k", Style::default().fg(t.highlight_key)),
+                Span::raw("  navigate     "),
+                Span::styled("s", Style::default().fg(t.highlight_key)),
+                Span::raw("  share with hive     "),
+                Span::styled("r", Style::default().fg(t.highlight_key)),
+                Span::raw("  rescan     "),
+                Span::styled("Tab", Style::default().fg(t.highlight_key)),
+                Span::raw("  Hive view     "),
+                Span::styled("Esc/K", Style::default().fg(t.highlight_key)),
+                Span::raw("  close"),
+            ]));
+        }
+        SkillsTab::Hive => {
+            lines.push(Line::from(Span::styled(
+                "Manage your hive — start a listener, invite peers, or join an existing one.",
+                Style::default().fg(t.text_muted),
+            )));
+            lines.push(Line::from(""));
+            lines.push(Line::from(vec![
+                Span::styled("  h", Style::default().fg(t.highlight_key)),
+                Span::raw("  start listener     "),
+                Span::styled("i", Style::default().fg(t.highlight_key)),
+                Span::raw("  generate invite     "),
+                Span::styled("J", Style::default().fg(t.highlight_key)),
+                Span::raw("  join via code     "),
+                Span::styled("r", Style::default().fg(t.highlight_key)),
+                Span::raw("  refresh peers     "),
+                Span::styled("Tab", Style::default().fg(t.highlight_key)),
+                Span::raw("  Skills view     "),
+                Span::styled("Esc/K", Style::default().fg(t.highlight_key)),
+                Span::raw("  close"),
+            ]));
+        }
+    }
+
+    if let Some(msg) = &app.skills_status_msg {
+        if !msg.is_empty() {
+            lines.push(Line::from(Span::styled(
+                format!("  {msg}"),
+                Style::default().fg(t.success).add_modifier(Modifier::BOLD),
+            )));
+        }
+    }
+
+    let para = Paragraph::new(lines).wrap(Wrap { trim: false });
+    frame.render_widget(para, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn truncates_long_strings() {
+        assert_eq!(truncate("short", 10), "short");
+        assert_eq!(truncate("abcdefghijklm", 6), "abcde…");
+    }
+
+    #[test]
+    fn skill_line_renders_shared_marker() {
+        let app = App::new();
+        let skill = DiscoveredSkill {
+            name: "X".into(),
+            description: "d".into(),
+            path: PathBuf::from("/tmp/x.md"),
+            source: crate::skills::SkillSource::User,
+            plugin: None,
+            size_bytes: 100,
+        };
+        let line = skill_line(&skill, &app, &app.theme);
+        assert!(!line.spans.is_empty());
+    }
+}

--- a/src/ui/skills.rs
+++ b/src/ui/skills.rs
@@ -34,13 +34,26 @@ pub fn render_skills_screen(frame: &mut Frame, area: Rect, app: &App) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
+    // Footer height adapts to whether there's a transient status message;
+    // either way it stays anchored to the bottom because the body uses Min.
+    let footer_height = if app
+        .skills_status_msg
+        .as_deref()
+        .map(|m| !m.is_empty())
+        .unwrap_or(false)
+    {
+        2
+    } else {
+        1
+    };
+
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(2), // tab row
-            Constraint::Length(2), // header
-            Constraint::Min(3),    // body
-            Constraint::Length(9), // footer
+            Constraint::Length(2),             // tab row
+            Constraint::Length(2),             // header
+            Constraint::Min(3),                // body (list + detail)
+            Constraint::Length(footer_height), // hint strip
         ])
         .split(inner);
 
@@ -145,6 +158,12 @@ fn render_skills_body(frame: &mut Frame, area: Rect, app: &App) {
         return;
     }
 
+    // Split body into the list (top) and a 2-line selected-skill detail (bottom).
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(3), Constraint::Length(2)])
+        .split(area);
+
     let items: Vec<ListItem> = app
         .skills
         .iter()
@@ -159,7 +178,39 @@ fn render_skills_body(frame: &mut Frame, area: Rect, app: &App) {
     let list = List::new(items)
         .highlight_style(Style::default().fg(t.header).add_modifier(Modifier::BOLD))
         .highlight_symbol("▶ ");
-    frame.render_stateful_widget(list, area, &mut state);
+    frame.render_stateful_widget(list, chunks[0], &mut state);
+
+    let detail = if let Some(s) = app.skills.get(app.skills_selected) {
+        let shared = crate::skills::is_shared(s, &app.shared_skill_keys);
+        let status = if shared {
+            "✓ already shared with hive"
+        } else if !s.within_share_limit() {
+            "⚠ too large to share (>32kb)"
+        } else if !cfg!(feature = "hive") {
+            "hive feature disabled in this build"
+        } else {
+            "press s to share with hive"
+        };
+        vec![
+            Line::from(vec![
+                Span::styled("Path:   ", Style::default().fg(t.text_muted)),
+                Span::styled(
+                    s.path.display().to_string(),
+                    Style::default().fg(t.text_primary),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("Status: ", Style::default().fg(t.text_muted)),
+                Span::styled(status, Style::default().fg(t.text_primary)),
+            ]),
+        ]
+    } else {
+        vec![Line::from(Span::styled(
+            "Select a skill with j/k.",
+            Style::default().fg(t.text_muted),
+        ))]
+    };
+    frame.render_widget(Paragraph::new(detail), chunks[1]);
 }
 
 fn render_hive_body(frame: &mut Frame, area: Rect, app: &App) {
@@ -292,88 +343,55 @@ fn truncate(s: &str, max: usize) -> String {
     }
 }
 
+/// Thin hint strip pinned to the bottom of the screen. Line 1 is the
+/// hotkey legend for the active tab; line 2 (if present) is a transient
+/// status message. The body section uses `Min` so this stays at the bottom.
 fn render_footer(frame: &mut Frame, area: Rect, app: &App) {
     let t = &app.theme;
     let mut lines = Vec::new();
 
-    match app.skills_tab {
-        SkillsTab::Skills => {
-            if let Some(s) = app.skills.get(app.skills_selected) {
-                let shared = crate::skills::is_shared(s, &app.shared_skill_keys);
-                lines.push(Line::from(vec![
-                    Span::styled("Path: ", Style::default().fg(t.text_muted)),
-                    Span::styled(
-                        s.path.display().to_string(),
-                        Style::default().fg(t.text_primary),
-                    ),
-                ]));
-                let status = if shared {
-                    "✓ already shared with hive"
-                } else if !s.within_share_limit() {
-                    "⚠ too large to share (>32kb)"
-                } else if !cfg!(feature = "hive") {
-                    "hive feature disabled in this build"
-                } else {
-                    "press s to share with hive"
-                };
-                lines.push(Line::from(vec![
-                    Span::styled("Status: ", Style::default().fg(t.text_muted)),
-                    Span::styled(status, Style::default().fg(t.text_primary)),
-                ]));
-            } else {
-                lines.push(Line::from(Span::styled(
-                    "Select a skill with j/k.",
-                    Style::default().fg(t.text_muted),
-                )));
-            }
-            lines.push(Line::from(""));
-            lines.push(Line::from(vec![
-                Span::styled("  j/k", Style::default().fg(t.highlight_key)),
-                Span::raw("  navigate     "),
-                Span::styled("s", Style::default().fg(t.highlight_key)),
-                Span::raw("  share with hive     "),
-                Span::styled("r", Style::default().fg(t.highlight_key)),
-                Span::raw("  rescan     "),
-                Span::styled("Tab", Style::default().fg(t.highlight_key)),
-                Span::raw("  Hive view     "),
-                Span::styled("Esc/K", Style::default().fg(t.highlight_key)),
-                Span::raw("  close"),
-            ]));
-        }
-        SkillsTab::Hive => {
-            lines.push(Line::from(Span::styled(
-                "Manage your hive — start a listener, invite peers, or join an existing one.",
-                Style::default().fg(t.text_muted),
-            )));
-            lines.push(Line::from(""));
-            lines.push(Line::from(vec![
-                Span::styled("  h", Style::default().fg(t.highlight_key)),
-                Span::raw("  start listener     "),
-                Span::styled("i", Style::default().fg(t.highlight_key)),
-                Span::raw("  generate invite     "),
-                Span::styled("J", Style::default().fg(t.highlight_key)),
-                Span::raw("  join via code     "),
-                Span::styled("r", Style::default().fg(t.highlight_key)),
-                Span::raw("  refresh peers     "),
-                Span::styled("Tab", Style::default().fg(t.highlight_key)),
-                Span::raw("  Skills view     "),
-                Span::styled("Esc/K", Style::default().fg(t.highlight_key)),
-                Span::raw("  close"),
-            ]));
-        }
-    }
+    let hint = match app.skills_tab {
+        SkillsTab::Skills => Line::from(vec![
+            Span::styled(" j/k", Style::default().fg(t.highlight_key)),
+            Span::raw(":nav  "),
+            Span::styled("s", Style::default().fg(t.highlight_key)),
+            Span::raw(":share  "),
+            Span::styled("r", Style::default().fg(t.highlight_key)),
+            Span::raw(":rescan  "),
+            Span::styled("Tab", Style::default().fg(t.highlight_key)),
+            Span::raw(":Hive  "),
+            Span::styled("Esc/K", Style::default().fg(t.highlight_key)),
+            Span::raw(":close"),
+        ]),
+        SkillsTab::Hive => Line::from(vec![
+            Span::styled(" h", Style::default().fg(t.highlight_key)),
+            Span::raw(":start  "),
+            Span::styled("i", Style::default().fg(t.highlight_key)),
+            Span::raw(":invite  "),
+            Span::styled("J", Style::default().fg(t.highlight_key)),
+            Span::raw(":join  "),
+            Span::styled("r", Style::default().fg(t.highlight_key)),
+            Span::raw(":refresh  "),
+            Span::styled("Tab", Style::default().fg(t.highlight_key)),
+            Span::raw(":Skills  "),
+            Span::styled("Esc/K", Style::default().fg(t.highlight_key)),
+            Span::raw(":close"),
+        ]),
+    };
+    lines.push(hint);
 
     if let Some(msg) = &app.skills_status_msg {
         if !msg.is_empty() {
             lines.push(Line::from(Span::styled(
-                format!("  {msg}"),
-                Style::default().fg(t.success).add_modifier(Modifier::BOLD),
+                format!(" {msg}"),
+                Style::default()
+                    .fg(t.success)
+                    .add_modifier(Modifier::BOLD),
             )));
         }
     }
 
-    let para = Paragraph::new(lines).wrap(Wrap { trim: false });
-    frame.render_widget(para, area);
+    frame.render_widget(Paragraph::new(lines), area);
 }
 
 #[cfg(test)]

--- a/src/ui/skills.rs
+++ b/src/ui/skills.rs
@@ -1,36 +1,38 @@
-// TUI overlay: lists Claude Code skills discovered on disk and, on its second
-// tab, exposes hive controls (identity, peers, invite, join, start). All
-// hive-side actions resolve to `claudectl relay …` subprocesses so the TUI
-// event loop stays responsive.
+// Full-screen Skills & Hive mode. When `app.show_skills` is set, the main
+// draw loop hands the whole frame to `render_skills_screen` instead of the
+// session table. Two tabs: Skills (discovered Claude Code skills + share)
+// and Hive (identity, peers, invite, join, start listener). All hive-side
+// actions resolve to `claudectl relay …` subprocesses so the TUI event loop
+// stays responsive.
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
 
 use crate::app::{App, SkillsTab};
 use crate::skills::DiscoveredSkill;
 use crate::theme::Theme;
 
-use super::help::centered_rect;
-
-pub fn render_skills_overlay(frame: &mut Frame, area: Rect, app: &App) {
+pub fn render_skills_screen(frame: &mut Frame, area: Rect, app: &App) {
     let t = &app.theme;
-    let popup = centered_rect(82, 82, area);
 
-    frame.render_widget(Clear, popup);
-
-    let title = match app.skills_tab {
-        SkillsTab::Skills => " Skills & Hive — Skills ",
-        SkillsTab::Hive => " Skills & Hive — Hive ",
-    };
-    let outer = Block::default()
+    let title = Line::from(vec![
+        Span::styled(" claudectl ", Style::default().fg(t.text_primary)),
+        Span::styled(
+            "│ Skills & Hive ",
+            Style::default()
+                .fg(t.header)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]);
+    let block = Block::default()
         .title(title)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(t.header));
-    let inner = outer.inner(popup);
-    frame.render_widget(outer, popup);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
 
     let layout = Layout::default()
         .direction(Direction::Vertical)
@@ -38,7 +40,7 @@ pub fn render_skills_overlay(frame: &mut Frame, area: Rect, app: &App) {
             Constraint::Length(2), // tab row
             Constraint::Length(2), // header
             Constraint::Min(3),    // body
-            Constraint::Length(8), // footer
+            Constraint::Length(9), // footer
         ])
         .split(inner);
 

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -68,7 +68,17 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                         .fg(t.highlight_key)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(" for help.", Style::default().fg(t.text_muted)),
+                Span::styled(" for help, ", Style::default().fg(t.text_muted)),
+                Span::styled(
+                    "K",
+                    Style::default()
+                        .fg(t.highlight_key)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    " for Skills & Hive.",
+                    Style::default().fg(t.text_muted),
+                ),
             ]),
         ];
 
@@ -89,9 +99,6 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
         if app.show_help {
             render_help_overlay(frame, area, app);
-        }
-        if app.show_skills {
-            super::skills::render_skills_overlay(frame, area, app);
         }
         return;
     }
@@ -129,9 +136,6 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
         if app.show_help {
             render_help_overlay(frame, area, app);
-        }
-        if app.show_skills {
-            super::skills::render_skills_overlay(frame, area, app);
         }
         return;
     }
@@ -312,11 +316,11 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         // Contextual hints based on selected session state
         let hint = match app.selected_session().map(|s| s.status) {
             Some(SessionStatus::NeedsInput) => {
-                "  y:approve i:type c:compact R:record Tab:go f/v:filter /:search z:clear d:kill ?:help".to_string()
+                "  y:approve i:type c:compact R:record Tab:go f/v:filter /:search z:clear d:kill K:skills ?:help".to_string()
             }
             _ => {
                 format!(
-                    "  q:quit j/k:nav Tab:go y:approve i:input c:compact R:record f/v:filter /:search z:clear d:kill s:sort({sort_name}) ?:help"
+                    "  q:quit j/k:nav Tab:go y:approve i:input c:compact R:record f/v:filter /:search z:clear d:kill s:sort({sort_name}) K:skills ?:help"
                 )
             }
         };
@@ -427,9 +431,6 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     // Help overlay
     if app.show_help {
         render_help_overlay(frame, area, app);
-    }
-    if app.show_skills {
-        super::skills::render_skills_overlay(frame, area, app);
     }
 }
 

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -90,6 +90,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         if app.show_help {
             render_help_overlay(frame, area, app);
         }
+        if app.show_skills {
+            super::skills::render_skills_overlay(frame, area, app);
+        }
         return;
     }
 
@@ -126,6 +129,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
         if app.show_help {
             render_help_overlay(frame, area, app);
+        }
+        if app.show_skills {
+            super::skills::render_skills_overlay(frame, area, app);
         }
         return;
     }
@@ -421,6 +427,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     // Help overlay
     if app.show_help {
         render_help_overlay(frame, area, app);
+    }
+    if app.show_skills {
+        super::skills::render_skills_overlay(frame, area, app);
     }
 }
 

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -75,10 +75,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                         .fg(t.highlight_key)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(
-                    " for Skills & Hive.",
-                    Style::default().fg(t.text_muted),
-                ),
+                Span::styled(" for Skills & Hive.", Style::default().fg(t.text_muted)),
             ]),
         ];
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1575,12 +1575,19 @@ fn run_brain_gate(
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
     let mut child = cmd.spawn().expect("spawn bash");
-    child
+    // BrokenPipe is expected when the hook exits before reading stdin (e.g.
+    // the missing-claudectl path returns at line 21 of brain-gate.sh, before
+    // the `cat` that consumes stdin). Treat it like the parent's job is done.
+    match child
         .stdin
         .as_mut()
         .unwrap()
         .write_all(stdin_payload.as_bytes())
-        .unwrap();
+    {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {}
+        Err(e) => panic!("write_all failed: {e:?}"),
+    }
     let output = child.wait_with_output().expect("hook output");
     (
         String::from_utf8(output.stdout).expect("utf8 stdout"),


### PR DESCRIPTION
## Summary

- **`K` opens a full-screen Skills & Hive mode**. Two tabs (Skills, Hive) toggled with Tab; `Esc/K/q` returns to the session table.
- **Skills tab**: scans `~/.claude/skills`, `~/.claude/plugins/*/skills`, and `<cwd>/.claude/skills`. Shows `✓` for skills already in the local hive store. `s` shares the selected skill (honours the 32 KiB hive limit, surfaces a warning when oversized).
- **Hive tab**: shows local peer identity, listener status, and known peers (read from `~/.claudectl/relay/peers/`). Hotkeys: `h` start listener, `i` generate invite (relay code + word phrase + invite link shown inline), `J` join via paste, `r` refresh peers. Long-running relay commands (`relay serve`, `relay join`) spawn as detached subprocesses so the TUI stays responsive.
- **`K:skills` hint added to the session-table footer** (both selected-state and default variants) and to the no-sessions empty state.
- Footer hint strip is now pinned to the bottom (body uses `Min`, footer is a tight 1-2 row strip) — earlier iteration had a band of empty space above the bottom border.

## Modules touched

- `src/skills.rs` *(new)* — skill discovery + YAML frontmatter parsing + shared-key lookup that aligns with the hive's `skill:<lowercased-name>` semantic key.
- `src/ui/skills.rs` *(new)* — full-screen renderer with Skills/Hive tabs.
- `src/hive/cli.rs` — public `share_artifact_from_path()` wrapper around the previously-private `cmd_share` so non-CLI callers can share.
- `src/app.rs` — `SkillsTab`, `HiveInvite`, state fields, key handlers, detached-subprocess helpers (`spawn_relay_serve`, `spawn_relay_join`, `generate_invite_via_cli`).
- `src/main.rs` — full-screen dispatch in the draw loop.
- `src/ui/table.rs`, `src/ui/help.rs`, `src/ui/mod.rs` — `K:skills` hint, help overlay entry, module registration.
- `CHANGELOG.md`, `Cargo.toml` — release notes for 0.49.0 → 0.49.1 → 0.49.2 (squashed into one PR; bumps to **0.49.2**).

## Test plan

- [x] `cargo build` (default features) — clean
- [x] `cargo build --features relay` — clean
- [x] `cargo build --no-default-features --features hive` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — **580 passed** (5 new: 3 for `skills` module, 2 for overlay rendering)
- [x] `cargo test --tests` — integration tests pass
- [x] `cargo build --release` — 3.3 MB binary
- [ ] Smoke-test the TUI manually: press K, switch tabs, share a skill, generate an invite, paste an invite to join

## Notes

- Default features remain `["hive"]`; the relay-side actions (start listener, invite, join) are gated behind the `relay` feature and degrade gracefully ("relay feature not built").
- The Hive tab reads `~/.claudectl/relay/peers/` for the known-peer list. Live heartbeat state isn't streamed into the overlay yet — that would need the `PeerRegistry` plumbed into `App`. Tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)