### PR TITLE
refactor(workspace): migrate compute_* to DecisionSummary (toward #275)

### DIFF
--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -165,6 +165,15 @@ pub struct DecisionSummary {
     /// `test_failed`, the error message for `error`).
     #[serde(default)]
     pub outcome_detail: Option<String>,
+    /// Epoch seconds when the brain suggestion was first surfaced. Used by
+    /// time-to-correct analysis. `None` for records pre-instrumentation or
+    /// passive observations.
+    #[serde(default)]
+    pub suggested_at: Option<u64>,
+    /// Epoch seconds when the user acted on the suggestion. `None` for
+    /// passive observations or records still in flight.
+    #[serde(default)]
+    pub resolved_at: Option<u64>,
 }
 
 impl DecisionSummary {
@@ -806,6 +815,8 @@ mod tests {
                     model: None,
                     outcome_kind: None,
                     outcome_detail: None,
+                    suggested_at: None,
+                    resolved_at: None,
                 })
                 .collect(),
             ..Default::default()

--- a/src/brain/decisions.rs
+++ b/src/brain/decisions.rs
@@ -192,6 +192,8 @@ impl From<&DecisionRecord> for claudectl_core::runtime::DecisionSummary {
                 DecisionOutcome::TestFailed(cmd) => Some(cmd.clone()),
                 _ => None,
             }),
+            suggested_at: r.suggested_at,
+            resolved_at: r.resolved_at,
         }
     }
 }

--- a/src/brain/metrics.rs
+++ b/src/brain/metrics.rs
@@ -2,7 +2,21 @@
 
 use std::collections::{HashMap, HashSet};
 
+use claudectl_core::runtime::DecisionSummary;
+
 use super::decisions::{DecisionRecord, read_all_decisions};
+
+/// Read every decision on disk and project to the core `DecisionSummary`
+/// DTO in one pass. Used by every `print_*` and `compute_*` helper below —
+/// the on-disk shape stays `DecisionRecord`, but the metrics pipeline
+/// operates on the summary form so the surface can be shared with the TUI
+/// (`ui/brain.rs`) without depending on brain-private types.
+fn read_all_summaries() -> Vec<DecisionSummary> {
+    read_all_decisions()
+        .iter()
+        .map(DecisionSummary::from)
+        .collect()
+}
 
 // ────────────────────────────────────────────────────────────────────────────
 // Re-exports from sub-modules so that existing `brain::metrics::*` paths
