### PR TITLE
chore(positioning): reposition to 'Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you'

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # claudectl
 
-**Auto-pilot for Claude Code — supervise, budget, orchestrate, and auto-pilot sessions with a local LLM brain.**
+**Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you.**
 
 claudectl is the missing control plane for Claude Code. If you're building tools, agents, or workflows that interact with Claude Code sessions, claudectl provides the monitoring, orchestration, and automation layer.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # claudectl
 
-Mission control for Claude Code — supervise, budget, orchestrate, and auto-pilot sessions with a local LLM brain.
+Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you.
 
 ## Build & Test
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "claudectl"
 version = "0.49.3"
 edition = "2024"
-description = "Mission control for Claude Code — supervise, orchestrate, and connect coding agents with a local LLM brain and hive mind"
+description = "Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you."
 license = "MIT"
 repository = "https://github.com/mercurialsolo/claudectl"
 homepage = "https://mercurialsolo.github.io/claudectl/"

--- a/LAUNCH_POSTS.md
+++ b/LAUNCH_POSTS.md
@@ -44,7 +44,7 @@ Reason:
 
 Title:
 
-`claudectl`: mission control for Claude Code
+`claudectl`: orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you
 
 Body:
 
@@ -112,7 +112,7 @@ If this matches how you use Claude Code, I’d like to know what breaks first fo
 
 Title:
 
-Mission control for Claude Code: supervising multiple sessions from one terminal
+Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you
 
 Body:
 
@@ -168,7 +168,7 @@ Attach:
 
 Title:
 
-Show HN: claudectl, mission control for Claude Code
+Show HN: claudectl – orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you
 
 Body:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <p align="center">
   <img src="assets/logo.png" alt="claudectl" width="372">
 </p>
