### PR TITLE
chore(packaging): prep claudectl for homebrew-core submission

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
+clap_mangen = "0.2"
 libc = "0.2"
 ctrlc = "3"
 rusqlite = { version = "0.33", features = ["bundled"], optional = true }

--- a/packaging/homebrew-core/README.md
+++ b/packaging/homebrew-core/README.md
@@ -1,0 +1,44 @@
+# homebrew-core Submission
+
+This directory holds the formula draft that will land in
+[`Homebrew/homebrew-core`](https://github.com/Homebrew/homebrew-core) — *not*
+the tap formula at `mercurialsolo/homebrew-tap`, which keeps shipping
+prebuilt-binary tarballs as the fast install path.
+
+The core formula is source-built, runs through Homebrew's CI bottle pipeline,
+and is what `brew install claudectl` resolves to once accepted.
+
+## Submitting
+
+1. Bump `url` and `sha256` in `claudectl.rb` to the release you want to ship.
+   ```sh
+   curl -fsSL https://github.com/mercurialsolo/claudectl/archive/refs/tags/vX.Y.Z.tar.gz \
+     | shasum -a 256
+   ```
+2. Locally:
+   ```sh
+   brew install --build-from-source ./packaging/homebrew-core/claudectl.rb
+   brew test claudectl
+   brew audit --strict --new --online claudectl
+   ```
+   All three must pass cleanly before opening the PR.
+3. Fork `Homebrew/homebrew-core`, drop the file at `Formula/c/claudectl.rb`,
+   and open a PR following the
+   [Adding Software to Homebrew](https://docs.brew.sh/Adding-Software-to-Homebrew)
+   checklist. Mention this repo and a recent release in the description.
+
+## What this formula does differently from the tap
+
+| Aspect                | Tap (`homebrew-tap`)             | Core (`homebrew-core`)                 |
+| --------------------- | -------------------------------- | -------------------------------------- |
+| Source                | Prebuilt release tarballs        | GitHub source tarball, built via Cargo |
+| Bottles               | None                             | Built by Homebrew CI                   |
+| Test                  | `--version` smoke test           | Completions + man + sandboxed `--list` |
+| Auto-version tracking | Manual via `release.yml`         | `livecheck` block (`:github_latest`)   |
+| Completions / man     | Not installed                    | Installed for bash/zsh/fish + `man1`   |
+
+## When updating
+
+After the formula is accepted into core, Homebrew's auto-bumper handles version
+updates on each tag via the `livecheck` block. We only touch the formula here
+if the install layout or test surface changes.

--- a/packaging/homebrew-core/claudectl.rb
+++ b/packaging/homebrew-core/claudectl.rb
@@ -1,0 +1,41 @@
+class Claudectl < Formula
+  desc "Mission control for Claude Code: supervise, orchestrate, and connect coding agents"
+  homepage "https://github.com/mercurialsolo/claudectl"
+  url "https://github.com/mercurialsolo/claudectl/archive/refs/tags/v0.49.2.tar.gz"
+  sha256 "REPLACE_WITH_SHA256_OF_SOURCE_TARBALL"
+  license "MIT"
+  head "https://github.com/mercurialsolo/claudectl.git", branch: "main"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: ".")
+
+    generate_completions_from_executable(bin/"claudectl", "completions")
+
+    (man1/"claudectl.1").write Utils.safe_popen_read(bin/"claudectl", "man")
+  end
+
+  test do
+    # Completions render for the major shells we support
+    assert_match "_claudectl", shell_output("#{bin}/claudectl completions bash")
+    assert_match "#compdef claudectl", shell_output("#{bin}/claudectl completions zsh")
+    assert_match "complete -c claudectl", shell_output("#{bin}/claudectl completions fish")
+
+    # Man page renders to roff
+    assert_match ".TH claudectl 1", shell_output("#{bin}/claudectl man")
+
+    # Version surface
+    assert_match version.to_s, shell_output("#{bin}/claudectl --version")
+
+    # `--list` against an empty HOME should succeed and produce no sessions.
+    # Use a sandboxed HOME so we don't read the user's real ~/.claude.
+    ENV["HOME"] = testpath
+    system bin/"claudectl", "--list"
+  end
+end

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,8 @@ mod ui;
 use std::io;
 use std::time::{Duration, Instant};
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::Shell;
 use crossterm::{
     event::{self, Event},
     execute,
@@ -80,6 +81,16 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: coord::cli::CoordCommand,
     },
+
+    /// Print a shell completion script for the given shell (bash, zsh, fish, …) to stdout
+    Completions {
+        /// Shell to emit completions for
+        #[arg(value_enum)]
+        shell: Shell,
+    },
+
+    /// Print a roff-formatted man page to stdout
+    Man,
 }
 
 #[derive(Parser)]
@@ -590,6 +601,21 @@ fn run_main(cli: Cli) -> io::Result<()> {
 
             #[cfg(feature = "coord")]
             Command::Coord { command } => return coord::cli::dispatch_command(command, cli.json),
+
+            Command::Completions { shell } => {
+                let mut cmd = Cli::command();
+                let name = cmd.get_name().to_string();
+                clap_complete::generate(*shell, &mut cmd, name, &mut io::stdout());
+                return Ok(());
+            }
+
+            Command::Man => {
+                let cmd = Cli::command();
+                clap_mangen::Man::new(cmd)
+                    .render(&mut io::stdout())
+                    .map_err(io::Error::other)?;
+                return Ok(());
+            }
         }
     }
 


### PR DESCRIPTION
Closes #265.

## Summary

- Adds `claudectl completions <shell>` (clap_complete) and `claudectl man` (clap_mangen) — the surfaces homebrew-core reviewers look for on any non-trivial CLI.
- Drops `packaging/homebrew-core/claudectl.rb`, a source-built formula with `livecheck`, `generate_completions_from_executable`, `man1` install, and a real `test do` block.
- Documents the tap-vs-core split in `packaging/homebrew-core/README.md`. The existing tap formula keeps shipping prebuilt-binary tarballs; the core formula is the source-built one Homebrew CI bottles.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 584 + 78 + 8 tests pass
- [x] `claudectl completions {bash,zsh,fish}` — outputs valid completion scripts
- [x] `claudectl man` — outputs roff with `.TH claudectl 1`
- [ ] Local Homebrew dry-run before opening the homebrew-core PR:
  ```sh
  brew install --build-from-source ./packaging/homebrew-core/claudectl.rb
  brew test claudectl
  brew audit --strict --new --online claudectl
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)