### PR TITLE
refactor(workspace): swap coord field types to runtime DTOs (toward #275)

### DIFF
--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -140,6 +140,10 @@ pub struct LeaseSummary {
     pub resource_value: String,
     pub mode: String,
     pub acquired_at: String,
+    /// ISO timestamp when the lease expires. `None` for leases held without
+    /// an explicit deadline.
+    #[serde(default)]
+    pub expires_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -319,9 +319,9 @@ pub struct App {
     pub idle_report: Vec<String>,
     // Coordination layer (feature-gated)
     #[cfg(feature = "coord")]
-    pub coord_leases: Vec<crate::coord::types::Lease>,
+    pub coord_leases: Vec<claudectl_core::runtime::LeaseSummary>,
     #[cfg(feature = "coord")]
-    pub coord_handoffs: Vec<crate::coord::types::Handoff>,
+    pub coord_handoffs: Vec<claudectl_core::runtime::HandoffSummary>,
     #[cfg(feature = "coord")]
     pub coord_lease_sessions: HashSet<String>,
     #[cfg(feature = "coord")]
@@ -329,7 +329,7 @@ pub struct App {
     #[cfg(feature = "coord")]
     pub coord_interrupt_targets: HashSet<String>,
     #[cfg(feature = "coord")]
-    pub coord_pending_interrupts: Vec<crate::coord::types::Interrupt>,
+    pub coord_pending_interrupts: Vec<claudectl_core::runtime::InterruptSummary>,
     #[cfg(feature = "coord")]
     pub coord_tick: u32,
     // Relay peers panel (feature-gated)
@@ -1379,18 +1379,24 @@ impl App {
         }
     }
 
-    /// Refresh cached coordination state from SQLite.
+    /// Refresh cached coordination state from the runtime.
+    ///
+    /// The `expire_stale_*` calls remain direct because they're side-effects
+    /// on the SQLite store (bookkeeping), not part of the read-only
+    /// `CoordView` surface. The actual list queries go through the runtime
+    /// trait so the binary-coord coupling stays one layer thick.
     #[cfg(feature = "coord")]
     pub fn coord_refresh(&mut self) {
-        let conn = match crate::coord::store::open() {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let _ = crate::coord::store::expire_stale_leases(&conn);
-        self.coord_leases =
-            crate::coord::store::list_leases(&conn, Some(crate::coord::types::LeaseStatus::Active))
-                .unwrap_or_default();
-        self.coord_handoffs = crate::coord::store::list_pending_handoffs(&conn).unwrap_or_default();
+        // Bookkeeping (expire stale rows). Best-effort; failures are logged
+        // by the store itself.
+        if let Ok(conn) = crate::coord::store::open() {
+            let _ = crate::coord::store::expire_stale_leases(&conn);
+            let _ = crate::coord::store::expire_stale_interrupts(&conn);
+        }
+
+        self.coord_leases = self.runtime.coord.active_leases();
+        self.coord_handoffs = self.runtime.coord.pending_handoffs();
+        self.coord_pending_interrupts = self.runtime.coord.pending_interrupts();
 
         self.coord_lease_sessions = self
             .coord_leases
@@ -1408,13 +1414,6 @@ impl App {
                 ids
             })
             .collect();
-
-        let _ = crate::coord::store::expire_stale_interrupts(&conn);
-        self.coord_pending_interrupts = crate::coord::store::list_interrupts(
-            &conn,
-            Some(crate::coord::types::InterruptState::Pending),
-        )
-        .unwrap_or_default();
         self.coord_interrupt_targets = self
             .coord_pending_interrupts
             .iter()

--- a/src/runtime/coord.rs
+++ b/src/runtime/coord.rs
@@ -70,6 +70,7 @@ fn lease_summary_from(l: crate::coord::types::Lease) -> LeaseSummary {
         resource_value: l.resource_value,
         mode: l.mode.to_string(),
         acquired_at: l.acquired_at,
+        expires_at: l.expires_at,
     }
 }
 

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -254,13 +254,13 @@ pub fn render_detail_panel(frame: &mut Frame, area: Rect, session: &ClaudeSessio
     // Coordination section (leases and handoffs for this session)
     #[cfg(feature = "coord")]
     {
-        let session_leases: Vec<&crate::coord::types::Lease> = app
+        let session_leases: Vec<&claudectl_core::runtime::LeaseSummary> = app
             .coord_leases
             .iter()
             .filter(|l| l.owner_session_id == session.session_id)
             .collect();
 
-        let session_handoffs: Vec<&crate::coord::types::Handoff> = app
+        let session_handoffs: Vec<&claudectl_core::runtime::HandoffSummary> = app
             .coord_handoffs
             .iter()
             .filter(|h| {
@@ -319,7 +319,7 @@ pub fn render_detail_panel(frame: &mut Frame, area: Rect, session: &ClaudeSessio
             }
 
             // Pending interrupts targeting this session
-            let session_interrupts: Vec<&crate::coord::types::Interrupt> = app
+            let session_interrupts: Vec<&claudectl_core::runtime::InterruptSummary> = app
                 .coord_pending_interrupts
                 .iter()
                 .filter(|i| i.target_session_id == session.session_id)


### PR DESCRIPTION
## Summary

Third call-site migration on top of the runtime contract from #285 / #289 / #290.

The App struct's coord fields — `Vec<coord::types::Lease>` and friends — are replaced with `Vec<claudectl_core::runtime::LeaseSummary>` etc. The direct `coord::store::list_*` calls in `coord_refresh()` route through `runtime.coord.*`. Behaviour is unchanged.

## What changed

| Old | New |
| --- | --- |
| `Vec<coord::types::Lease>` | `Vec<LeaseSummary>` |
| `Vec<coord::types::Handoff>` | `Vec<HandoffSummary>` |
| `Vec<coord::types::Interrupt>` | `Vec<InterruptSummary>` |
| `coord::store::list_leases(&conn, Some(LeaseStatus::Active))` | `self.runtime.coord.active_leases()` |
| `coord::store::list_pending_handoffs(&conn)` | `self.runtime.coord.pending_handoffs()` |
| `coord::store::list_interrupts(&conn, Some(InterruptState::Pending))` | `self.runtime.coord.pending_interrupts()` |

UI sites updated to use the new DTO types (`src/ui/detail.rs`): three local `Vec<&...>` bindings retyped from `coord::types::*` to `claudectl_core::runtime::*Summary`. Field access patterns (`lease.resource_kind`, `handoff.summary`, `intr.priority`, etc.) unchanged — the DTOs carry the same shape.

## DTO fix

`LeaseSummary` gained `expires_at: Option<String>` — the UI rendered `lease.expires_at` and the DTO was missing the field. Added with `#[serde(default)]` so older serialized markers stay forward-compatible.

## What stays direct (intentionally, per #289 scope)

- `coord::store::expire_stale_leases` / `expire_stale_interrupts` — bookkeeping side-effects, not part of the read-only `CoordView` contract.
- `coord::interrupt_bus::deliver_pending` — orchestrator-style mailbox delivery, belongs on a future `Orchestrator` trait, not `CoordView`.

## Progress

After this PR, cross-binary refs in `app.rs` drop from **24 → 17** (was 49 before #291).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets [--features coord, bus] -- -D warnings` clean
- [x] `cargo test --features bus` — 1300 tests pass, 0 behavior change
- [x] `cargo test -p claudectl-core` (standalone) — 104 tests pass

## What remains for #275

- `brain_decisions_cache` / `brain_queue` direct reads (need new traits for the Brain Review surface)
- `mailbox::deliver_pending` orchestration (future `Orchestrator` trait)
- The remaining ~17 sites are mostly the Brain Review and review-mark paths
- After those: file move into `crates/claudectl-tui/` and `tui-standalone` CI job

🤖 Generated with [Claude Code](https://claude.com/claude-code)