### PR TITLE
refactor(workspace): add BrainDriver trait (stateful, toward #275)

### DIFF
--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -251,6 +251,80 @@ pub trait Actions: Send + Sync {
 }
 
 // ============================================================================
+// Brain driver (stateful)
+// ============================================================================
+
+/// One pending brain suggestion the user can accept or reject. Mirrors the
+/// binary's `brain::client::BrainSuggestion` without exposing brain types.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingSuggestion {
+    /// PID of the session this suggestion applies to.
+    pub pid: u32,
+    /// String label of the suggested action — `"approve"`, `"deny"`,
+    /// `"send"`, `"terminate"`. String to avoid pulling `RuleAction`'s enum
+    /// shape into the contract (it's already in `claudectl-core::rules` but
+    /// callers may want to add new categories without bumping the trait).
+    pub action: String,
+    /// Suggested message body (a prompt to inject, a rationale to surface).
+    pub message: Option<String>,
+    /// Why the brain suggested this — used for the detail panel and the
+    /// rejection log.
+    pub reasoning: String,
+    /// 0.0–1.0 confidence the brain assigned.
+    pub confidence: f64,
+    /// Epoch seconds when the suggestion was created. Drives time-to-correct
+    /// telemetry.
+    pub suggested_at: u64,
+}
+
+/// Stateful brain orchestration. Unlike the read-only views, this needs
+/// `&mut` per tick — the engine accumulates pending suggestions, cleans up
+/// after exited sessions, and applies user accept/reject decisions.
+///
+/// Boxed as `Box<dyn BrainDriver>` rather than `Arc<dyn BrainDriver>`
+/// because there is exactly one owner (the TUI's `App`) and every method
+/// needs `&mut self`. Sharing across threads is not a goal here.
+///
+/// Implementations may be `None` — the brain is opt-in (`--brain` flag).
+/// When the field is `None` the TUI renders without brain interaction.
+pub trait BrainDriver: Send {
+    /// Run one tick of the brain loop against the current session set and
+    /// the operator's deny rules. Returns `(pid, status_message)` pairs
+    /// for any actions the brain decided on this tick — the TUI surfaces
+    /// the messages in the status bar.
+    fn tick(
+        &mut self,
+        sessions: &[SessionSnapshot],
+        deny_rules: &[crate::rules::AutoRule],
+    ) -> Vec<(u32, String)>;
+
+    /// Drop pending suggestions for sessions that have exited. Called every
+    /// refresh so the pending map stays bounded by the live session count.
+    fn cleanup(&mut self, sessions: &[SessionSnapshot]);
+
+    /// User accepted the pending suggestion for `pid`. Implementations
+    /// return the log message the TUI should surface (`None` when there's
+    /// no suggestion to accept).
+    fn accept(&mut self, pid: u32) -> Option<String>;
+
+    /// User rejected the pending suggestion for `pid`. Returns the
+    /// suggestion that was rejected — the TUI logs it for replay /
+    /// counterfactual analysis.
+    fn reject(&mut self, pid: u32) -> Option<PendingSuggestion>;
+
+    /// Lookup the pending suggestion for `pid`, if any. Used by detail
+    /// panels and the status bar.
+    fn pending_for(&self, pid: u32) -> Option<PendingSuggestion>;
+
+    /// Total pending suggestion count. Used by the status bar.
+    fn pending_count(&self) -> usize;
+
+    /// Drop every pending suggestion. Called when the brain mode flips
+    /// off or the operator resets state.
+    fn clear_pending(&mut self);
+}
+
+// ============================================================================
 // Runtime aggregate
 // ============================================================================
 

