### PR TITLE
chore(packaging): sync homebrew-core template with submitted formula

### DIFF
--- a/packaging/homebrew-core/claudectl.rb
+++ b/packaging/homebrew-core/claudectl.rb
@@ -1,8 +1,8 @@
 class Claudectl < Formula
-  desc "Mission control for Claude Code: supervise, orchestrate, and connect coding agents"
+  desc "Supervise, orchestrate, and connect Claude Code coding agents"
   homepage "https://github.com/mercurialsolo/claudectl"
-  url "https://github.com/mercurialsolo/claudectl/archive/refs/tags/v0.49.2.tar.gz"
-  sha256 "REPLACE_WITH_SHA256_OF_SOURCE_TARBALL"
+  url "https://github.com/mercurialsolo/claudectl/archive/refs/tags/v0.49.3.tar.gz"
+  sha256 "601bad4b04822b5910ddd05833de955d238874476270f0a0a26262a8a513b6fd"
   license "MIT"
   head "https://github.com/mercurialsolo/claudectl.git", branch: "main"
 


### PR DESCRIPTION
Tiny follow-up to #266 / [Homebrew/homebrew-core#285155](https://github.com/Homebrew/homebrew-core/pull/285155).

`brew audit --strict --new --online` flagged the original description as 82 chars (limit is 80). The trimmed version sits at 61 chars and is what was submitted to homebrew-core, so syncing the template here. Also pinning to the real v0.49.3 source-tarball values instead of the \`REPLACE_WITH_SHA256\` placeholder, so the next bump starts from a known-good baseline.

## Test plan

- [x] `wc -c` of `desc` value is 61
- [x] `brew audit --strict --new --online` clean against the same formula content (verified during the homebrew-core submission flow)

Refs: #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)