### PR TITLE
refactor(workspace): migrate brain_queue/decisions_cache fields + ui/brain.rs (toward #275)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -380,9 +380,9 @@ pub struct App {
     /// Currently selected index into `brain_queue`.
     pub brain_review_selected: usize,
     /// Prioritized review candidates (refreshed when the overlay opens or `r` is pressed).
-    pub brain_queue: Vec<crate::brain::review::ReviewItem>,
+    pub brain_queue: Vec<claudectl_core::runtime::ReviewItemSummary>,
     /// All decision records loaded for the scorecard view.
-    pub brain_decisions_cache: Vec<crate::brain::decisions::DecisionRecord>,
+    pub brain_decisions_cache: Vec<claudectl_core::runtime::DecisionSummary>,
     /// Transient status message shown in the overlay footer.
     pub brain_status_msg: Option<String>,
     /// When true, the overlay captures text input for a canonical-note.
@@ -2009,8 +2009,8 @@ impl App {
     }
 
     pub fn refresh_brain(&mut self) {
-        self.brain_decisions_cache = crate::brain::decisions::read_all_decisions();
-        self.brain_queue = crate::brain::review::build_queue(&self.brain_decisions_cache);
+        self.brain_decisions_cache = self.runtime.review.all_decisions();
+        self.brain_queue = self.runtime.review.review_queue();
         if self.brain_review_selected >= self.brain_queue.len() {
             self.brain_review_selected = self.brain_queue.len().saturating_sub(1);
         }
@@ -2084,10 +2084,12 @@ impl App {
         let Some(item) = self.brain_queue.get(self.brain_review_selected) else {
             return;
         };
-        let Some(id) = item.record.decision_id.clone() else {
+        // DecisionSummary stores the id as a String; empty == "no decision_id".
+        let id = item.decision.id.clone();
+        if id.is_empty() {
             self.brain_status_msg = Some("No decision_id — older record, can't mark.".into());
             return;
-        };
+        }
         match self
             .runtime
             .actions

--- a/src/ui/brain.rs
+++ b/src/ui/brain.rs
@@ -15,8 +15,9 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
 
+use claudectl_core::runtime::DecisionSummary;
+
 use crate::app::{App, BrainTab};
-use crate::brain::decisions::DecisionRecord;
 use crate::brain::metrics::{
     CacheSummary, LatencySummary, TierStats, compute_cache, compute_counterfactuals,
     compute_latency, compute_tier_stats,
@@ -105,7 +106,7 @@ fn render_counts_header(frame: &mut Frame, area: Rect, app: &App) {
     let with_brain = app
         .brain_decisions_cache
         .iter()
-        .filter(|d| !d.brain_action.is_empty())
+        .filter(|d| !d.action.is_empty())
         .count();
     let line = Line::from(vec![
         Span::styled(
@@ -129,19 +130,10 @@ fn render_counts_header(frame: &mut Frame, area: Rect, app: &App) {
 fn render_scorecard(frame: &mut Frame, area: Rect, app: &App) {
     let t = &app.theme;
     let decisions = &app.brain_decisions_cache;
-    // Project once for every compute_* call below — the metrics surface
-    // operates on the core `DecisionSummary` DTO so it can be shared with
-    // future callers outside the binary.
-    let summaries: Vec<claudectl_core::runtime::DecisionSummary> =
-        decisions.iter().map(Into::into).collect();
-
-    let total_with_brain = decisions
-        .iter()
-        .filter(|d| !d.brain_action.is_empty())
-        .count();
+    let total_with_brain = decisions.iter().filter(|d| !d.action.is_empty()).count();
     let correct = decisions
         .iter()
-        .filter(|d| !d.brain_action.is_empty() && d.is_positive())
+        .filter(|d| !d.action.is_empty() && d.is_positive())
         .count();
     let north_star = if total_with_brain > 0 {
         (correct as f64 / total_with_brain as f64) * 100.0
@@ -149,10 +141,10 @@ fn render_scorecard(frame: &mut Frame, area: Rect, app: &App) {
         0.0
     };
 
-    let tier_stats = compute_tier_stats(&summaries);
-    let latency = compute_latency(&summaries);
-    let cache = compute_cache(&summaries);
-    let cfs = compute_counterfactuals(&summaries);
+    let tier_stats = compute_tier_stats(decisions);
+    let latency = compute_latency(decisions);
+    let cache = compute_cache(decisions);
+    let cfs = compute_counterfactuals(decisions);
     let brain_right = cfs.iter().filter(|c| c.brain_was_right).count();
     let user_right = cfs.len() - brain_right;
     let canonical_count = decisions
@@ -160,10 +152,10 @@ fn render_scorecard(frame: &mut Frame, area: Rect, app: &App) {
         .filter(|d| d.canonical == Some(true))
         .count();
 
-    let override_window: Vec<&DecisionRecord> = decisions
+    let override_window: Vec<&DecisionSummary> = decisions
         .iter()
         .rev()
-        .filter(|d| !d.brain_action.is_empty())
+        .filter(|d| !d.action.is_empty())
         .take(50)
         .collect();
     let override_rate = if override_window.is_empty() {
@@ -381,11 +373,14 @@ fn render_review_list(frame: &mut Frame, area: Rect, app: &App) {
         .iter()
         .enumerate()
         .map(|(i, item)| {
-            let tier = classify_risk(item.record.tool.as_deref(), item.record.command.as_deref());
+            let tier = classify_risk(
+                item.decision.tool.as_deref(),
+                item.decision.command.as_deref(),
+            );
             let header = format!(
                 "[{score:>3}] {tool:<8} {tier:<8}",
                 score = item.score,
-                tool = item.record.tool.as_deref().unwrap_or("?"),
+                tool = item.decision.tool.as_deref().unwrap_or("?"),
                 tier = tier.label(),
             );
             let reason = truncate(&item.reason, 60);
@@ -422,7 +417,7 @@ fn render_review_detail(frame: &mut Frame, area: Rect, app: &App) {
     let Some(item) = app.brain_queue.get(app.brain_review_selected) else {
         return;
     };
-    let d = &item.record;
+    let d = &item.decision;
     let tier = classify_risk(d.tool.as_deref(), d.command.as_deref());
 
     let muted = Style::default().fg(t.text_muted);
@@ -441,7 +436,7 @@ fn render_review_detail(frame: &mut Frame, area: Rect, app: &App) {
     ]));
     lines.push(Line::from(vec![
         Span::styled("  project:     ", muted),
-        Span::styled(&d.project, primary),
+        Span::styled(d.project.as_deref().unwrap_or("(none)"), primary),
     ]));
     lines.push(Line::from(vec![
         Span::styled("  tool:        ", muted),
@@ -459,21 +454,22 @@ fn render_review_detail(frame: &mut Frame, area: Rect, app: &App) {
         Span::styled(
             format!(
                 "{} ({:.0}% confidence)",
-                d.brain_action,
-                d.brain_confidence * 100.0
+                d.action,
+                d.confidence.unwrap_or(0.0) * 100.0
             ),
             primary,
         ),
     ]));
-    if !d.brain_reasoning.is_empty() {
+    let reasoning = d.reasoning.as_deref().unwrap_or("");
+    if !reasoning.is_empty() {
         lines.push(Line::from(Span::styled("  reasoning:", muted)));
-        for chunk in wrap_lines(&d.brain_reasoning, 70) {
+        for chunk in wrap_lines(reasoning, 70) {
             lines.push(Line::from(Span::styled(format!("    {}", chunk), primary)));
         }
     }
     lines.push(Line::from(vec![
         Span::styled("  user:        ", muted),
-        Span::styled(&d.user_action, primary),
+        Span::styled(d.user_action.as_deref().unwrap_or("(none)"), primary),
     ]));
     if let Some(reason) = &d.override_reason {
         lines.push(Line::from(vec![
@@ -493,14 +489,18 @@ fn render_review_detail(frame: &mut Frame, area: Rect, app: &App) {
             Span::styled(format!("{hit}"), primary),
         ]));
     }
-    if let Some(ctx) = &d.context {
+    // DecisionSummary flattens `DecisionRecord.context` into two top-level
+    // fields. Render whichever pieces are present.
+    if let Some(cost) = d.cost_usd {
         lines.push(Line::from(vec![
             Span::styled("  cost:        ", muted),
-            Span::styled(format!("${:.4}", ctx.cost_usd), primary),
+            Span::styled(format!("${cost:.4}"), primary),
         ]));
+    }
+    if let Some(ref model) = d.model {
         lines.push(Line::from(vec![
             Span::styled("  model:       ", muted),
-            Span::styled(&ctx.model, primary),
+            Span::styled(model.as_str(), primary),
         ]));
     }
 


### PR DESCRIPTION
## Summary

Swaps the last two TUI struct fields that held brain-private types to the core runtime DTOs, and migrates `ui/brain.rs` (the Brain Review screen) onto `DecisionSummary`. The `compute_*` cascade from #297 made this clean — no projection helpers needed at the field-type boundary anymore.

## What changed

### App struct
| Field | Old | New |
| --- | --- | --- |
| `brain_queue` | `Vec<crate::brain::review::ReviewItem>` | `Vec<ReviewItemSummary>` |
| `brain_decisions_cache` | `Vec<crate::brain::decisions::DecisionRecord>` | `Vec<DecisionSummary>` |

### App::refresh_brain
Now reads through `runtime.review`:
```rust
self.brain_decisions_cache = self.runtime.review.all_decisions();
self.brain_queue = self.runtime.review.review_queue();
```

### App::mark_selected_canonical
Updated for the DTO shape:
- `item.record.decision_id.clone()` (`Option<String>`) → `item.decision.id` (`String`, empty == no id)

### ui/brain.rs
- Import: `crate::brain::decisions::DecisionRecord` → `claudectl_core::runtime::DecisionSummary`
- Field renames: `d.brain_action` → `d.action`; `d.brain_confidence` → `d.confidence.unwrap_or(0.0)`; `d.brain_reasoning` → `d.reasoning.as_deref().unwrap_or("")`
- `d.user_action` and `d.project` now `Option<String>` — render with `.as_deref().unwrap_or("(none)")`
- `item.record` → `item.decision`
- `Vec<&DecisionRecord>` → `Vec<&DecisionSummary>`
- `d.context` struct → two flat fields `d.cost_usd` + `d.model` (added in #296)
- `render_scorecard`'s local `summaries` projection deleted — `decisions` is already `Vec<DecisionSummary>` after the field swap

## Progress

Cross-binary refs in `app.rs`: **11 → 7**.

The remaining 7 are all genuine deferred-by-design cases:
- `mailbox::deliver_pending` (3) — orchestrator-style, future `Orchestrator` trait
- `coord::store::expire_stale_*` + `coord::interrupt_bus::deliver_pending` (3) — bookkeeping, not on read-only `CoordView`
- `Box<dyn BrainDriver>` annotation (1) — that's the trait field itself

`ui/brain.rs` is now ready to move into `claudectl-tui` alongside the rest of `ui/`. The only thing keeping `app.rs` in the binary crate is the intentional orchestration / bookkeeping refs above — those need an `Orchestrator` trait, not call-site fixes.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets [--features bus] -- -D warnings` clean
- [x] `cargo clippy -p claudectl-core --all-targets -- -D warnings` clean
- [x] `cargo test --features bus` — 1300 tests pass, 0 behavior change
- [x] `cargo test -p claudectl-core` — 104 tests pass
- [x] Layering grep clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)