### PR TITLE
feat(bus): Stop hook + continue-in-turn delivery (Trigger A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.52.0] - 2026-06-06
+
+### Added
+- **Agent bus Stop-hook delivery (Trigger A, phase 5 of `docs/AGENT_BUS.md`)** — closes the loop on bus messaging. After every turn finishes, the Claude Code plugin's new `Stop` hook drains the caller's mailbox and, when mail is present, returns `decision: "block"` with the rendered messages as `additionalContext`. The agent picks the work up **in the same turn** without waiting for the user to type `/inbox`. The bus is now self-driving.
+- **`claudectl bus stop-hook` subcommand** — owns the Claude Code Stop-hook output protocol. Silent + exit 0 on every failure mode (no role bound, empty inbox, missing DB, ambiguous cwd) so the hook can never block a session because of a bus problem. All logic lives in Rust (`src/bus/stop_hook.rs`) where it is unit-tested.
+- **`--json` flag on `bus inbox` and `bus whoami`** — machine-readable output for tooling. `inbox --json` soft-fails on unbound/ambiguous cwds (returns `{"role":null,"messages":[],"note":"..."}`) so the Stop hook never errors out on a session that hasn't bound a role yet.
+- **`claude-plugin/hooks/scripts/inbox-drain.sh`** — Stop-hook wrapper installed by the plugin. Intentionally thin: protects against the case where `claudectl` is not on PATH, then delegates to `claudectl bus stop-hook`. Wired into `hooks.json` with a 5 s timeout.
+
+### Internals
+- New `src/bus/stop_hook.rs` module owning the Stop-output schema (`StopHookResponse`, `HookSpecificOutput`) and the markdown rendering of drained messages into context. Decoupled from the CLI so the schema is independently testable.
+- `dispatch_inbox` / `dispatch_whoami` in `src/bus/cli.rs` refactored to separate data-fetch from rendering. Both now share a single `fetch_inbox` helper; human and JSON paths render the same `InboxOutcome` differently.
+- 5 new unit tests covering Stop-hook envelope shape, pluralization, JSON wire format, and the critical "no raw newlines inside the JSON string fields" invariant (caught a real bug in development).
+
+### Compatibility
+- `claudectl bus inbox` without `--json` is unchanged — human-readable output, errors interactively on unbound/ambiguous cwds.
+- No new dependencies. Stop hook ships behind the existing `bus` feature.
+
 ## [0.51.0] - 2026-06-06
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 description = "Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you."
 license = "MIT"

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudectl",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "Mission control for Claude Code — local LLM brain, session monitoring, spend control, and hive mind skill sharing",
   "author": {
     "name": "mercurialsolo",

--- a/claude-plugin/hooks/hooks.json
+++ b/claude-plugin/hooks/hooks.json
@@ -33,5 +33,16 @@
         }
       ]
     }
+  ],
+  "Stop": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/inbox-drain.sh",
+          "timeout": 5
+        }
+      ]
+    }
   ]
 }

--- a/claude-plugin/hooks/scripts/inbox-drain.sh
+++ b/claude-plugin/hooks/scripts/inbox-drain.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Stop hook for the claudectl agent bus (Trigger A, AGENT_BUS.md §6).
+#
+# Fires after each turn finishes. Delegates entirely to `claudectl bus
+# stop-hook`, which:
+#   - drains the caller's mailbox via cwd-inferred role resolution,
+#   - if mail is present, emits Claude Code's Stop-hook output protocol so the
+#     agent picks the work up in the same turn (decision: "block" +
+#     hookSpecificOutput.additionalContext),
+#   - is silent + exit 0 in every other case (no role bound, empty inbox, DB
+#     missing) so the hook never blocks a session.
+#
+# This shell wrapper is intentionally thin: it only protects against the case
+# where claudectl is not on PATH. All bus logic lives in Rust where it is
+# tested. See `src/bus/stop_hook.rs`.
+set +e
+command -v claudectl >/dev/null 2>&1 || exit 0
+exec claudectl bus stop-hook 2>/dev/null