@@ -1823,7 +1837,7 @@ impl TierStats {
 
 /// Compute per-tier stats over every decision record where the brain was involved.
 /// Observations (brain_action == "") are excluded — we can't score what the brain didn't predict.
-pub fn compute_tier_stats(decisions: &[DecisionRecord]) -> Vec<TierStats> {
+pub fn compute_tier_stats(decisions: &[DecisionSummary]) -> Vec<TierStats> {
     let tiers = [
         RiskTier::Low,
         RiskTier::Medium,
@@ -1833,20 +1847,20 @@ pub fn compute_tier_stats(decisions: &[DecisionRecord]) -> Vec<TierStats> {
     tiers
         .into_iter()
         .map(|tier| {
-            let matching: Vec<&DecisionRecord> = decisions
+            let matching: Vec<&DecisionSummary> = decisions
                 .iter()
-                .filter(|d| !d.brain_action.is_empty())
+                .filter(|d| !d.action.is_empty())
                 .filter(|d| classify_risk(d.tool.as_deref(), d.command.as_deref()) == tier)
                 .collect();
             let n = matching.len();
             let correct = matching.iter().filter(|d| d.is_positive()).count();
             let false_approves = matching
                 .iter()
-                .filter(|d| d.brain_action == "approve" && d.is_negative())
+                .filter(|d| d.action == "approve" && d.is_negative())
                 .count();
             let false_denies = matching
                 .iter()
-                .filter(|d| d.brain_action == "deny" && d.is_negative())
+                .filter(|d| d.action == "deny" && d.is_negative())
                 .count();
             let overrides = matching.iter().filter(|d| d.is_negative()).count();
             let override_rate = if n > 0 {
@@ -1868,7 +1882,7 @@ pub fn compute_tier_stats(decisions: &[DecisionRecord]) -> Vec<TierStats> {
 
 /// Print the per-tier breakdown.
 pub fn print_tier_breakdown() {
-    let decisions = read_all_decisions();
+    let decisions = read_all_summaries();
     let stats = compute_tier_stats(&decisions);
 
     println!("Per-Risk-Tier Accuracy");
@@ -1927,7 +1941,7 @@ pub struct LatencySummary {
 }
 
 /// Compute latency percentiles from decisions that have `brain_decision_ms` set.
-pub fn compute_latency(decisions: &[DecisionRecord]) -> LatencySummary {
+pub fn compute_latency(decisions: &[DecisionSummary]) -> LatencySummary {
     let mut samples: Vec<u64> = decisions
         .iter()
         .filter_map(|d| d.brain_decision_ms)
@@ -1955,7 +1969,7 @@ pub fn compute_latency(decisions: &[DecisionRecord]) -> LatencySummary {
 /// Print a latency report with histogram. Skips gracefully when no
 /// instrumented records exist yet.
 pub fn print_latency() {
-    let decisions = read_all_decisions();
+    let decisions = read_all_summaries();
     let summary = compute_latency(&decisions);
 
     println!("Brain Decision Latency");
@@ -2047,7 +2061,7 @@ impl CacheSummary {
     }
 }
 
-pub fn compute_cache(decisions: &[DecisionRecord]) -> CacheSummary {
+pub fn compute_cache(decisions: &[DecisionSummary]) -> CacheSummary {
     let hits = decisions
         .iter()
         .filter(|d| d.cache_hit == Some(true))
@@ -2064,7 +2078,7 @@ pub fn compute_cache(decisions: &[DecisionRecord]) -> CacheSummary {
 }
 
 pub fn print_cache_hits() {
-    let decisions = read_all_decisions();
+    let decisions = read_all_summaries();
     let summary = compute_cache(&decisions);
 
     println!("Few-Shot Cache Hit Rate");
@@ -2119,12 +2133,12 @@ pub struct Counterfactual {
 /// Find counterfactual cases: where brain and user disagreed, and the
 /// subsequent outcome went badly. Heuristic: a `TestFailed` or `Error`
 /// outcome on a same-PID decision within `WINDOW` records after this one.
-pub fn compute_counterfactuals(decisions: &[DecisionRecord]) -> Vec<Counterfactual> {
+pub fn compute_counterfactuals(decisions: &[DecisionSummary]) -> Vec<Counterfactual> {
     const WINDOW: usize = 5;
     let mut out = Vec::new();
     for (i, d) in decisions.iter().enumerate() {
         // We only care about cases where brain was involved AND user disagreed.
-        if d.brain_action.is_empty() {
+        if d.action.is_empty() {
             continue;
         }
         if !d.is_negative() {
@@ -2137,12 +2151,14 @@ pub fn compute_counterfactuals(decisions: &[DecisionRecord]) -> Vec<Counterfactu
             if next.pid != d.pid {
                 continue;
             }
-            match &next.outcome {
-                Some(super::decisions::DecisionOutcome::TestFailed(cmd)) => {
+            match next.outcome_kind.as_deref() {
+                Some("test_failed") => {
+                    let cmd = next.outcome_detail.as_deref().unwrap_or("");
                     failing = Some(format!("TestFailed: {}", truncate(cmd, 60)));
                     break;
                 }
-                Some(super::decisions::DecisionOutcome::Error(msg)) => {
+                Some("error") => {
+                    let msg = next.outcome_detail.as_deref().unwrap_or("");
                     failing = Some(format!("Error: {}", truncate(msg, 60)));
                     break;
                 }
@@ -2150,17 +2166,21 @@ pub fn compute_counterfactuals(decisions: &[DecisionRecord]) -> Vec<Counterfactu
             }
         }
         if let Some(summary) = failing {
-            // brain_action == "deny" and user accepted → user-accepted thing
+            // action == "deny" and user accepted → user-accepted thing
             // led to failure → brain was right.
-            let brain_was_right = d.brain_action == "deny" || d.brain_action == "ask";
+            let brain_was_right = d.action == "deny" || d.action == "ask";
             out.push(Counterfactual {
-                decision_id: d.decision_id.clone(),
-                project: d.project.clone(),
+                decision_id: if d.id.is_empty() {
+                    None
+                } else {
+                    Some(d.id.clone())
+                },
+                project: d.project.clone().unwrap_or_default(),
                 tool: d.tool.clone(),
                 command: d.command.clone(),
-                brain_action: d.brain_action.clone(),
-                user_action: d.user_action.clone(),
-                brain_confidence: d.brain_confidence,
+                brain_action: d.action.clone(),
+                user_action: d.user_action.clone().unwrap_or_default(),
+                brain_confidence: d.confidence.unwrap_or(0.0),
                 brain_was_right,
                 outcome_summary: summary,
             });
@@ -2178,7 +2198,7 @@ fn truncate(s: &str, max: usize) -> String {
 }
 
 pub fn print_counterfactuals() {
-    let decisions = read_all_decisions();
+    let decisions = read_all_summaries();
     let cfs = compute_counterfactuals(&decisions);
 
     println!("Counterfactual Analysis");
@@ -2252,20 +2272,17 @@ pub fn print_counterfactuals() {
 
 /// Render every key metric in one screen — the periodic-review surface.
 pub fn print_scorecard() {
-    let decisions = read_all_decisions();
+    let decisions = read_all_summaries();
 
     println!("Brain Scorecard");
     println!("===============");
     println!();
 
     // North-star: auto-handled accuracy.
-    let total_with_brain = decisions
-        .iter()
-        .filter(|d| !d.brain_action.is_empty())
-        .count();
+    let total_with_brain = decisions.iter().filter(|d| !d.action.is_empty()).count();
     let correct = decisions
         .iter()
-        .filter(|d| !d.brain_action.is_empty() && d.is_positive())
+        .filter(|d| !d.action.is_empty() && d.is_positive())
         .count();
     let north_star = if total_with_brain > 0 {
         (correct as f64 / total_with_brain as f64) * 100.0
@@ -2307,10 +2324,10 @@ pub fn print_scorecard() {
         }
     }
 
-    let override_window: Vec<&DecisionRecord> = decisions
+    let override_window: Vec<&DecisionSummary> = decisions
         .iter()
         .rev()
-        .filter(|d| !d.brain_action.is_empty())
+        .filter(|d| !d.action.is_empty())
         .take(50)
         .collect();
     if !override_window.is_empty() {

--- a/src/brain/review.rs
+++ b/src/brain/review.rs
@@ -28,7 +28,12 @@ pub struct ReviewItem {
 /// Build the prioritized review queue.
 pub fn build_queue(decisions: &[DecisionRecord]) -> Vec<ReviewItem> {
     let mut items: Vec<ReviewItem> = Vec::new();
-    let cfs = compute_counterfactuals(decisions);
+    // compute_counterfactuals (and the other compute_* helpers) operate on
+    // the core `DecisionSummary` DTO since the metrics surface is shared
+    // with the TUI. Project once at the call site.
+    let summaries: Vec<claudectl_core::runtime::DecisionSummary> =
+        decisions.iter().map(Into::into).collect();
+    let cfs = compute_counterfactuals(&summaries);
 
     for cf in &cfs {
         if cf.brain_was_right {
@@ -262,7 +267,9 @@ pub fn mark_by_id(decision_id: &str, note: Option<&str>) -> Result<(), String> {
 pub fn print_queue() {
     let decisions = read_all_decisions();
     let queue = build_queue(&decisions);
-    let tier_stats = compute_tier_stats(&decisions);
+    let summaries: Vec<claudectl_core::runtime::DecisionSummary> =
+        decisions.iter().map(Into::into).collect();
+    let tier_stats = compute_tier_stats(&summaries);
 
     println!("Review Queue ({} item(s))", queue.len());
     println!(

--- a/src/ui/brain.rs
+++ b/src/ui/brain.rs
@@ -129,6 +129,11 @@ fn render_counts_header(frame: &mut Frame, area: Rect, app: &App) {
 fn render_scorecard(frame: &mut Frame, area: Rect, app: &App) {
     let t = &app.theme;
     let decisions = &app.brain_decisions_cache;
+    // Project once for every compute_* call below — the metrics surface
+    // operates on the core `DecisionSummary` DTO so it can be shared with
+    // future callers outside the binary.
+    let summaries: Vec<claudectl_core::runtime::DecisionSummary> =
+        decisions.iter().map(Into::into).collect();
 
     let total_with_brain = decisions
         .iter()
@@ -144,10 +149,10 @@ fn render_scorecard(frame: &mut Frame, area: Rect, app: &App) {
         0.0
     };
 
-    let tier_stats = compute_tier_stats(decisions);
-    let latency = compute_latency(decisions);
-    let cache = compute_cache(decisions);
-    let cfs = compute_counterfactuals(decisions);
+    let tier_stats = compute_tier_stats(&summaries);
+    let latency = compute_latency(&summaries);
+    let cache = compute_cache(&summaries);
+    let cfs = compute_counterfactuals(&summaries);
     let brain_right = cfs.iter().filter(|c| c.brain_was_right).count();
     let user_right = cfs.len() - brain_right;
     let canonical_count = decisions


### PR DESCRIPTION
## Summary

Completes the metrics.rs cascade started in #296. All four `brain::metrics::compute_*` functions now operate on the core `DecisionSummary` DTO, so the same surface is reachable from the TUI (`ui/brain.rs`) without depending on brain-private types.

## What changed

### Signatures

| Function | Old | New |
| --- | --- | --- |
| `compute_tier_stats` | `&[DecisionRecord]` | `&[DecisionSummary]` |
| `compute_latency` | `&[DecisionRecord]` | `&[DecisionSummary]` |
| `compute_cache` | `&[DecisionRecord]` | `&[DecisionSummary]` |
| `compute_counterfactuals` | `&[DecisionRecord]` | `&[DecisionSummary]` |

### Field renames inside the function bodies

- `d.brain_action` → `d.action`
- `d.brain_confidence` → `d.confidence.unwrap_or(0.0)`
- `d.decision_id` → `d.id` (with empty-string-to-`None` projection in the `Counterfactual::decision_id` field)
- `next.outcome` (enum) → `next.outcome_kind` + `next.outcome_detail` (the flat strings added in #296)
- `d.project` (String) → `d.project.clone().unwrap_or_default()`
- `d.user_action` (String) → `d.user_action.clone().unwrap_or_default()`

### Call sites updated

`src/brain/metrics.rs`:
- New `read_all_summaries()` helper alongside `read_all_decisions()`.
- `print_tier_breakdown` / `print_latency` / `print_cache_hits` / `print_counterfactuals` / `print_scorecard` all swap to it.
- `print_scorecard`'s inline field reads (`d.brain_action`, `Vec<&DecisionRecord>` override window) renamed accordingly.

`src/brain/review.rs`:
- `build_queue` projects records → summaries before calling `compute_counterfactuals`.
- `print_queue` projects records → summaries before calling `compute_tier_stats`.

`src/ui/brain.rs` (`render_scorecard`):
- One-pass projection of `app.brain_decisions_cache` to `Vec<DecisionSummary>`, used for all four `compute_*` calls.

### DTO

Two new fields on `DecisionSummary`: `suggested_at: Option<u64>`, `resolved_at: Option<u64>`. Covers the time-to-correct surface that `DecisionRecord` exposed but the DTO didn't yet. Both `#[serde(default)]` so older serialized markers still parse.

## What this unblocks

`ui/brain.rs`'s `brain_decisions_cache` / `brain_queue` **field types** can now be migrated to `Vec<DecisionSummary>` / `Vec<ReviewItemSummary>` in the next PR. The rest of `ui/brain.rs`'s direct `DecisionRecord` field reads still need migration after that — but the metrics surface (the biggest dependency) is now clean.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets [--features bus] -- -D warnings` clean
- [x] `cargo clippy -p claudectl-core --all-targets -- -D warnings` clean
- [x] `cargo test --features bus` — 1300 tests pass, 0 behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)