### PR TITLE
refactor(workspace): swap App.brain_engine for Box<dyn BrainDriver> (toward #275)

### DIFF
--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -340,6 +340,12 @@ pub trait BrainDriver: Send {
     /// Drop every pending suggestion. Called when the brain mode flips
     /// off or the operator resets state.
     fn clear_pending(&mut self);
+
+    /// Inject a pending suggestion for `pid`. Used by demo mode to fake
+    /// brain activity for screenshots / recordings. Implementations may
+    /// drop suggestions whose `action` string doesn't map to a known
+    /// engine action (rather than erroring out) — demo is best-effort.
+    fn set_pending(&mut self, suggestion: PendingSuggestion);
 }
 
 // ============================================================================

--- a/src/app.rs
+++ b/src/app.rs
@@ -308,7 +308,10 @@ pub struct App {
     pub last_rule_action: Option<String>,                     // Last auto-action status for display
     pub health_thresholds: crate::config::HealthThresholds,
     pub brain_config: Option<crate::config::BrainConfig>,
-    pub brain_engine: Option<crate::brain::engine::BrainEngine>,
+    /// Stateful brain driver, swapped in by `main.rs` when the brain is
+    /// configured. Held as `Box<dyn BrainDriver>` (not `Arc`) because every
+    /// method needs `&mut`. `None` when the brain is off.
+    pub brain_driver: Option<Box<dyn claudectl_core::runtime::BrainDriver>>,
     pub idle_config: crate::config::IdleConfig,
     pub last_user_interaction: std::time::Instant,
     pub idle_mode_active: bool,
@@ -479,6 +482,43 @@ impl Default for App {
     }
 }
 
+/// Inverse projection: lift a core `PendingSuggestion` back to the binary's
+/// `BrainSuggestion` for the call sites that still need it (notably
+/// `brain::decisions::log_decision`, which is intentionally not on the
+/// `Actions` trait per the #289 scope decision). Falls back to
+/// `RuleAction::Approve` when the string label doesn't parse — the only
+/// callers today come from the driver, so the action is always a known
+/// label and the fallback is unreachable in practice.
+fn pending_to_brain_suggestion(
+    p: &claudectl_core::runtime::PendingSuggestion,
+) -> crate::brain::client::BrainSuggestion {
+    crate::brain::client::BrainSuggestion {
+        action: claudectl_core::rules::RuleAction::parse(&p.action)
+            .unwrap_or(claudectl_core::rules::RuleAction::Approve),
+        message: p.message.clone(),
+        reasoning: p.reasoning.clone(),
+        confidence: p.confidence,
+        suggested_at: p.suggested_at,
+    }
+}
+
+/// Project a live `ClaudeSession` to the core `SessionSnapshot` DTO the
+/// runtime traits accept. Used by `BrainDriver` call sites that have the
+/// live values in memory already.
+fn snapshot_from(session: &ClaudeSession) -> claudectl_core::runtime::SessionSnapshot {
+    claudectl_core::runtime::SessionSnapshot {
+        session_id: session.session_id.clone(),
+        pid: session.pid,
+        cwd: session.cwd.clone(),
+        project_name: session.project_name.clone(),
+        status: session.status.to_string(),
+        cost_usd: session.cost_usd,
+        context_tokens: session.context_tokens,
+        context_max: session.context_max,
+        last_message_ts: session.last_message_ts,
+    }
+}
+
 /// Build a runtime `ObservationInput` from the live session + an observed-
 /// action label. Centralizes the projection so call sites don't repeat the
 /// field plumbing (cf. the 5 sites that used to call
@@ -559,7 +599,7 @@ impl App {
             last_rule_action: None,
             health_thresholds: crate::config::HealthThresholds::default(),
             brain_config: None,
-            brain_engine: None,
+            brain_driver: None,
             runtime: claudectl_core::runtime::MockRuntime::default().into_runtime(),
             idle_config: crate::config::IdleConfig::default(),
             last_user_interaction: std::time::Instant::now(),
@@ -1205,27 +1245,26 @@ impl App {
             }
         }
 
-        // Inject fake brain pending suggestions so the status bar shows brain activity
-        if let Some(ref mut engine) = self.brain_engine {
-            engine.pending.clear();
-            // At certain phases, show a pending suggestion for a NeedsInput session
+        // Inject fake brain pending suggestions so the status bar shows brain activity.
+        // Demo mode flows through the BrainDriver trait's set_pending escape hatch
+        // rather than mutating an engine field directly — same path the real brain
+        // would take.
+        if let Some(ref mut driver) = self.brain_driver {
+            driver.clear_pending();
             let phase = self.demo_tick % 32;
             if (9..=12).contains(&phase) {
-                // Find a NeedsInput session to attach the suggestion to
                 if let Some(s) = sessions
                     .iter()
                     .find(|s| s.status == SessionStatus::NeedsInput)
                 {
-                    engine.pending.insert(
-                        s.pid,
-                        crate::brain::client::BrainSuggestion {
-                            action: crate::rules::RuleAction::Approve,
-                            message: s.pending_tool_input.clone(),
-                            reasoning: "Safe build command, no side effects".into(),
-                            confidence: 0.92,
-                            suggested_at: 0,
-                        },
-                    );
+                    driver.set_pending(claudectl_core::runtime::PendingSuggestion {
+                        pid: s.pid,
+                        action: "approve".into(),
+                        message: s.pending_tool_input.clone(),
+                        reasoning: "Safe build command, no side effects".into(),
+                        confidence: 0.92,
+                        suggested_at: 0,
+                    });
                 }
             }
             if (14..=16).contains(&phase) {
@@ -1233,16 +1272,14 @@ impl App {
                     .iter()
                     .find(|s| s.status == SessionStatus::NeedsInput)
                 {
-                    engine.pending.insert(
-                        s.pid,
-                        crate::brain::client::BrainSuggestion {
-                            action: crate::rules::RuleAction::Deny,
-                            message: s.pending_tool_input.clone(),
-                            reasoning: "Destructive operation, needs manual review".into(),
-                            confidence: 0.87,
-                            suggested_at: 0,
-                        },
-                    );
+                    driver.set_pending(claudectl_core::runtime::PendingSuggestion {
+                        pid: s.pid,
+                        action: "deny".into(),
+                        message: s.pending_tool_input.clone(),
+                        reasoning: "Destructive operation, needs manual review".into(),
+                        confidence: 0.87,
+                        suggested_at: 0,
+                    });
                 }
             }
         }
@@ -1669,7 +1706,7 @@ impl App {
         } // end if !self.rules.is_empty()
 
         // Brain inference (opt-in, runs after rules)
-        if let Some(ref mut engine) = self.brain_engine {
+        if let Some(ref mut driver) = self.brain_driver {
             // Collect deny-only rules for override checking
             let deny_rules: Vec<_> = self
                 .rules
@@ -1678,13 +1715,14 @@ impl App {
                 .cloned()
                 .collect();
 
-            let actions = engine.tick(&self.sessions, &deny_rules);
+            let snapshots: Vec<_> = self.sessions.iter().map(snapshot_from).collect();
+            let actions = driver.tick(&snapshots, &deny_rules);
             for (_pid, msg) in actions {
                 crate::logger::log("BRAIN", &msg);
                 self.status_msg = msg;
             }
 
-            engine.cleanup(&self.sessions);
+            driver.cleanup(&snapshots);
 
             // Deliver pending mailbox messages to sessions waiting for input
             let deliveries = crate::brain::mailbox::deliver_pending(&self.sessions);
@@ -2683,42 +2721,40 @@ impl App {
             return;
         }
         let pid = session.pid;
-        let Some(ref mut engine) = self.brain_engine else {
+        let Some(ref mut driver) = self.brain_driver else {
             self.status_msg = "Brain is not enabled".into();
             return;
         };
         // Get suggestion before accept (for logging)
-        let suggestion = engine.pending.get(&pid).cloned();
-        if suggestion.is_none() {
+        let suggestion = driver.pending_for(pid);
+        let Some(sg) = suggestion else {
             self.status_msg = "No brain suggestion pending for this session".into();
+            return;
+        };
+
+        // If brain suggested deny and no override reason yet, prompt for one
+        if sg.action == "deny" && override_reason.is_none() {
+            self.pending_override_reason = Some(pid);
+            self.status_msg =
+                "Override reason: [1] Always safe  [2] One-time exception  [3] Brain is wrong  [Esc] Cancel"
+                    .into();
             return;
         }
 
-        // If brain suggested deny and no override reason yet, prompt for one
-        if let Some(ref sg) = suggestion {
-            if sg.action.label() == "deny" && override_reason.is_none() {
-                self.pending_override_reason = Some(pid);
-                self.status_msg =
-                    "Override reason: [1] Always safe  [2] One-time exception  [3] Brain is wrong  [Esc] Cancel"
-                        .into();
-                return;
-            }
-        }
-
-        if let Some(msg) = engine.accept(pid, &session) {
-            if let Some(ref sg) = suggestion {
-                crate::brain::decisions::log_decision(
-                    pid,
-                    session.display_name(),
-                    session.pending_tool_name.as_deref(),
-                    session.pending_tool_input.as_deref(),
-                    sg,
-                    "accept",
-                    Some(&session),
-                    crate::brain::decisions::DecisionType::Session,
-                    override_reason,
-                );
-            }
+        if let Some(msg) = driver.accept(pid) {
+            // log_decision is intentionally NOT on the Actions trait yet
+            // (see #289 scope decision). Stays as a direct call.
+            crate::brain::decisions::log_decision(
+                pid,
+                session.display_name(),
+                session.pending_tool_name.as_deref(),
+                session.pending_tool_input.as_deref(),
+                &pending_to_brain_suggestion(&sg),
+                "accept",
+                Some(&session),
+                crate::brain::decisions::DecisionType::Session,
+                override_reason,
+            );
             crate::logger::log("BRAIN", &format!("Accepted: {msg}"));
             self.status_msg = msg;
         }
@@ -2734,17 +2770,17 @@ impl App {
             return;
         }
         let pid = session.pid;
-        let Some(ref mut engine) = self.brain_engine else {
+        let Some(ref mut driver) = self.brain_driver else {
             self.status_msg = "Brain is not enabled".into();
             return;
         };
-        if let Some(suggestion) = engine.reject(pid) {
+        if let Some(suggestion) = driver.reject(pid) {
             crate::brain::decisions::log_decision(
                 pid,
                 session.display_name(),
                 session.pending_tool_name.as_deref(),
                 session.pending_tool_input.as_deref(),
-                &suggestion,
+                &pending_to_brain_suggestion(&suggestion),
                 "reject",
                 Some(&session),
                 crate::brain::decisions::DecisionType::Session,
@@ -2752,8 +2788,7 @@ impl App {
             );
             let msg = format!(
                 "Rejected brain suggestion: {} ({})",
-                suggestion.action.label(),
-                suggestion.reasoning,
+                suggestion.action, suggestion.reasoning,
             );
             crate::logger::log("BRAIN", &msg);
             self.status_msg = msg;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -988,7 +988,9 @@ pub(crate) fn run_headless(
     if let Some(ref brain_cfg) = cfg.brain {
         if brain_cfg.enabled {
             if check_brain_endpoint(&brain_cfg.endpoint, brain_cfg.timeout_ms) {
-                app.brain_engine = Some(crate::brain::engine::BrainEngine::new(brain_cfg.clone()));
+                app.brain_driver = Some(Box::new(crate::runtime::LiveBrainDriver::new(
+                    crate::brain::engine::BrainEngine::new(brain_cfg.clone()),
+                )));
                 emit_headless_event(
                     "startup",
                     serde_json::json!({

--- a/src/main.rs
+++ b/src/main.rs
@@ -1005,7 +1005,9 @@ fn run_tui<W: io::Write>(
     if let Some(ref brain_cfg) = cfg.brain {
         if brain_cfg.enabled {
             if commands::check_brain_endpoint(&brain_cfg.endpoint, brain_cfg.timeout_ms) {
-                app.brain_engine = Some(brain::engine::BrainEngine::new(brain_cfg.clone()));
+                app.brain_driver = Some(Box::new(runtime::LiveBrainDriver::new(
+                    brain::engine::BrainEngine::new(brain_cfg.clone()),
+                )));
                 app.status_msg = format!(
                     "Brain: connected to {} ({})",
                     brain_cfg.endpoint, brain_cfg.model
@@ -1026,10 +1028,10 @@ fn run_tui<W: io::Write>(
         app.budget_usd = Some(10.0);
         app.rules = demo::demo_rules();
         // Create a stub brain engine so the status bar can show brain suggestions
-        if app.brain_engine.is_none() {
-            app.brain_engine = Some(brain::engine::BrainEngine::new(
-                config::BrainConfig::default(),
-            ));
+        if app.brain_driver.is_none() {
+            app.brain_driver = Some(Box::new(runtime::LiveBrainDriver::new(
+                brain::engine::BrainEngine::new(config::BrainConfig::default()),
+            )));
         }
         // Re-refresh to replace real sessions discovered during App::new()
         app.refresh();

--- a/src/runtime/brain_driver.rs
+++ b/src/runtime/brain_driver.rs
@@ -88,6 +88,25 @@ impl BrainDriver for LiveBrainDriver {
     fn clear_pending(&mut self) {
         self.engine.pending.clear();
     }
+
+    fn set_pending(&mut self, suggestion: PendingSuggestion) {
+        // The trait carries `action` as a string for flexibility; the engine
+        // needs a real `RuleAction`. Best-effort: drop the suggestion if it
+        // doesn't parse rather than error out (demo callers are permissive).
+        let Some(action) = claudectl_core::rules::RuleAction::parse(&suggestion.action) else {
+            return;
+        };
+        self.engine.pending.insert(
+            suggestion.pid,
+            BrainSuggestion {
+                action,
+                message: suggestion.message,
+                reasoning: suggestion.reasoning,
+                confidence: suggestion.confidence,
+                suggested_at: suggestion.suggested_at,
+            },
+        );
+    }
 }
 
 fn suggestion_from_brain(pid: u32, s: BrainSuggestion) -> PendingSuggestion {

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -107,9 +107,9 @@ pub fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
             Style::default().fg(t.error).add_modifier(Modifier::BOLD),
         ));
         frame.render_widget(msg, area);
-    } else if let Some(ref engine) = app.brain_engine {
-        if !engine.pending.is_empty() {
-            let count = engine.pending.len();
+    } else if let Some(ref driver) = app.brain_driver {
+        if driver.pending_count() > 0 {
+            let count = driver.pending_count();
             let label = if count == 1 {
                 "1 suggestion".into()
             } else {

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -458,19 +458,15 @@ fn session_row(s: &ClaudeSession, app: &App) -> Row<'static> {
         Style::default().fg(t.status_color(&s.status))
     };
 
-    let has_brain_suggestion = app
-        .brain_engine
-        .as_ref()
-        .is_some_and(|e| e.pending.contains_key(&s.pid));
+    let pending_suggestion = app.brain_driver.as_ref().and_then(|d| d.pending_for(s.pid));
+    let has_brain_suggestion = pending_suggestion.is_some();
 
     let status_text = if app.auto_approve.contains(&s.pid) {
         format!("{}*", s.status)
     } else if has_brain_suggestion {
-        let action = app
-            .brain_engine
+        let action = pending_suggestion
             .as_ref()
-            .and_then(|e| e.pending.get(&s.pid))
-            .map(|sg| sg.action.label())
+            .map(|sg| sg.action.as_str())
             .unwrap_or("?");
         format!("{} [b:{}]", s.status, action)
     } else if s.status == SessionStatus::Unknown {


### PR DESCRIPTION
## Summary

Second call-site migration on top of the runtime contract from #285 / #289 / #290.

`App.brain_engine: Option<BrainEngine>` becomes `App.brain_driver: Option<Box<dyn BrainDriver>>`. Every `tick` / `accept` / `reject` / `pending` site in `app.rs` (and the two `ui/` readers that touched `engine.pending`) now goes through the trait. Behaviour is byte-for-byte identical; this is pure plumbing.

## What changed

| Old | New |
| --- | --- |
| `Option<brain::engine::BrainEngine>` | `Option<Box<dyn BrainDriver>>` |
| `engine.tick(&self.sessions, &deny_rules)` | `driver.tick(&snapshots, &deny_rules)` (snapshots projected via new `snapshot_from` helper) |
| `engine.cleanup(&self.sessions)` | `driver.cleanup(&snapshots)` |
| `engine.pending.get(&pid).cloned()` | `driver.pending_for(pid)` |
| `engine.accept(pid, &session)` | `driver.accept(pid)` (session resolved inside `LiveBrainDriver`) |
| `engine.reject(pid)` | `driver.reject(pid)` returns `PendingSuggestion` |
| `engine.pending.clear()` (demo) | `driver.clear_pending()` |
| `engine.pending.insert(pid, BrainSuggestion {...})` (demo) | `driver.set_pending(PendingSuggestion {...})` |
| `engine.pending.is_empty()` / `.len()` (status bar) | `driver.pending_count() == 0` / `pending_count()` |
| `engine.pending.contains_key(&pid)` / `get(&pid)` (table render) | `driver.pending_for(pid)` |

## New / changed in this PR

- **`BrainDriver::set_pending(PendingSuggestion)`** added to the trait + `LiveBrainDriver` impl. Demo mode (the only caller) injects fake suggestions for screenshots; `LiveBrainDriver` parses the `action: String` back to `RuleAction` via `RuleAction::parse`, dropping unknown labels rather than erroring out.
- **`snapshot_from(&ClaudeSession) → SessionSnapshot`** helper in `app.rs`. The trait operates on snapshots; the TUI has the live values, so it projects once per `tick`. The wasted discovery scan inside `LiveBrainDriver::tick` is a known minor inefficiency (one extra scan per refresh) — fixable later if needed.
- **`pending_to_brain_suggestion(&PendingSuggestion) → BrainSuggestion`** helper. Inverse projection used for the still-direct `brain::decisions::log_decision` call site, which is intentionally not on the `Actions` trait per the #289 scope decision.
- **Field rename**: `brain_engine` → `brain_driver` everywhere (App struct, `main.rs`, `commands.rs`, `ui/`).

## Why this matters

This removes the **biggest single binary-coupling lever from `App`**. The engine was the one stateful, deeply-mutated thing the TUI owned — every other dep on brain/coord/bus was a function call. After this lands, the TUI's binary surface is purely call sites — no concrete brain types in the struct's type signature.

## What's NOT in this PR (next focused PRs)

- `coord_leases` / `coord_handoffs` / `coord_pending_interrupts` field types still on the concrete `coord::types::*` types
- `coord::store::open()` + `list_leases` / `list_pending_handoffs` / `list_interrupts` direct calls (~5 sites)
- `brain_decisions_cache` + `brain_queue` (no trait coverage yet — needs an `EngineQueryView` or similar)
- `mailbox::deliver_pending` (orchestrator-style, see #289 scope)

After this PR, cross-binary refs in `app.rs` drop from **25 → 17** (was 49 before #291).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets [--features bus] -- -D warnings` clean
- [x] `cargo test --features bus` — 1300 tests pass, **0 behavior change**
- [x] Local install with `--features "coord,hive,relay,bus"` still builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)