-<p align="center"><strong>Mission control for Claude Code.</strong></p>
-<p align="center">Supervise, orchestrate, and connect coding agents with a local LLM brain and hive mind.</p>
+<p align="center"><strong>Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you.</strong></p>
 
 [![CI](https://github.com/mercurialsolo/claudectl/actions/workflows/ci.yml/badge.svg)](https://github.com/mercurialsolo/claudectl/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/claudectl)](https://crates.io/crates/claudectl)

--- a/blog/posts.md
+++ b/blog/posts.md
@@ -151,7 +151,7 @@ Happy to answer questions about keeping the dependency count low or the no-async
 
 ## 5. r/commandline
 
-**Title:** claudectl: TUI mission control for Claude Code — local LLM brain that learns to auto-approve your sessions
+**Title:** claudectl: orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you
 
 **Body:**
 

--- a/docs/index-old.html
+++ b/docs/index-old.html
@@ -45,8 +45,8 @@
       <main id="top">
         <section class="hero">
           <div class="hero-copy">
-            <p class="eyebrow">Mission control for Claude Code</p>
-            <h1>Supervise every Claude Code session from one terminal.</h1>
+            <p class="eyebrow">Orchestrate a swarm of Claude Code agents</p>
+            <h1>With a local-LLM brain that learns from you.</h1>
             <p class="hero-text">
               Know which agent is blocked, burning budget, waiting for approval,
               or stalled, and intervene without tab hunting.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # claudectl
 
-**Mission control for Claude Code** - supervise, budget, orchestrate, and auto-pilot sessions with a local LLM brain.
+**Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you.**
 
 <p class="hero-tagline">
 Know which agent is blocked, burning budget, waiting for approval, or stalled - and intervene without tab hunting.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # claudectl
 
-> Mission control for Claude Code - supervise, budget, orchestrate, and auto-pilot sessions with a local LLM brain.
+> Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you.
 
 claudectl is a Rust TUI that monitors all your Claude Code sessions from one terminal. It shows which agent is blocked, burning budget, waiting for approval, or stalled - and lets you intervene without tab hunting.
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "claudectl - TUI for monitoring and managing Claude Code CLI agents";
+  description = "Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you.";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -19,7 +19,7 @@
           cargoLock.lockFile = ./Cargo.lock;
 
           meta = with pkgs.lib; {
-            description = "TUI for monitoring and managing Claude Code CLI agents";
+            description = "Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you.";
             homepage = "https://github.com/mercurialsolo/claudectl";
             license = licenses.mit;
             mainProgram = "claudectl";

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: claudectl
 site_url: https://mercurialsolo.github.io/claudectl/
-site_description: Mission control for Claude Code — supervise, orchestrate, and connect your coding agents with a local LLM brain and hive mind.
+site_description: Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you.
 repo_url: https://github.com/mercurialsolo/claudectl
 repo_name: mercurialsolo/claudectl
 

--- a/packaging/aur/claudectl-bin/PKGBUILD
+++ b/packaging/aur/claudectl-bin/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=claudectl-bin
 pkgver=0.16.0
 pkgrel=1
-pkgdesc='Mission control TUI for Claude Code sessions'
+pkgdesc='Orchestrate a swarm of Claude Code agents with a learning local-LLM brain'
 arch=('x86_64')
 url='https://github.com/mercurialsolo/claudectl'
 license=('MIT')

--- a/packaging/homebrew-core/claudectl.rb
+++ b/packaging/homebrew-core/claudectl.rb
@@ -1,5 +1,5 @@
 class Claudectl < Formula
-  desc "Supervise, orchestrate, and connect Claude Code coding agents"
+  desc "Orchestrate a swarm of Claude Code agents with a learning local-LLM brain"
   homepage "https://github.com/mercurialsolo/claudectl"
   url "https://github.com/mercurialsolo/claudectl/archive/refs/tags/v0.49.3.tar.gz"
   sha256 "601bad4b04822b5910ddd05833de955d238874476270f0a0a26262a8a513b6fd"

--- a/packaging/nixpkgs/README.md
+++ b/packaging/nixpkgs/README.md
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = lib.fakeHash;
 
   meta = {
-    description = "TUI for monitoring and managing Claude Code CLI agents";
+    description = "Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you.";
     homepage = "https://github.com/mercurialsolo/claudectl";
     license = lib.licenses.mit;
     mainProgram = "claudectl";

--- a/scripts/render-aur-bin-files.sh
+++ b/scripts/render-aur-bin-files.sh
@@ -15,7 +15,7 @@ cat >"${OUT_DIR}/PKGBUILD" <<EOF
 pkgname=claudectl-bin
 pkgver=${VERSION}
 pkgrel=1
-pkgdesc='Mission control TUI for Claude Code sessions'
+pkgdesc='Orchestrate a swarm of Claude Code agents with a learning local-LLM brain'
 arch=('x86_64')
 url='https://github.com/mercurialsolo/claudectl'
 license=('MIT')
@@ -38,7 +38,7 @@ EOF
 
 cat >"${OUT_DIR}/.SRCINFO" <<EOF
 pkgbase = claudectl-bin
-	pkgdesc = Mission control TUI for Claude Code sessions
+	pkgdesc = Orchestrate a swarm of Claude Code agents with a learning local-LLM brain
 	pkgver = ${VERSION}
 	pkgrel = 1
 	url = https://github.com/mercurialsolo/claudectl

--- a/scripts/render-homebrew-formula.sh
+++ b/scripts/render-homebrew-formula.sh
@@ -13,7 +13,7 @@ BASE_URL="https://github.com/mercurialsolo/claudectl/releases/download/${TAG}"
 
 cat <<EOF
 class Claudectl < Formula
-  desc "TUI for monitoring and managing Claude Code CLI sessions"
+  desc "Orchestrate a swarm of Claude Code agents with a learning local-LLM brain"
   homepage "https://github.com/mercurialsolo/claudectl"
   version "${VERSION}"
   license "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ pub(crate) enum Command {
 #[command(
     name = "claudectl",
     version,
-    about = "Monitor and manage Claude Code CLI agents"
+    about = "Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you."
 )]
 pub(crate) struct Cli {
     // ── Dashboard ───────────────────────────────────────────────────────


### PR DESCRIPTION
Repositions every public-facing surface to a single tagline:

> **Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you.**

## Why

Previous positioning ("Mission control for Claude Code", "Auto-pilot", "TUI for monitoring and managing...") undersold the differentiated parts of claudectl — the swarm orchestration, the local-LLM brain, and the learning loop. The new tagline leans into the agent-swarm framing that Anthropic itself is leaning into, and surfaces the two things no other Claude Code tool ships (local-LLM gating + cross-session learning).

## Surfaces updated

| File | Field |
| --- | --- |
| `README.md` | Hero |
| `mkdocs.yml` | `site_description` |
| `docs/index.md`, `docs/llms.txt` | Lead |
| `docs/index-old.html` | Hero (eyebrow + h1) |
| `Cargo.toml` | `description` |
| `src/main.rs` | clap `about` |
| `flake.nix` | top-level + `meta.description` |
| `AGENTS.md`, `CLAUDE.md` (project), `LAUNCH_POSTS.md`, `blog/posts.md` | Lead |
| `packaging/nixpkgs/README.md` | nixpkgs handoff snippet |
| `packaging/homebrew-core/claudectl.rb` | `desc` (trimmed variant — 80-char cap) |
| `packaging/aur/claudectl-bin/PKGBUILD` | `pkgdesc` (trimmed variant) |
| `scripts/render-homebrew-formula.sh`, `scripts/render-aur-bin-files.sh` | Renderer templates |

## Two variants in use

- **Full (85 chars):** `Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you.`
- **Trimmed (73 chars, for homebrew/AUR which cap at 80):** `Orchestrate a swarm of Claude Code agents with a learning local-LLM brain`

## Test plan

- [x] `cargo build --release` — clean, ~1m
- [x] `./target/release/claudectl --help` first line shows the new tagline
- [x] `rg 'Mission control|Auto.?pilot|TUI for monitoring|Monitor and manage'` returns clean (CHANGELOG.md and GROWTH.md excluded — historical / local-only)
- [ ] Visual check after merge: docs site landing page (mkdocs deploy), crates.io page (next release)

## Out of scope

- GitHub repo description (updated separately via `gh`)
- The companion Notion `Outreach Drafts` page (updated separately)
- CHANGELOG.md history (frozen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)