--- a/src/runtime/brain_driver.rs
+++ b/src/runtime/brain_driver.rs
@@ -1,0 +1,140 @@
+//! Bind `BrainDriver` to the binary's `BrainEngine`.
+//!
+//! Wraps a `BrainEngine` instance and translates the trait's
+//! `SessionSnapshot` inputs to the live `ClaudeSession` values the engine
+//! expects, looking up real sessions via discovery on each call. The
+//! `PendingSuggestion` DTO is projected from the brain's internal type.
+
+use claudectl_core::discovery;
+use claudectl_core::rules::AutoRule;
+use claudectl_core::runtime::{BrainDriver, PendingSuggestion, SessionSnapshot};
+use claudectl_core::session::ClaudeSession;
+
+use crate::brain;
+use crate::brain::client::BrainSuggestion;
+
+pub struct LiveBrainDriver {
+    engine: brain::engine::BrainEngine,
+}
+
+impl LiveBrainDriver {
+    /// Wrap an existing `BrainEngine`. The next PR (call-site migration)
+    /// is what makes `App::new` call this; until then the constructor is
+    /// referenced only by tests.
+    #[allow(dead_code)]
+    pub fn new(engine: brain::engine::BrainEngine) -> Self {
+        Self { engine }
+    }
+
+    /// Convert a SessionSnapshot batch into the live `ClaudeSession` values
+    /// the engine expects. Sessions that have exited between the snapshot
+    /// and the call are silently dropped (the engine's cleanup pass will
+    /// notice independently).
+    fn resolve_live(&self, snapshots: &[SessionSnapshot]) -> Vec<ClaudeSession> {
+        let mut live = discovery::scan_sessions();
+        discovery::resolve_jsonl_paths(&mut live);
+        let mut by_id: std::collections::HashMap<String, ClaudeSession> = live
+            .into_iter()
+            .map(|s| (s.session_id.clone(), s))
+            .collect();
+        snapshots
+            .iter()
+            .filter_map(|snap| by_id.remove(snap.session_id.as_str()))
+            .collect()
+    }
+}
+
+impl BrainDriver for LiveBrainDriver {
+    fn tick(
+        &mut self,
+        sessions: &[SessionSnapshot],
+        deny_rules: &[AutoRule],
+    ) -> Vec<(u32, String)> {
+        let live = self.resolve_live(sessions);
+        self.engine.tick(&live, deny_rules)
+    }
+
+    fn cleanup(&mut self, sessions: &[SessionSnapshot]) {
+        let live = self.resolve_live(sessions);
+        self.engine.cleanup(&live);
+    }
+
+    fn accept(&mut self, pid: u32) -> Option<String> {
+        // accept() needs the live session for the PID; look it up directly.
+        let mut live = discovery::scan_sessions();
+        discovery::resolve_jsonl_paths(&mut live);
+        let session = live.into_iter().find(|s| s.pid == pid)?;
+        self.engine.accept(pid, &session)
+    }
+
+    fn reject(&mut self, pid: u32) -> Option<PendingSuggestion> {
+        self.engine
+            .reject(pid)
+            .map(|s| suggestion_from_brain(pid, s))
+    }
+
+    fn pending_for(&self, pid: u32) -> Option<PendingSuggestion> {
+        self.engine
+            .pending
+            .get(&pid)
+            .cloned()
+            .map(|s| suggestion_from_brain(pid, s))
+    }
+
+    fn pending_count(&self) -> usize {
+        self.engine.pending.len()
+    }
+
+    fn clear_pending(&mut self) {
+        self.engine.pending.clear();
+    }
+}
+
+fn suggestion_from_brain(pid: u32, s: BrainSuggestion) -> PendingSuggestion {
+    PendingSuggestion {
+        pid,
+        action: format!("{:?}", s.action).to_lowercase(),
+        message: s.message,
+        reasoning: s.reasoning,
+        confidence: s.confidence,
+        suggested_at: s.suggested_at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `RuleAction` formatted via `Debug` (then lowercased) is the wire
+    /// label callers see. Lock the shape so future variants don't silently
+    /// drift.
+    #[test]
+    fn action_label_format_is_stable() {
+        let s = BrainSuggestion {
+            action: claudectl_core::rules::RuleAction::Approve,
+            message: None,
+            reasoning: "test".into(),
+            confidence: 0.5,
+            suggested_at: 0,
+        };
+        let proj = suggestion_from_brain(42, s);
+        assert_eq!(proj.action, "approve");
+        assert_eq!(proj.pid, 42);
+        assert_eq!(proj.confidence, 0.5);
+    }
+
+    #[test]
+    fn deny_action_lowercases() {
+        let s = BrainSuggestion {
+            action: claudectl_core::rules::RuleAction::Deny,
+            message: Some("dangerous".into()),
+            reasoning: "rm -rf".into(),
+            confidence: 0.99,
+            suggested_at: 1_780_000_000,
+        };
+        let proj = suggestion_from_brain(99, s);
+        assert_eq!(proj.action, "deny");
+        assert_eq!(proj.message.as_deref(), Some("dangerous"));
+        assert_eq!(proj.suggested_at, 1_780_000_000);
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -16,12 +16,17 @@ use claudectl_core::runtime::Runtime;
 
 mod actions;
 mod brain;
+mod brain_driver;
 mod bus;
 mod coord;
 mod sessions;
 
 pub use actions::LiveActions;
 pub use brain::LiveBrainView;
+// LiveBrainDriver is the only stateful runtime adapter; the TUI's `App` is the
+// owner. Re-exported for tests and the future `App::new` wiring (next PR).
+#[allow(unused_imports)]
+pub use brain_driver::LiveBrainDriver;
 pub use bus::LiveBusView;
 pub use coord::LiveCoordView;
 pub use sessions::LiveSessionSource;


### PR DESCRIPTION
## Summary

Closes the last design gap for #275. The runtime contract from #285 + #289 was missing one shape: **`BrainEngine` is stateful** — the TUI mutably ticks it every refresh, owns the pending-suggestion map, and applies user accept/reject decisions. `Arc<dyn ...>` doesn't work for that surface; every method needs `&mut`.

This adds **`BrainDriver`** — the trait shape that lets the TUI hold the engine through a contract instead of as a concrete `brain::engine::BrainEngine` field. Same pattern as `Actions` (#289) for the binary-side wrapper.

## Trait surface (`crates/claudectl-core/src/runtime.rs`)

```rust
pub trait BrainDriver: Send {
    fn tick(&mut self, sessions: &[SessionSnapshot],
            deny_rules: &[AutoRule]) -> Vec<(u32, String)>;
    fn cleanup(&mut self, sessions: &[SessionSnapshot]);
    fn accept(&mut self, pid: u32) -> Option<String>;
    fn reject(&mut self, pid: u32) -> Option<PendingSuggestion>;
    fn pending_for(&self, pid: u32) -> Option<PendingSuggestion>;
    fn pending_count(&self) -> usize;
    fn clear_pending(&mut self);
}
```

Plus a `PendingSuggestion` DTO mirroring `brain::client::BrainSuggestion` without exposing brain types. **Boxed (`Box<dyn>`), not `Arc`d** — single owner, `&mut` every call.

## Binary impl (`src/runtime/brain_driver.rs`)

- `LiveBrainDriver` wraps a `BrainEngine`.
- `resolve_live()` translates `SessionSnapshot` batches → live `ClaudeSession` values via discovery. The engine still operates on the rich type internally; the trait surface stays decoupled.
- `accept(pid)` looks up the live session by PID before calling `engine.accept(pid, &session)`.
- `PendingSuggestion` projection uses lowercased `RuleAction` `Debug` as the wire label; round-tripped in a unit test so future `RuleAction` variants don't silently break the wire shape.

## What's NOT in this PR (intentionally)

- **`App` still owns `Option<brain::engine::BrainEngine>` directly.** Switching it to `Option<Box<dyn BrainDriver>>` is the next PR's job (the call-site migration of #275).
- **`engine.pending.insert()` direct mutation** — only used in demo-mode code paths to fake suggestions for screenshots. Will get a demo-mode escape hatch in the migration PR rather than a public trait method.

## After this lands

The contract is complete: **5 read traits + `Actions` + `BrainDriver`**. The rest of #275 is mechanical:

1. Flip ~30 call sites in `app.rs` / `ui/*.rs` from `crate::brain::*` / `crate::coord::*` / `crate::bus::*` to `runtime.{view,actions,brain_driver}.*`.
2. Move 5 files (`app.rs`, `ui/`, `recorder.rs`, `session_recorder.rs`, `demo.rs`) into `crates/claudectl-tui/`.
3. Add `tui-standalone` CI job + final CLAUDE.md note.

No more design questions.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets [--features bus] -- -D warnings` clean
- [x] `cargo test --features bus` — 1308 tests pass (+2 new `BrainDriver` unit tests: `action_label_format_is_stable`, `deny_action_lowercases`)
- [x] `cargo test -p claudectl-core` (standalone) — 104 tests pass
- [x] Layering grep finds zero upward refs in core

🤖 Generated with [Claude Code](https://claude.com/claude-code)