### PR TITLE
ci: standalone claudectl-core build + layering check (closes #277)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,42 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-targets
       - run: cargo test --all-targets --features coord
+
+  # Workspace refactor (#279) — verify claudectl-core builds and tests
+  # standalone, without the binary crate. Guards the
+  # claudectl → claudectl-core dependency direction at the workspace level.
+  # The claudectl-tui standalone job lands with #275.
+  core-standalone:
+    name: Core (standalone)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Build claudectl-core standalone
+        run: cargo build -p claudectl-core
+      - name: Clippy claudectl-core standalone
+        run: cargo clippy -p claudectl-core --all-targets -- -D warnings
+      - name: Test claudectl-core standalone
+        run: cargo test -p claudectl-core
+
+  # Layering check: nothing inside claudectl-core may reference binary-crate
+  # modules. This is a textual guard on top of the standalone build above —
+  # the build would already fail on a real upward dep, but grep catches
+  # subtler attempts (e.g. cfg-gated paths that don't trip on this matrix).
+  layering:
+    name: Layering
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: No `crate::{brain,bus,coord,hive,relay,init,orchestrator,launch,hooks,recorder,session_recorder,app,ui,demo}` inside claudectl-core
+        run: |
+          set -e
+          PATTERN='crate::(brain|bus|coord|hive|relay|init|orchestrator|launch|hooks|recorder|session_recorder|app|ui|demo)\b'
+          if grep -rEn "${PATTERN}" crates/claudectl-core/src/ ; then
+            echo "::error::claudectl-core must not depend on binary-crate modules. See #279 dependency rule."
+            exit 1
+          fi
+          echo "claudectl-core has no upward dependencies on the binary crate."


### PR DESCRIPTION
## Summary

Closes #277 (partial — `claudectl-core` half). Adds CI jobs that guard the workspace-refactor (#279) dependency direction:

**`claudectl → claudectl-core`** — one direction only. CI rejects attempts to reverse it.

The `claudectl-tui` standalone job lands with #275 (TUI extraction).

## What's added

Two new jobs in `.github/workflows/ci.yml`:

### `core-standalone`

```
cargo build  -p claudectl-core
cargo clippy -p claudectl-core --all-targets -- -D warnings
cargo test   -p claudectl-core
```

Builds and tests the crate without the binary in scope. Catches the case where core accidentally compiles only because something in the binary forwards a missing piece via re-export.

### `layering`

```
grep -rEn 'crate::(brain|bus|coord|hive|relay|init|orchestrator|launch|hooks|recorder|session_recorder|app|ui|demo)\b' \
  crates/claudectl-core/src/
```

Textual guard — fails the build if any source file under `crates/claudectl-core/src/` references a binary-only module. Belt-and-suspenders alongside the standalone build: the build would already fail on a real upward dep, but grep catches subtler attempts (cfg-gated paths that don't trip on this matrix, partially-applied refactors mid-PR).

## Why both

The standalone build is the load-bearing guard. The grep adds:
- Faster feedback (no compile required to see the error)
- Clearer error message that names the rule
- Coverage of conditional paths the matrix might miss

## Test plan

- [x] Local dry run: layering grep finds nothing, standalone build clean, 61 tests pass.

## Epic progress

- ✅ #273 workspace skeleton (PR #284)
- ✅ #274 trait contract (PR #285)
- ✅ #276 health/rules in core (PR #286)
- ✅ #277 this PR (claudectl-core half)
- ✅ #278 docs (PR #287)
- ⏳ #275 TUI extraction — last remaining sub-issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)