--- a/docs/AGENT_BUS.md
+++ b/docs/AGENT_BUS.md
@@ -11,7 +11,7 @@
 | 2. In-process bus MCP server, autostarted | **Partial** — runs as a stdio subprocess (`claudectl bus stdio`); the in-process autostart-with-TUI form (Unix-socket singleton) is not built yet. | `src/bus/mcp.rs`, `claude-plugin/.mcp.json` |
 | 3. Provisioning (role binding + plugin install + hook capability probe) | **Folded into [`claudectl init`](https://github.com/mercurialsolo/claudectl/issues/257)** — there is no separate `claudectl setup` verb. Non-interactive equivalent ships today as `claudectl bus role bind <name> <cwd>`. | — |
 | 4. Mailbox + directed `publish` / `read_inbox` | **Shipped** | `src/bus/store.rs`, `src/bus/mcp.rs` |
-| 5. `Stop` hook → `read_inbox` (Trigger A) + `/inbox` fallback (Trigger B) | **Partial** — `/inbox` slash command ships; `Stop` hook + continue-in-turn not yet. | `claude-plugin/commands/inbox.md` |
+| 5. `Stop` hook → `read_inbox` (Trigger A) + `/inbox` fallback (Trigger B) | **Shipped (Trigger A continue-in-turn + Trigger B)** | `src/bus/stop_hook.rs`, `claude-plugin/hooks/scripts/inbox-drain.sh`, `claude-plugin/commands/inbox.md` |
 | 6. Command sanitization + content validation | **Shipped (subset)** — leading-`/` neutralized, body cap, subject grammar, type allowlist. Hop/rate/echo guards not yet. | `src/bus/policy.rs` |
 | 7. Subjects + `subscribe` + claim protocol | **Not started** | — |
 | 8. Flow guards (rate/hop/loop/cost) + ACLs | **Not started** | — |

--- a/src/bus/cli.rs
+++ b/src/bus/cli.rs
@@ -13,11 +13,13 @@
 use std::path::PathBuf;
 
 use clap::Subcommand;
+use serde::Serialize;
 
 use super::mcp;
 use super::policy::{self, DEFAULT_MAX_BODY_BYTES};
 use super::roles::{self, RoleResolution};
-use super::store;
+use super::stop_hook;
+use super::store::{self, MessageRow};
 
 #[derive(Subcommand)]
 pub enum BusCommand {
@@ -52,12 +54,25 @@ pub enum BusCommand {
         /// Role to drain. Defaults to cwd inference.
         #[arg(long)]
         role: Option<String>,
+        /// Emit a machine-readable JSON payload instead of human text. Used by
+        /// the Stop hook (Trigger A); soft-fails on unbound/ambiguous cwds so
+        /// the hook never blocks a session.
+        #[arg(long)]
+        json: bool,
     },
     /// Report which role the current cwd resolves to.
     Whoami {
         #[arg(long)]
         role: Option<String>,
+        /// Emit a machine-readable JSON payload instead of human text.
+        #[arg(long)]
+        json: bool,
     },
+    /// Stop-hook driver for the Claude Code plugin (Trigger A). Drains the
+    /// caller's mailbox; when there's mail, emits Stop-hook output so the
+    /// agent picks the work up in-turn. Silent + exit 0 in every other case
+    /// so a missing role / empty inbox / unbound cwd never blocks a session.
+    StopHook,
 }
 
 #[derive(Subcommand)]
@@ -92,8 +107,9 @@ pub fn dispatch(cmd: &BusCommand) -> Result<(), String> {
             from,
             priority,
         } => dispatch_send(to, body, subject, msg_type, from.as_deref(), priority),
-        BusCommand::Inbox { role } => dispatch_inbox(role.as_deref()),
-        BusCommand::Whoami { role } => dispatch_whoami(role.as_deref()),
+        BusCommand::Inbox { role, json } => dispatch_inbox(role.as_deref(), *json),
+        BusCommand::Whoami { role, json } => dispatch_whoami(role.as_deref(), *json),
+        BusCommand::StopHook => dispatch_stop_hook(),
     }
 }
 
@@ -156,29 +172,108 @@ fn dispatch_send(
     Ok(())
 }
 
