### PR TITLE
refactor(workspace): scaffold DecisionRecord → DecisionSummary projection (toward #275)

### DIFF
--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -119,6 +119,11 @@ pub struct DecisionSummary {
     pub confidence: Option<f64>,
     pub project: Option<String>,
     pub tool: Option<String>,
+    /// PID of the session this decision belongs to. Used by counterfactual
+    /// analysis to pair decisions with their subsequent outcome from the
+    /// same session.
+    #[serde(default)]
+    pub pid: u32,
 
     /// Tool input string when the decision was about a specific command.
     #[serde(default)]
@@ -150,6 +155,16 @@ pub struct DecisionSummary {
     /// Model that produced the suggestion.
     #[serde(default)]
     pub model: Option<String>,
+    /// Resolved outcome category, when known. `"success" | "error" |
+    /// "test_failed" | "skipped"` etc. Mirrors the variants of the binary's
+    /// `brain::decisions::DecisionOutcome` enum, flattened to a string so
+    /// the contract doesn't pull the enum upward.
+    #[serde(default)]
+    pub outcome_kind: Option<String>,
+    /// Free-form detail for failure outcomes (the failing command for
+    /// `test_failed`, the error message for `error`).
+    #[serde(default)]
+    pub outcome_detail: Option<String>,
 }
 
 impl DecisionSummary {
@@ -779,6 +794,7 @@ mod tests {
                     confidence: Some(0.9),
                     project: None,
                     tool: None,
+                    pid: 0,
                     command: None,
                     reasoning: None,
                     user_action: None,
@@ -788,6 +804,8 @@ mod tests {
                     cache_hit: None,
                     cost_usd: None,
                     model: None,
+                    outcome_kind: None,
+                    outcome_detail: None,
                 })
                 .collect(),
             ..Default::default()

--- a/src/brain/decisions.rs
+++ b/src/brain/decisions.rs
@@ -158,6 +158,44 @@ pub struct DecisionContext {
     pub hour: Option<u8>,
 }
 
+/// Project a `DecisionRecord` into the core `DecisionSummary` DTO. Used by
+/// every runtime adapter (`BrainView`, `BrainReviewView`) plus the metrics
+/// pipeline once it migrates to operate on summaries. Conversion lives here
+/// because `DecisionRecord` is local to the binary crate, satisfying the
+/// orphan rules for the foreign `DecisionSummary` impl.
+impl From<&DecisionRecord> for claudectl_core::runtime::DecisionSummary {
+    fn from(r: &DecisionRecord) -> Self {
+        Self {
+            id: r.decision_id.clone().unwrap_or_default(),
+            timestamp: r.timestamp.clone(),
+            action: r.brain_action.clone(),
+            confidence: Some(r.brain_confidence),
+            project: Some(r.project.clone()),
+            tool: r.tool.clone(),
+            pid: r.pid,
+            command: r.command.clone(),
+            reasoning: Some(r.brain_reasoning.clone()).filter(|s| !s.is_empty()),
+            user_action: Some(r.user_action.clone()),
+            override_reason: r.override_reason.clone(),
+            brain_decision_ms: r.brain_decision_ms,
+            canonical: r.canonical,
+            cache_hit: r.cache_hit,
+            cost_usd: r.context.as_ref().map(|c| c.cost_usd),
+            model: r.context.as_ref().map(|c| c.model.clone()),
+            outcome_kind: r.outcome.as_ref().map(|o| match o {
+                DecisionOutcome::Success => "success".to_string(),
+                DecisionOutcome::Error(_) => "error".to_string(),
+                DecisionOutcome::TestFailed(_) => "test_failed".to_string(),
+            }),
+            outcome_detail: r.outcome.as_ref().and_then(|o| match o {
+                DecisionOutcome::Error(msg) => Some(msg.clone()),
+                DecisionOutcome::TestFailed(cmd) => Some(cmd.clone()),
+                _ => None,
+            }),
+        }
+    }
+}
+
 impl DecisionRecord {
     /// Whether this decision represents a positive outcome (user agreed or auto-executed).
     pub fn is_positive(&self) -> bool {

--- a/src/runtime/brain.rs
+++ b/src/runtime/brain.rs
@@ -35,23 +35,7 @@ fn parse_gate_mode(raw: &str) -> BrainGateMode {
 }
 
 fn summary_from_record(r: brain::decisions::DecisionRecord) -> DecisionSummary {
-    DecisionSummary {
-        id: r.decision_id.unwrap_or_default(),
-        timestamp: r.timestamp,
-        action: r.brain_action,
-        confidence: Some(r.brain_confidence),
-        project: Some(r.project),
-        tool: r.tool,
-        command: r.command,
-        reasoning: Some(r.brain_reasoning).filter(|s| !s.is_empty()),
-        user_action: Some(r.user_action),
-        override_reason: r.override_reason,
-        brain_decision_ms: r.brain_decision_ms,
-        canonical: r.canonical,
-        cache_hit: r.cache_hit,
-        cost_usd: r.context.as_ref().map(|c| c.cost_usd),
-        model: r.context.as_ref().map(|c| c.model.clone()),
-    }
+    DecisionSummary::from(&r)
 }
 
 #[cfg(test)]

--- a/src/runtime/brain_review.rs
+++ b/src/runtime/brain_review.rs
@@ -29,23 +29,7 @@ impl BrainReviewView for LiveBrainReviewView {
 }
 
 fn summary_from(r: brain::decisions::DecisionRecord) -> DecisionSummary {
-    DecisionSummary {
-        id: r.decision_id.unwrap_or_default(),
-        timestamp: r.timestamp,
-        action: r.brain_action,
-        confidence: Some(r.brain_confidence),
-        project: Some(r.project),
-        tool: r.tool,
-        command: r.command,
-        reasoning: Some(r.brain_reasoning).filter(|s| !s.is_empty()),
-        user_action: Some(r.user_action),
-        override_reason: r.override_reason,
-        brain_decision_ms: r.brain_decision_ms,
-        canonical: r.canonical,
-        cache_hit: r.cache_hit,
-        cost_usd: r.context.as_ref().map(|c| c.cost_usd),
-        model: r.context.as_ref().map(|c| c.model.clone()),
-    }
+    DecisionSummary::from(&r)
 }
 
 fn item_summary_from(item: brain::review::ReviewItem) -> ReviewItemSummary {


### PR DESCRIPTION
## Summary

Lays the groundwork for the metrics.rs cascade refactor needed to finish migrating `ui/brain.rs` onto the runtime contract. The actual `compute_*` signature changes need a focused follow-up PR.

## What's in

### `crates/claudectl-core/src/runtime.rs`

Three new fields on `DecisionSummary` covering what `compute_counterfactuals` reads from `DecisionRecord`:

```rust
pub pid: u32,                          // session pid — used to pair decisions with outcomes
pub outcome_kind: Option<String>,      // "success" | "error" | "test_failed"
pub outcome_detail: Option<String>,    // failing command for test_failed, message for error
```

`outcome_kind`/`outcome_detail` flatten the `DecisionOutcome` enum to strings so the contract stays free of brain types.

### `src/brain/decisions.rs`

```rust
impl From<&DecisionRecord> for claudectl_core::runtime::DecisionSummary {
    fn from(r: &DecisionRecord) -> Self { /* ... */ }
}
```

`DecisionRecord` is local to the binary crate, satisfying orphan rules for this foreign-type impl. Replaces the **two near-identical `summary_from*` helpers** in `src/runtime/{brain,brain_review}.rs` with a single canonical projection that lives next to its source type — eliminates a real drift risk (the duplicates would have been a pain to keep in sync as `DecisionSummary` grew).

### `src/runtime/brain.rs` + `src/runtime/brain_review.rs`

Both `summary_from*` helpers now delegate to `DecisionSummary::from(&r)`.

## NOT in this PR

Migrating `brain::metrics::compute_tier_stats` / `compute_latency` / `compute_cache` / `compute_counterfactuals` to take `&[DecisionSummary]`. That cascade touches ~10 call sites in `metrics.rs` where the OTHER `compute_*` functions read `DecisionRecord` fields not yet in `DecisionSummary` (`resolved_at`, `suggested_at`). It needs its own focused PR with judgment on whether to also extend `DecisionSummary` or carve out a `Vec<DecisionRecord>` path for those internal callers.

After this PR, the path forward is clearer: extend `DecisionSummary` once more (`resolved_at`, `suggested_at`), then migrate all four `compute_*` in one motion.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy -p claudectl-core --all-targets -- -D warnings` clean
- [x] `cargo test --features bus` — 1300 tests pass, 0 behavior change
- [x] `cargo test -p claudectl-core` (standalone) — 104 tests pass
- [x] Layering grep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)