### PR TITLE
refactor(workspace): define UI ↔ runtime trait contract (closes #274)

### DIFF
--- a/crates/claudectl-core/src/lib.rs
+++ b/crates/claudectl-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod logger;
 pub mod models;
 pub mod monitor;
 pub mod process;
+pub mod runtime;
 pub mod session;
 pub mod terminals;
 pub mod theme;

--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -1,0 +1,372 @@
+//! UI ↔ runtime contract.
+//!
+//! Tracking: issue #274 of the workspace-refactor epic (#279).
+//!
+//! The TUI today reaches deep into brain / coord / bus / rules internals. This
+//! module defines the **read-only** boundary it should reach through instead,
+//! so a future `claudectl-tui` crate (#275) can be extracted and iterated on
+//! without recompiling brain or the bus.
+//!
+//! ## Why traits, why core-owned DTOs
+//!
+//! Each view is a trait, not a concrete struct, so:
+//!
+//! - The binary crate can hand the TUI a real implementation backed by SQLite
+//!   / the engine / the bus DB. A future remote frontend can hand it an HTTP
+//!   client. Tests hand it a fixture.
+//! - Adding a method to a trait is a contract change reviewable in one PR;
+//!   adding a method to a concrete struct ripples through every caller.
+//!
+//! Each DTO (`SessionSnapshot`, `LeaseSummary`, …) is owned by `core` so the
+//! traits don't drag `brain::DecisionRecord` / `coord::Lease` upward into the
+//! TUI's dependency surface. Conversion happens once, in the wrapper.
+//!
+//! ## What's in scope here
+//!
+//! Read-only views only. Side-effecting paths (`terminate_session`,
+//! `inject_prompt`, `log_decision`) deserve a separate `Actions` trait once
+//! the TUI's write surface is mapped. Adding it speculatively now would
+//! violate the "only add methods existing call sites need" rule the epic
+//! committed to.
+//!
+//! ## What's NOT in scope
+//!
+//! - The TUI doesn't yet call through these traits — that's #275.
+//! - Brain's review/scorecard surface — it's heavier and worth its own
+//!   trait once #275 stabilizes the basic shape.
+//! - Pub/sub claim protocol — #283 builds on top of these traits, not the
+//!   other way around.
+
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+// ============================================================================
+// Sessions
+// ============================================================================
+
+/// One running Claude Code session, as observed by the runtime. Minimal
+/// projection of the binary-crate `ClaudeSession`; only fields the TUI
+/// renders.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionSnapshot {
+    pub session_id: String,
+    pub pid: u32,
+    pub cwd: String,
+    pub project_name: String,
+    pub status: String,
+    pub cost_usd: f64,
+    pub context_tokens: u64,
+    pub context_max: u64,
+    pub last_message_ts: u64,
+}
+
+/// Read access to the live session roster.
+pub trait SessionSource: Send + Sync {
+    /// Snapshot of every running Claude Code session. Order is the
+    /// implementor's choice; the TUI sorts again client-side.
+    fn list(&self) -> Vec<SessionSnapshot>;
+
+    /// Fetch a specific session by its ID. `None` when the session has
+    /// exited or never existed.
+    fn detail(&self, session_id: &str) -> Option<SessionSnapshot> {
+        self.list().into_iter().find(|s| s.session_id == session_id)
+    }
+}
+
+// ============================================================================
+// Brain
+// ============================================================================
+
+/// Mirrors the binary's `brain::GateMode` without depending on the brain
+/// crate. Persisted as the lowercased label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BrainGateMode {
+    On,
+    Off,
+    Auto,
+}
+
+/// A single past brain decision, projected for display.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DecisionSummary {
+    pub id: String,
+    pub timestamp: String,
+    pub action: String,
+    pub confidence: Option<f64>,
+    pub project: Option<String>,
+    pub tool: Option<String>,
+}
+
+/// Read access to the brain's decision history and current mode.
+pub trait BrainView: Send + Sync {
+    fn gate_mode(&self) -> BrainGateMode;
+
+    /// Most recent `n` decisions, newest first.
+    fn recent_decisions(&self, n: usize) -> Vec<DecisionSummary>;
+
+    /// Total count of brain decisions on disk. Drives the "decisions: N"
+    /// status line.
+    fn decision_count(&self) -> usize;
+}
+
+// ============================================================================
+// Coordination layer
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LeaseSummary {
+    pub id: String,
+    pub owner_session_id: String,
+    pub resource_kind: String,
+    pub resource_value: String,
+    pub mode: String,
+    pub acquired_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandoffSummary {
+    pub id: String,
+    pub from_session_id: String,
+    pub to_session_id: Option<String>,
+    pub task_id: String,
+    pub summary: String,
+    pub priority: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InterruptSummary {
+    pub id: String,
+    pub interrupt_type: String,
+    pub priority: String,
+    pub target_session_id: String,
+    pub reason: String,
+    pub created_at: String,
+}
+
+/// Read access to coordination state (leases, handoffs, interrupts).
+/// Backed today by the `coord` SQLite store; in tests, by a fixture.
+pub trait CoordView: Send + Sync {
+    fn active_leases(&self) -> Vec<LeaseSummary>;
+    fn pending_handoffs(&self) -> Vec<HandoffSummary>;
+    fn pending_interrupts(&self) -> Vec<InterruptSummary>;
+}
+
+// ============================================================================
+// Agent bus
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentDirectoryEntry {
+    pub session_id: String,
+    pub pid: u32,
+    pub cwd: String,
+    pub project: String,
+    pub status: String,
+    pub role: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoleBinding {
+    pub name: String,
+    pub cwd_selector: String,
+    pub last_session_id: Option<String>,
+    pub last_seen: String,
+}
+
+/// Read access to the agent-bus roster + role table. Disabled implementations
+/// (`bus` feature off in the binary) return empty vectors so the TUI can
+/// render the panel as "no bus" without conditional compilation.
+pub trait BusView: Send + Sync {
+    fn list_agents(&self) -> Vec<AgentDirectoryEntry>;
+    fn list_roles(&self) -> Vec<RoleBinding>;
+}
+
+// ============================================================================
+// Runtime aggregate
+// ============================================================================
+
+/// Single struct the binary builds at startup and hands to the TUI.
+///
+/// All fields are `Arc<dyn ...>` so the TUI doesn't care whether an impl is
+/// a thin SQLite wrapper, a remote HTTP client, or an in-memory mock — they
+/// all share the same shape.
+#[derive(Clone)]
+pub struct Runtime {
+    pub sessions: Arc<dyn SessionSource>,
+    pub brain: Arc<dyn BrainView>,
+    pub coord: Arc<dyn CoordView>,
+    pub bus: Arc<dyn BusView>,
+}
+
+impl Runtime {
+    pub fn new(
+        sessions: Arc<dyn SessionSource>,
+        brain: Arc<dyn BrainView>,
+        coord: Arc<dyn CoordView>,
+        bus: Arc<dyn BusView>,
+    ) -> Self {
+        Self {
+            sessions,
+            brain,
+            coord,
+            bus,
+        }
+    }
+}
+
+// ============================================================================
+// MockRuntime — for tests in this crate and in claudectl-tui
+// ============================================================================
+
+/// In-memory runtime backed by `Vec`s. Used by tests in this crate to verify
+/// the trait shapes compile and roundtrip cleanly, and by the future
+/// `claudectl-tui` crate's tests to render the TUI against fixtures without
+/// dragging in brain / coord / bus.
+#[derive(Default, Clone)]
+pub struct MockRuntime {
+    pub sessions: Vec<SessionSnapshot>,
+    pub gate_mode: Option<BrainGateMode>,
+    pub decisions: Vec<DecisionSummary>,
+    pub leases: Vec<LeaseSummary>,
+    pub handoffs: Vec<HandoffSummary>,
+    pub interrupts: Vec<InterruptSummary>,
+    pub agents: Vec<AgentDirectoryEntry>,
+    pub roles: Vec<RoleBinding>,
+}
+
+impl MockRuntime {
+    pub fn into_runtime(self) -> Runtime {
+        let arc = Arc::new(self);
+        Runtime::new(arc.clone(), arc.clone(), arc.clone(), arc)
+    }
+}
+
+impl SessionSource for MockRuntime {
+    fn list(&self) -> Vec<SessionSnapshot> {
+        self.sessions.clone()
+    }
+}
+
+impl BrainView for MockRuntime {
+    fn gate_mode(&self) -> BrainGateMode {
+        self.gate_mode.unwrap_or(BrainGateMode::On)
+    }
+    fn recent_decisions(&self, n: usize) -> Vec<DecisionSummary> {
+        self.decisions.iter().take(n).cloned().collect()
+    }
+    fn decision_count(&self) -> usize {
+        self.decisions.len()
+    }
+}
+
+impl CoordView for MockRuntime {
+    fn active_leases(&self) -> Vec<LeaseSummary> {
+        self.leases.clone()
+    }
+    fn pending_handoffs(&self) -> Vec<HandoffSummary> {
+        self.handoffs.clone()
+    }
+    fn pending_interrupts(&self) -> Vec<InterruptSummary> {
+        self.interrupts.clone()
+    }
+}
+
+impl BusView for MockRuntime {
+    fn list_agents(&self) -> Vec<AgentDirectoryEntry> {
+        self.agents.clone()
+    }
+    fn list_roles(&self) -> Vec<RoleBinding> {
+        self.roles.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_session(id: &str) -> SessionSnapshot {
+        SessionSnapshot {
+            session_id: id.into(),
+            pid: 12345,
+            cwd: "/work/proj".into(),
+            project_name: "proj".into(),
+            status: "Processing".into(),
+            cost_usd: 1.23,
+            context_tokens: 4000,
+            context_max: 200_000,
+            last_message_ts: 1_780_000_000,
+        }
+    }
+
+    #[test]
+    fn mock_runtime_assembles_and_lists_sessions() {
+        let mock = MockRuntime {
+            sessions: vec![sample_session("sess_a"), sample_session("sess_b")],
+            ..Default::default()
+        };
+        let rt = mock.into_runtime();
+        let listed = rt.sessions.list();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].session_id, "sess_a");
+    }
+
+    #[test]
+    fn session_detail_falls_back_to_list_scan() {
+        let mock = MockRuntime {
+            sessions: vec![sample_session("sess_a"), sample_session("sess_b")],
+            ..Default::default()
+        };
+        let rt = mock.into_runtime();
+        assert!(rt.sessions.detail("sess_a").is_some());
+        assert!(rt.sessions.detail("sess_missing").is_none());
+    }
+
+    #[test]
+    fn brain_view_returns_recent_decisions_with_cap() {
+        let mock = MockRuntime {
+            decisions: (0..5)
+                .map(|i| DecisionSummary {
+                    id: format!("dec_{i}"),
+                    timestamp: format!("2026-06-06T00:00:0{i}Z"),
+                    action: "approve".into(),
+                    confidence: Some(0.9),
+                    project: None,
+                    tool: None,
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let rt = mock.into_runtime();
+        assert_eq!(rt.brain.recent_decisions(3).len(), 3);
+        assert_eq!(rt.brain.decision_count(), 5);
+        assert_eq!(rt.brain.gate_mode(), BrainGateMode::On);
+    }
+
+    #[test]
+    fn coord_view_reports_empty_state_cleanly() {
+        let rt = MockRuntime::default().into_runtime();
+        assert!(rt.coord.active_leases().is_empty());
+        assert!(rt.coord.pending_handoffs().is_empty());
+        assert!(rt.coord.pending_interrupts().is_empty());
+    }
+
+    #[test]
+    fn bus_view_reports_empty_state_cleanly() {
+        let rt = MockRuntime::default().into_runtime();
+        assert!(rt.bus.list_agents().is_empty());
+        assert!(rt.bus.list_roles().is_empty());
+    }
+
+    /// Smoke test that the trait shapes are usable behind `dyn`. If this
+    /// compiles, the boxed-trait composition works.
+    #[test]
+    fn runtime_implements_clone_and_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Runtime>();
+
+        let rt = MockRuntime::default().into_runtime();
+        let _rt2 = rt.clone();
+    }
+}

--- a/crates/claudectl-core/src/transcript.rs
+++ b/crates/claudectl-core/src/transcript.rs
@@ -167,7 +167,7 @@ mod tests {
 
     #[test]
     fn parse_real_fixture_line() {
-        let line = include_str!("../tests/fixtures/real-transcript-line.json");
+        let line = include_str!("../../../tests/fixtures/real-transcript-line.json");
         let Some(TranscriptEvent::Message(msg)) = parse_line(line.trim()) else {
             panic!("expected message event");
         };
@@ -179,7 +179,8 @@ mod tests {
 
     #[test]
     fn parse_legacy_fixture_line() {
-        let line = include_str!("../tests/fixtures/legacy-transcript-line.json");
+        // Fixture lives at the workspace root, not in this crate.
+        let line = include_str!("../../../tests/fixtures/legacy-transcript-line.json");
         let Some(TranscriptEvent::Message(msg)) = parse_line(line.trim()) else {
             panic!("expected message event");
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod recorder;
 #[cfg(feature = "relay")]
 pub mod relay;
 pub mod rules;
+pub mod runtime;
 pub mod session_recorder;
 pub mod skills;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod recorder;
 #[cfg(feature = "relay")]
 mod relay;
 mod rules;
+mod runtime;
 mod session_recorder;
 mod skills;
 mod ui;

--- a/src/runtime/brain.rs
+++ b/src/runtime/brain.rs
@@ -1,0 +1,65 @@
+//! Bind `BrainView` to the binary's brain subsystem.
+
+use claudectl_core::runtime::{BrainGateMode, BrainView, DecisionSummary};
+
+use crate::brain;
+
+pub struct LiveBrainView;
+
+impl BrainView for LiveBrainView {
+    fn gate_mode(&self) -> BrainGateMode {
+        parse_gate_mode(&brain::read_gate_mode())
+    }
+
+    fn recent_decisions(&self, n: usize) -> Vec<DecisionSummary> {
+        let mut all = brain::decisions::read_all_decisions();
+        // brain::decisions::read_all_decisions returns oldest-first; the TUI
+        // wants newest-first.
+        all.reverse();
+        all.into_iter().take(n).map(summary_from_record).collect()
+    }
+
+    fn decision_count(&self) -> usize {
+        brain::decisions::read_all_decisions().len()
+    }
+}
+
+/// String → enum. Unknown values fall back to `On` to match
+/// `brain::read_gate_mode`'s "no file" default.
+fn parse_gate_mode(raw: &str) -> BrainGateMode {
+    match raw.trim().to_lowercase().as_str() {
+        "off" => BrainGateMode::Off,
+        "auto" => BrainGateMode::Auto,
+        _ => BrainGateMode::On,
+    }
+}
+
+fn summary_from_record(r: brain::decisions::DecisionRecord) -> DecisionSummary {
+    DecisionSummary {
+        id: r.decision_id.unwrap_or_default(),
+        timestamp: r.timestamp,
+        action: r.brain_action,
+        confidence: Some(r.brain_confidence),
+        project: Some(r.project),
+        tool: r.tool,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gate_mode_parsing_recognizes_known_values() {
+        assert_eq!(parse_gate_mode("on"), BrainGateMode::On);
+        assert_eq!(parse_gate_mode("OFF"), BrainGateMode::Off);
+        assert_eq!(parse_gate_mode(" auto "), BrainGateMode::Auto);
+    }
+
+    #[test]
+    fn gate_mode_parsing_falls_back_to_on() {
+        // Matches the file-missing default in `brain::read_gate_mode`.
+        assert_eq!(parse_gate_mode(""), BrainGateMode::On);
+        assert_eq!(parse_gate_mode("garbage"), BrainGateMode::On);
+    }
+}

--- a/src/runtime/bus.rs
+++ b/src/runtime/bus.rs
@@ -1,0 +1,73 @@
+//! Bind `BusView` to the binary's agent-bus store.
+//!
+//! Under `--features bus` the impl reads from the SQLite-backed bus DB
+//! (`~/.claudectl/bus/bus.db`). Without it, every accessor returns an empty
+//! list so the TUI can render the "no bus" state with zero conditional
+//! compilation.
+
+use claudectl_core::runtime::{AgentDirectoryEntry, BusView, RoleBinding};
+
+pub struct LiveBusView;
+
+impl BusView for LiveBusView {
+    #[cfg(feature = "bus")]
+    fn list_agents(&self) -> Vec<AgentDirectoryEntry> {
+        use claudectl_core::discovery;
+
+        let Ok(bus_conn) = crate::bus::store::open() else {
+            return Vec::new();
+        };
+        let mut sessions = discovery::scan_sessions();
+        discovery::resolve_jsonl_paths(&mut sessions);
+
+        sessions
+            .into_iter()
+            .map(|s| {
+                let role = resolve_role(&bus_conn, &s.cwd);
+                AgentDirectoryEntry {
+                    session_id: s.session_id,
+                    pid: s.pid,
+                    cwd: s.cwd,
+                    project: s.project_name,
+                    status: s.status.to_string(),
+                    role,
+                }
+            })
+            .collect()
+    }
+    #[cfg(not(feature = "bus"))]
+    fn list_agents(&self) -> Vec<AgentDirectoryEntry> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "bus")]
+    fn list_roles(&self) -> Vec<RoleBinding> {
+        let Ok(conn) = crate::bus::store::open() else {
+            return Vec::new();
+        };
+        crate::bus::store::list_roles(&conn)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|r| RoleBinding {
+                name: r.role,
+                cwd_selector: r.cwd_selector,
+                last_session_id: r.last_session_id,
+                last_seen: r.last_seen,
+            })
+            .collect()
+    }
+    #[cfg(not(feature = "bus"))]
+    fn list_roles(&self) -> Vec<RoleBinding> {
+        Vec::new()
+    }
+}
+
+#[cfg(feature = "bus")]
+fn resolve_role(conn: &rusqlite::Connection, cwd: &str) -> Option<String> {
+    use crate::bus::roles;
+    use std::path::PathBuf;
+    match roles::resolve(conn, None, &PathBuf::from(cwd)) {
+        Ok(roles::RoleResolution::Resolved(r)) => Some(r.name),
+        _ => None,
+    }
+}

--- a/src/runtime/coord.rs
+++ b/src/runtime/coord.rs
@@ -1,0 +1,99 @@
+//! Bind `CoordView` to the binary's coordination store.
+//!
+//! Under `--features coord` the impl reads from the SQLite-backed `coord`
+//! store. Without it, every accessor returns an empty list so the TUI can
+//! render the "no coord" state without conditional compilation.
+
+use claudectl_core::runtime::{CoordView, HandoffSummary, InterruptSummary, LeaseSummary};
+
+pub struct LiveCoordView;
+
+impl CoordView for LiveCoordView {
+    #[cfg(feature = "coord")]
+    fn active_leases(&self) -> Vec<LeaseSummary> {
+        use crate::coord::{store, types::LeaseStatus};
+        let Ok(conn) = store::open() else {
+            return Vec::new();
+        };
+        store::list_leases(&conn, Some(LeaseStatus::Active))
+            .unwrap_or_default()
+            .into_iter()
+            .map(lease_summary_from)
+            .collect()
+    }
+    #[cfg(not(feature = "coord"))]
+    fn active_leases(&self) -> Vec<LeaseSummary> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "coord")]
+    fn pending_handoffs(&self) -> Vec<HandoffSummary> {
+        use crate::coord::store;
+        let Ok(conn) = store::open() else {
+            return Vec::new();
+        };
+        store::list_pending_handoffs(&conn)
+            .unwrap_or_default()
+            .into_iter()
+            .map(handoff_summary_from)
+            .collect()
+    }
+    #[cfg(not(feature = "coord"))]
+    fn pending_handoffs(&self) -> Vec<HandoffSummary> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "coord")]
+    fn pending_interrupts(&self) -> Vec<InterruptSummary> {
+        use crate::coord::{store, types::InterruptState};
+        let Ok(conn) = store::open() else {
+            return Vec::new();
+        };
+        store::list_interrupts(&conn, Some(InterruptState::Pending))
+            .unwrap_or_default()
+            .into_iter()
+            .map(interrupt_summary_from)
+            .collect()
+    }
+    #[cfg(not(feature = "coord"))]
+    fn pending_interrupts(&self) -> Vec<InterruptSummary> {
+        Vec::new()
+    }
+}
+
+#[cfg(feature = "coord")]
+fn lease_summary_from(l: crate::coord::types::Lease) -> LeaseSummary {
+    LeaseSummary {
+        id: l.id,
+        owner_session_id: l.owner_session_id,
+        resource_kind: l.resource_kind,
+        resource_value: l.resource_value,
+        mode: l.mode.to_string(),
+        acquired_at: l.acquired_at,
+    }
+}
+
+#[cfg(feature = "coord")]
+fn handoff_summary_from(h: crate::coord::types::Handoff) -> HandoffSummary {
+    HandoffSummary {
+        id: h.id,
+        from_session_id: h.from_session_id,
+        to_session_id: h.to_session_id,
+        task_id: h.task_id,
+        summary: h.summary,
+        priority: h.priority,
+        created_at: h.created_at,
+    }
+}
+
+#[cfg(feature = "coord")]
+fn interrupt_summary_from(i: crate::coord::types::Interrupt) -> InterruptSummary {
+    InterruptSummary {
+        id: i.id,
+        interrupt_type: i.interrupt_type.to_string(),
+        priority: i.priority,
+        target_session_id: i.target_session_id,
+        reason: i.reason,
+        created_at: i.created_at,
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,0 +1,41 @@
+//! Binary-side implementations of the `claudectl-core` runtime traits.
+//!
+//! Each submodule provides a `Live*` adapter that reads from the binary
+//! crate's actual subsystem (brain, coord, bus, discovery) and projects it
+//! into the core-owned DTOs the TUI will consume.
+//!
+//! The runtime is **read-only**. Side-effecting paths (terminate, inject,
+//! log_decision) still live as direct calls in the binary until #275 maps
+//! them onto a follow-up `Actions` trait.
+//!
+//! Tracking: workspace-refactor epic #279, issue #274.
+
+use std::sync::Arc;
+
+use claudectl_core::runtime::Runtime;
+
+mod brain;
+mod bus;
+mod coord;
+mod sessions;
+
+pub use brain::LiveBrainView;
+pub use bus::LiveBusView;
+pub use coord::LiveCoordView;
+pub use sessions::LiveSessionSource;
+
+/// Assemble the production runtime: each view backed by the corresponding
+/// binary-crate subsystem. Cheap — every view is a unit struct that holds no
+/// state, all the work happens in the trait method calls.
+///
+/// Unused until #275 wires the TUI through `Runtime`. Kept on the public
+/// surface so reviewers can verify it compiles end-to-end today.
+#[allow(dead_code)]
+pub fn build_runtime() -> Runtime {
+    Runtime::new(
+        Arc::new(LiveSessionSource),
+        Arc::new(LiveBrainView),
+        Arc::new(LiveCoordView),
+        Arc::new(LiveBusView),
+    )
+}

--- a/src/runtime/sessions.rs
+++ b/src/runtime/sessions.rs
@@ -1,0 +1,28 @@
+//! Bind `SessionSource` to the binary's live discovery + monitor pipeline.
+
+use claudectl_core::discovery;
+use claudectl_core::runtime::{SessionSnapshot, SessionSource};
+
+pub struct LiveSessionSource;
+
+impl SessionSource for LiveSessionSource {
+    fn list(&self) -> Vec<SessionSnapshot> {
+        let mut sessions = discovery::scan_sessions();
+        discovery::resolve_jsonl_paths(&mut sessions);
+        sessions.into_iter().map(snapshot_from_live).collect()
+    }
+}
+
+fn snapshot_from_live(s: claudectl_core::session::ClaudeSession) -> SessionSnapshot {
+    SessionSnapshot {
+        session_id: s.session_id,
+        pid: s.pid,
+        cwd: s.cwd,
+        project_name: s.project_name,
+        status: s.status.to_string(),
+        cost_usd: s.cost_usd,
+        context_tokens: s.context_tokens,
+        context_max: s.context_max,
+        last_message_ts: s.last_message_ts,
+    }
+}


### PR DESCRIPTION
## Summary

Closes #274. Second mechanical step of the workspace-refactor epic (#279). Defines the **read-only** boundary the future `claudectl-tui` crate (#275) will reach through instead of into brain / coord / bus internals.

This PR stakes the contract. #275 actually moves the TUI onto it.

## What's in

`crates/claudectl-core/src/runtime.rs` — five view traits plus a `Runtime` aggregate, all backed by core-owned DTOs:

```rust
pub trait SessionSource { fn list(&self) -> Vec<SessionSnapshot>; ... }
pub trait BrainView    { fn gate_mode(&self) -> BrainGateMode; ... }
pub trait CoordView    { fn active_leases(&self) -> Vec<LeaseSummary>; ... }
pub trait BusView      { fn list_agents(&self) -> Vec<AgentDirectoryEntry>; ... }

pub struct Runtime {
    pub sessions: Arc<dyn SessionSource>,
    pub brain:    Arc<dyn BrainView>,
    pub coord:    Arc<dyn CoordView>,
    pub bus:      Arc<dyn BusView>,
}
```

Plus a `MockRuntime` that implements every trait against in-memory `Vec`s — for tests in this crate and in the future `claudectl-tui` tests.

Binary side (`src/runtime/`): four `Live*` adapters that read from the real subsystems and project them into the core DTOs:

| Trait | Live impl | Backed by |
| --- | --- | --- |
| `SessionSource` | `LiveSessionSource` | `discovery::scan_sessions` + `monitor` |
| `BrainView` | `LiveBrainView` | `brain::read_gate_mode` + `brain::decisions::read_all_decisions` |
| `CoordView` | `LiveCoordView` | `coord::store::list_leases` / `list_pending_handoffs` / `list_interrupts` |
| `BusView` | `LiveBusView` | `bus::store::list_roles` + cwd-inferred role on `discovery` |

`coord` and `bus` impls are cfg-gated; the disabled paths return empty vecs so the TUI can render the "absent" state without conditional compilation.

## Design choices worth review

**Traits, not concrete structs.** Adding a method to a trait is a contract change reviewable in one PR; adding a method to a concrete struct ripples through every caller. The TUI doesn't care whether an impl is SQLite-backed, a future HTTP client, or a fixture.

**Core-owned DTOs.** Each trait returns `SessionSnapshot` / `LeaseSummary` / etc., not `brain::DecisionRecord` / `coord::Lease`. Conversion happens once, in the wrapper. The cost is a small DTO file per concern; the win is that the TUI's dependency surface contains no brain or coord types.

**Read-only only.** Side-effecting paths (`terminate_session`, `inject_prompt`, `log_decision`) deserve a separate `Actions` trait once #275 maps the TUI's write surface. Adding it speculatively now would violate the epic's commitment to "only add methods existing call sites need."

**`Send + Sync` on every trait.** Future remote frontends will share a `Runtime` across threads. Cheap to add now.

## What's NOT in scope

- The TUI doesn't yet call through these traits. That's the actual payoff of #275; this PR stakes the contract so reviewers can weigh in on shape before the TUI lands on it.
- Brain's `review` / `scorecard` surface — heavier and worth its own trait once #275 stabilizes the basic shape.
- Side-effecting verbs — see "Read-only only" above.

## Test plan

- [x] `cargo build -p claudectl-core` (standalone) — clean
- [x] `cargo check` (default features) — clean
- [x] `cargo check --features bus` — clean
- [x] `cargo check --features coord` — clean
- [x] `cargo clippy --all-targets -- -D warnings` clean (default + bus)
- [x] **6 new unit tests in `claudectl-core::runtime`** — assemble-and-list, detail fallback, recent_decisions cap, empty coord/bus state, `Runtime: Send + Clone`
- [x] **2 new unit tests in `src/runtime/brain.rs`** — gate-mode string parsing including the file-missing fallback
- [x] `cargo test --features bus` — 1370 tests pass (+8 new)

Also fixed two stale `include_str!("../tests/fixtures/...")` paths in `transcript.rs` (legacy paths from the pre-workspace layout were 2 dirs too shallow).

## Follow-on

#275 — refactor `app.rs` and `ui/` to call through `Runtime` instead of direct `crate::brain::*` / `crate::coord::*`. That's the change that lets the TUI rebuild without recompiling brain/coord/bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)