-fn dispatch_inbox(role: Option<&str>) -> Result<(), String> {
+// ---------------- Inbox -----------------------------------------------------
+
+/// Result of a single drain pass — the resolved role (if any), why the role
+/// couldn't be resolved (if applicable), and the drained messages. Built once,
+/// rendered as either human text or JSON.
+struct InboxOutcome {
+    role: Option<String>,
+    note: Option<String>,
+    messages: Vec<MessageRow>,
+}
+
+#[derive(Serialize)]
+struct InboxOutcomeJson {
+    role: Option<String>,
+    note: Option<String>,
+    messages: Vec<InboxMessageJson>,
+}
+
+#[derive(Serialize)]
+struct InboxMessageJson {
+    id: String,
+    subject: String,
+    #[serde(rename = "type")]
+    msg_type: String,
+    sender_role: Option<String>,
+    thread_id: Option<String>,
+    body: String,
+    priority: String,
+    created_at: String,
+}
+
+impl From<MessageRow> for InboxMessageJson {
+    fn from(m: MessageRow) -> Self {
+        Self {
+            id: m.id,
+            subject: m.subject,
+            msg_type: m.msg_type,
+            sender_role: m.sender_role,
+            thread_id: m.thread_id,
+            body: m.body,
+            priority: m.priority,
+            created_at: m.created_at,
+        }
+    }
+}
+
+/// Resolve the caller's role and drain its mailbox. Soft-fails: unbound and
+/// ambiguous cwds produce a `note` rather than an error, so JSON callers (the
+/// Stop hook) can no-op cleanly without aborting a Claude Code session.
+fn fetch_inbox(role: Option<&str>) -> Result<InboxOutcome, String> {
     let mut conn = store::open()?;
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
-    let resolved = match roles::resolve(&conn, role, &cwd)? {
-        RoleResolution::Resolved(r) => r.name,
+    let resolution = roles::resolve(&conn, role, &cwd)?;
+    let (role, note) = match resolution {
+        RoleResolution::Resolved(r) => (Some(r.name), None),
         RoleResolution::Ambiguous { candidates } => {
-            return Err(format!(
-                "cwd matches multiple roles: {}. Pass --role explicitly.",
-                candidates.join(", ")
-            ));
+            (None, Some(format!("ambiguous: {}", candidates.join(", "))))
         }
-        RoleResolution::Unbound { cwd } => {
-            return Err(format!(
-                "no role bound for cwd {cwd}. Bind one with `claudectl bus role bind`."
-            ));
-        }
+        RoleResolution::Unbound { cwd } => (None, Some(format!("unbound (cwd={cwd})"))),
     };
-    let drained = store::drain_inbox(&mut conn, &resolved, None)?;
-    if drained.is_empty() {
-        println!("(inbox empty for role {resolved})");
+    let messages = if let Some(name) = role.as_deref() {
+        store::drain_inbox(&mut conn, name, None)?
+    } else {
+        Vec::new()
+    };
+    Ok(InboxOutcome {
+        role,
+        note,
+        messages,
+    })
+}
+
+fn dispatch_inbox(role: Option<&str>, json: bool) -> Result<(), String> {
+    let outcome = fetch_inbox(role)?;
+
+    if json {
+        let payload = InboxOutcomeJson {
+            role: outcome.role,
+            note: outcome.note,
+            messages: outcome
+                .messages
+                .into_iter()
+                .map(InboxMessageJson::from)
+                .collect(),
+        };
+        println!(
+            "{}",
+            serde_json::to_string(&payload).map_err(|e| format!("encode json: {e}"))?
+        );
         return Ok(());
     }
-    for m in drained {
+
+    // Human renderer: ambiguous / unbound are interactive errors, not silent.
+    let Some(name) = outcome.role else {
+        return Err(outcome.note.unwrap_or_else(|| "no role resolved".into()));
+    };
+
+    if outcome.messages.is_empty() {
+        println!("(inbox empty for role {name})");
+        return Ok(());
+    }
+    for m in outcome.messages {
         println!(
             "[{prio}] {subject} from={sender} thread={thread}\n  {body}",
             prio = m.priority,
@@ -191,10 +286,71 @@ fn dispatch_inbox(role: Option<&str>) -> Result<(), String> {
     Ok(())
 }
 
-fn dispatch_whoami(role: Option<&str>) -> Result<(), String> {
+// ---------------- Whoami ----------------------------------------------------
+
+#[derive(Serialize)]
+struct WhoamiJson {
+    role: Option<String>,
+    cwd_selector: Option<String>,
+    last_session_id: Option<String>,
+    note: Option<String>,
+}
+
+// ---------------- Stop hook -------------------------------------------------
+
+/// Drive the Claude Code Stop-hook protocol. Silent + exit 0 on any failure
+/// (missing DB, unbound role, ambiguous cwd, drain error) so the hook never
+/// blocks a session because of a bus problem.
+fn dispatch_stop_hook() -> Result<(), String> {
+    let outcome = match fetch_inbox(None) {
+        Ok(o) => o,
+        Err(_) => return Ok(()),
+    };
+    let Some(role) = outcome.role else {
+        return Ok(());
+    };
+    if let Some(response) = stop_hook::build_response(&role, &outcome.messages) {
+        let json =
+            serde_json::to_string(&response).map_err(|e| format!("encode stop-hook json: {e}"))?;
+        println!("{json}");
+    }
+    Ok(())
+}
+
+fn dispatch_whoami(role: Option<&str>, json: bool) -> Result<(), String> {
     let conn = store::open()?;
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
-    match roles::resolve(&conn, role, &cwd)? {
+    let resolution = roles::resolve(&conn, role, &cwd)?;
+
+    if json {
+        let payload = match resolution {
+            RoleResolution::Resolved(r) => WhoamiJson {
+                role: Some(r.name),
+                cwd_selector: Some(r.cwd_selector),
+                last_session_id: r.last_session_id,
+                note: None,
+            },
+            RoleResolution::Ambiguous { candidates } => WhoamiJson {
+                role: None,
+                cwd_selector: None,
+                last_session_id: None,
+                note: Some(format!("ambiguous: {}", candidates.join(", "))),
+            },
+            RoleResolution::Unbound { cwd } => WhoamiJson {
+                role: None,
+                cwd_selector: None,
+                last_session_id: None,
+                note: Some(format!("unbound (cwd={cwd})")),
+            },
+        };
+        println!(
+            "{}",
+            serde_json::to_string(&payload).map_err(|e| format!("encode json: {e}"))?
+        );
+        return Ok(());
+    }
+
+    match resolution {
         RoleResolution::Resolved(r) => {
             println!(
                 "role={name} cwd_selector={sel} last_session_id={sess}",

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -16,6 +16,7 @@ pub mod cli;
 pub mod mcp;
 pub mod policy;
 pub mod roles;
+pub mod stop_hook;
 pub mod store;
 
 #[allow(unused_imports)]

--- a/src/bus/stop_hook.rs
+++ b/src/bus/stop_hook.rs
@@ -1,0 +1,200 @@
+//! Claude Code `Stop` hook output protocol (Trigger A, spec §6).
+//!
+//! When a Claude Code session finishes a turn, the plugin's `Stop` hook fires.
+//! If we have mail for the caller's role, we want the conversation to
+//! **continue in the same turn** with the new messages folded in as context —
+//! not wait for the user to type `/inbox` next time. Claude Code lets a hook
+//! achieve that by returning `decision: "block"` together with an
+//! `additionalContext` payload; the runtime treats that as "don't stop, here's
+//! more context, keep going."
+//!
+//! This module owns the JSON shape and the rendering of messages into context
+//! text. The CLI calls `build_response` once per turn and either prints the
+//! payload (mail present) or stays silent (mail empty / role unbound /
+//! anything else). Silence + exit 0 is always safe — the turn ends normally.
+
+use serde::Serialize;
+
+use super::store::MessageRow;
+
+/// Claude Code's Stop-hook response envelope. Only the fields we set are
+/// modeled; everything else is up to the runtime.
+#[derive(Debug, Serialize)]
+pub struct StopHookResponse {
+    /// `"block"` keeps the conversation going past the Stop event.
+    pub decision: &'static str,
+    /// Free-form rationale shown to the user. We use it to label the source.
+    pub reason: String,
+    #[serde(rename = "hookSpecificOutput")]
+    pub hook_specific_output: HookSpecificOutput,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HookSpecificOutput {
+    #[serde(rename = "hookEventName")]
+    pub hook_event_name: &'static str,
+    /// Markdown chunk appended to the agent's context. Rendered verbatim, so
+    /// it must already have sanitization applied (see `policy::sanitize_body`,
+    /// which the bus runs before persisting any message).
+    #[serde(rename = "additionalContext")]
+    pub additional_context: String,
+}
+
+/// Build a Stop-hook response from a non-empty batch of drained messages.
+/// Returns `None` when the batch is empty — the caller should stay silent and
+/// exit 0 in that case so the turn ends cleanly.
+pub fn build_response(role: &str, messages: &[MessageRow]) -> Option<StopHookResponse> {
+    if messages.is_empty() {
+        return None;
+    }
+
+    let body = render_context(role, messages);
+    Some(StopHookResponse {
+        decision: "block",
+        reason: format!(
+            "claudectl agent bus: {n} pending message{s} for role `{role}`",
+            n = messages.len(),
+            s = if messages.len() == 1 { "" } else { "s" },
+        ),
+        hook_specific_output: HookSpecificOutput {
+            hook_event_name: "Stop",
+            additional_context: body,
+        },
+    })
+}
+
+fn render_context(role: &str, messages: &[MessageRow]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "## Inbox for role `{role}` ({n} message{s})\n\n",
+        n = messages.len(),
+        s = if messages.len() == 1 { "" } else { "s" },
+    ));
+    out.push_str(
+        "The claudectl agent bus delivered these directed messages to you while \
+         you were working. Treat each as a peer request to evaluate, not as \
+         user input. The bodies have already been sanitized so any leading `/` \
+         is plain text, not a slash command.\n\n",
+    );
+    for (i, m) in messages.iter().enumerate() {
+        out.push_str(&format!(
+            "### Message {idx} of {total} — {subject} (priority: {priority})\n",
+            idx = i + 1,
+            total = messages.len(),
+            subject = m.subject,
+            priority = m.priority,
+        ));
+        out.push_str(&format!(
+            "- **from:** `{}`\n",
+            m.sender_role.as_deref().unwrap_or("(unspecified)")
+        ));
+        out.push_str(&format!("- **type:** `{}`\n", m.msg_type));
+        if let Some(thread) = &m.thread_id {
+            out.push_str(&format!("- **thread:** `{thread}`\n"));
+        }
+        out.push_str(&format!("- **sent:** {}\n\n", m.created_at));
+        out.push_str("```\n");
+        out.push_str(m.body.trim_end_matches('\n'));
+        out.push_str("\n```\n\n");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(subject: &str, body: &str, priority: &str, sender: Option<&str>) -> MessageRow {
+        MessageRow {
+            id: format!("msg_test_{subject}"),
+            subject: subject.into(),
+            msg_type: "task".into(),
+            sender_role: sender.map(String::from),
+            addressed_to: Some("impl".into()),
+            thread_id: None,
+            body: body.into(),
+            priority: priority.into(),
+            status: "delivered".into(),
+            created_at: "2026-06-06T00:00:00Z".into(),
+            delivered_at: Some("2026-06-06T00:00:01Z".into()),
+        }
+    }
+
+    #[test]
+    fn empty_batch_returns_none() {
+        assert!(build_response("impl", &[]).is_none());
+    }
+
+    #[test]
+    fn single_message_response_blocks_the_stop() {
+        let r = build_response(
+            "impl",
+            &[msg("task.created", "fix the bug", "high", Some("planner"))],
+        )
+        .expect("non-empty");
+        assert_eq!(r.decision, "block");
+        assert!(r.reason.contains("1 pending message for role `impl`"));
+        assert_eq!(r.hook_specific_output.hook_event_name, "Stop");
+        let ctx = &r.hook_specific_output.additional_context;
+        assert!(ctx.contains("## Inbox for role `impl` (1 message)"));
+        assert!(ctx.contains("from:** `planner`"));
+        assert!(ctx.contains("priority: high"));
+        assert!(ctx.contains("fix the bug"));
+    }
+
+    #[test]
+    fn plural_messages_pluralizes_the_reason() {
+        let r = build_response(
+            "impl",
+            &[
+                msg("a.x", "one", "high", None),
+                msg("b.y", "two", "normal", Some("planner")),
+            ],
+        )
+        .expect("non-empty");
+        assert!(r.reason.contains("2 pending messages"));
+        let ctx = &r.hook_specific_output.additional_context;
+        assert!(ctx.contains("### Message 1 of 2"));
+        assert!(ctx.contains("### Message 2 of 2"));
+        assert!(ctx.contains("from:** `(unspecified)`"));
+    }
+
+    #[test]
+    fn json_shape_matches_claude_code_stop_protocol() {
+        let r = build_response("impl", &[msg("task.created", "go", "normal", None)])
+            .expect("non-empty");
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v["decision"], "block");
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "Stop");
+        assert!(v["hookSpecificOutput"]["additionalContext"].is_string());
+    }
+
+    /// The Stop hook prints one line of JSON. If we leave raw `\n` bytes inside
+    /// the JSON string, the receiving parser breaks (Claude Code's runtime,
+    /// jq, anything strict). serde_json escapes newlines for us — assert it.
+    #[test]
+    fn serialized_json_has_no_raw_newlines_inside_string_fields() {
+        let r = build_response(
+            "impl",
+            &[msg(
+                "task.created",
+                "line one\nline two\nline three",
+                "normal",
+                Some("planner"),
+            )],
+        )
+        .expect("non-empty");
+        let s = serde_json::to_string(&r).unwrap();
+        // Whole payload should be one line. (push past the trailing newline that
+        // println! would add — we serialize without it.)
+        assert!(
+            !s.contains('\n'),
+            "serialized JSON contains raw newline bytes, will break the Stop-hook parser. Got: {s:?}"
+        );
+        // And the escape sequence must actually be present.
+        assert!(
+            s.contains(r"line one\nline two"),
+            "expected escaped \\n in body. Got: {s:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #281. Closes the loop on bus messaging — phase 5 of `docs/AGENT_BUS.md` § 6. After this, the bus is self-driving: every turn ends with the plugin's `Stop` hook draining the caller's mailbox; if there's mail, the hook returns `decision: "block"` with the messages rendered as `additionalContext` and the agent picks the work up **in the same turn**.

Before: every message in the bus required a human typing `/inbox` to surface it. After: messages flow agent-to-agent automatically, with the human only stepping in to redirect.

## What's in

- **`claudectl bus stop-hook`** — new subcommand owning the Claude Code Stop-hook output protocol. Silent + exit 0 on every failure mode (no role, empty inbox, missing DB, ambiguous cwd) so the hook never blocks a session.
- **`--json` on `bus inbox` and `bus whoami`** — machine-readable shape for tooling, with soft-fail semantics for the hook case (unbound → `{"role":null,"messages":[],"note":"..."}`).
- **`claude-plugin/hooks/scripts/inbox-drain.sh` + Stop entry in `hooks.json`** — plugin wiring. Wrapper is intentionally thin (only protects against `claudectl` missing from PATH); all bus logic lives in Rust.
- **`src/bus/stop_hook.rs`** — new module owning the Stop-output schema (`StopHookResponse`, `HookSpecificOutput`) and the markdown rendering of drained messages. Decoupled from the CLI so the schema is independently testable.
- **`dispatch_inbox` / `dispatch_whoami` refactored** to separate data-fetch (`fetch_inbox` helper) from rendering. Human and JSON paths share one `InboxOutcome` rendered through different formatters.

## Why these abstractions

- The Stop hook crosses three layers: shell → Rust binary → Claude Code runtime. Putting the protocol shape in a dedicated module (not the CLI dispatcher) means the contract can be tested without spawning a process.
- `fetch_inbox` returning `InboxOutcome` (with `role: Option`, `note: Option<String>`, `messages`) instead of `Result<Vec<Message>, Error>` is what lets the JSON path soft-fail cleanly. Previously the only way to express "no role bound" was an error string; now it's structured data the renderer can choose what to do with.
- The shell wrapper does one thing — guard against missing PATH — and delegates everything else. Bash is a poor place to do JSON munging.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean (default + bus feature)
- [x] `cargo test --features bus` — 681 passes, +5 new (stop_hook envelope shape, pluralization, JSON wire format, **no-raw-newlines invariant** which caught a real bug in development)
- [x] 7-scenario end-to-end smoke: unbound cwd, empty inbox, populated inbox, second-drain idempotency, claudectl-absent wrapper safety, claudectl-present wrapper drive-through, leading-`/` neutralization preserved through the hook
- [ ] **Not yet verified by me:** the actual `Stop` event firing inside a real Claude Code session. The hook script + JSON shape match Claude Code's hooks protocol per the reference; needs an in-session validation before relying on it in production.

## Version

Minor bump 0.51.0 → 0.52.0. New user-visible subcommand + plugin behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)