### PR TITLE
refactor(workspace): add HiveActions trait, decouple last app.rs binary refs

### DIFF
--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -433,6 +433,43 @@ pub trait Actions: Send + Sync {
 }
 
 // ============================================================================
+// Hive actions — knowledge-store (`hive`) + transport (`relay`) reads/writes
+// ============================================================================
+
+/// Snapshot of local hive state the overlay reads to render the Hive tab.
+///
+/// Mirrors the binary's same-named struct, lifted here so the TUI can hold
+/// it without depending on the binary's app module.
+#[derive(Debug, Clone, Default)]
+pub struct HiveViewSnapshot {
+    /// Local relay identity (peer ID string). `None` when the `relay`
+    /// feature is compiled out.
+    pub identity: Option<String>,
+    /// Known peers, paired with last-seen address when available.
+    pub peers: Vec<(String, Option<String>)>,
+}
+
+/// Hive + relay surface the TUI needs to render the Skills and Hive panels.
+///
+/// Separate trait from `Actions` because the underlying subsystems are
+/// feature-gated (`hive`, `relay`) — when those features are off the
+/// implementation returns empty/no-op values rather than failing.
+pub trait HiveActions: Send + Sync {
+    /// Semantic keys (`skill:<lowered-name>`) of skills already shared into
+    /// the local hive store. Used by the Skills overlay to mark "already
+    /// shared" rows.
+    fn shared_skill_keys(&self) -> std::collections::HashSet<String>;
+
+    /// Share a discovered skill into the local hive store. Returns the new
+    /// unit ID on success.
+    fn share_skill(&self, skill: &crate::skills::DiscoveredSkill) -> Result<String, String>;
+
+    /// Current view of the local relay identity + known peers for the Hive
+    /// tab.
+    fn hive_view_snapshot(&self) -> HiveViewSnapshot;
+}
+
+// ============================================================================
 // Brain driver (stateful)
 // ============================================================================
 
@@ -568,9 +605,14 @@ pub struct Runtime {
     pub actions: Arc<dyn Actions>,
     pub review: Arc<dyn BrainReviewView>,
     pub orchestrator: Arc<dyn Orchestrator>,
+    pub hive: Arc<dyn HiveActions>,
 }
 
 impl Runtime {
+    // 8-trait composition root; each view is its own arc. Splitting this into
+    // sub-records would just trade one wide ctor for several narrow ones with
+    // the same total fan-out.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         sessions: Arc<dyn SessionSource>,
         brain: Arc<dyn BrainView>,
@@ -579,6 +621,7 @@ impl Runtime {
         actions: Arc<dyn Actions>,
         review: Arc<dyn BrainReviewView>,
         orchestrator: Arc<dyn Orchestrator>,
+        hive: Arc<dyn HiveActions>,
     ) -> Self {
         Self {
             sessions,
@@ -588,6 +631,7 @@ impl Runtime {
             actions,
             review,
             orchestrator,
+            hive,
         }
     }
 }
@@ -678,6 +722,7 @@ impl MockRuntime {
             arc.clone(),
             arc.clone(),
             arc.clone(),
+            arc.clone(),
             arc,
         )
     }
@@ -749,6 +794,18 @@ impl Orchestrator for MockRuntime {
         Vec::new()
     }
     fn expire_stale(&self) {}
+}
+
+impl HiveActions for MockRuntime {
+    fn shared_skill_keys(&self) -> std::collections::HashSet<String> {
+        std::collections::HashSet::new()
+    }
+    fn share_skill(&self, _skill: &crate::skills::DiscoveredSkill) -> Result<String, String> {
+        Err("MockRuntime does not implement skill sharing".into())
+    }
+    fn hive_view_snapshot(&self) -> HiveViewSnapshot {
+        HiveViewSnapshot::default()
+    }
 }
 
 impl Actions for MockRuntime {
@@ -928,6 +985,7 @@ mod tests {
             arc.clone(),
             arc.clone(),
             arc.clone(),
+            arc.clone(),
         );
         // Initial: default On.
         assert_eq!(rt.brain.gate_mode(), BrainGateMode::On);
@@ -959,6 +1017,7 @@ mod tests {
             arc.clone(),
             arc.clone(),
             arc.clone(),
+            arc.clone(),
         );
         let obs = ObservationInput {
             session_pid: 12345,
@@ -977,6 +1036,7 @@ mod tests {
         let mock = MockRuntime::default();
         let arc = Arc::new(mock);
         let rt = Runtime::new(
+            arc.clone(),
             arc.clone(),
             arc.clone(),
             arc.clone(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1983,14 +1983,14 @@ impl App {
     pub fn refresh_skills(&mut self) {
         let cwd = std::env::current_dir().ok();
         self.skills = crate::skills::discover(cwd.as_deref());
-        self.shared_skill_keys = load_shared_skill_keys();
+        self.shared_skill_keys = self.runtime.hive.shared_skill_keys();
         if self.skills_selected >= self.skills.len() {
             self.skills_selected = self.skills.len().saturating_sub(1);
         }
     }
 
     pub fn refresh_hive_view(&mut self) {
-        let snapshot = load_hive_view_snapshot();
+        let snapshot = self.runtime.hive.hive_view_snapshot();
         self.hive_identity = snapshot.identity;
         self.hive_known_peers = snapshot.peers;
     }
@@ -2276,7 +2276,7 @@ impl App {
             self.skills_status_msg = Some("Already shared".into());
             return;
         }
-        match share_skill_to_hive(&skill) {
+        match self.runtime.hive.share_skill(&skill) {
             Ok(unit_id) => {
                 self.shared_skill_keys.insert(skill.semantic_key());
                 self.skills_status_msg = Some(format!(
@@ -2963,46 +2963,11 @@ impl App {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Skills overlay helpers — kept at module scope so the App methods stay short.
+// Hive/relay shell-out helpers — kept at module scope so the App methods stay
+// short. The read-side helpers (skill-key collection, hive snapshot) and the
+// write-side helper (share skill) moved into `runtime::hive::LiveHiveActions`
+// so the future TUI crate (#275) can hold them through the trait surface.
 // ────────────────────────────────────────────────────────────────────────────
-
-/// Collect semantic keys for skills already in the local hive store.
-///
-/// The hive `semantic_key` is `<scope>/skill:<lowered-name>`; we strip the
-/// scope prefix here because `DiscoveredSkill::semantic_key()` is scope-less.
-fn load_shared_skill_keys() -> std::collections::HashSet<String> {
-    #[cfg(feature = "hive")]
-    {
-        let store = crate::hive::store::HiveStore::load();
-        let mut out = std::collections::HashSet::new();
-        for unit in store.all_units() {
-            if let crate::hive::KnowledgeContent::Skill { name, .. } = &unit.content {
-                out.insert(format!("skill:{}", name.to_lowercase().replace(' ', "-")));
-            }
-        }
-        out
-    }
-    #[cfg(not(feature = "hive"))]
-    {
-        std::collections::HashSet::new()
-    }
-}
-
-/// Share a discovered skill into the local hive store. Returns the new unit ID.
-fn share_skill_to_hive(skill: &crate::skills::DiscoveredSkill) -> Result<String, String> {
-    #[cfg(feature = "hive")]
-    {
-        let path_str = skill.path.to_string_lossy().to_string();
-        crate::hive::cli::share_artifact_from_path("skill", &path_str, "universal")
-            .map(|(unit_id, _summary)| unit_id)
-            .map_err(|e| e.to_string())
-    }
-    #[cfg(not(feature = "hive"))]
-    {
-        let _ = skill;
-        Err("hive feature disabled".into())
-    }
-}
 
 /// Detach a `claudectl relay serve` child so the TUI keeps running.
 #[cfg(feature = "relay")]
@@ -3040,38 +3005,6 @@ fn spawn_relay_join(code: &str) -> Result<(), String> {
 #[cfg(not(feature = "relay"))]
 fn spawn_relay_join(_code: &str) -> Result<(), String> {
     Err("relay feature not built".into())
-}
-
-/// Snapshot of local hive state the overlay reads to render the Hive tab.
-pub struct HiveViewSnapshot {
-    pub identity: Option<String>,
-    /// (peer_id, optional last-known address)
-    pub peers: Vec<(String, Option<String>)>,
-}
-
-#[cfg(feature = "relay")]
-fn load_hive_view_snapshot() -> HiveViewSnapshot {
-    let identity = Some(crate::relay::load_or_create_identity().as_str().to_string());
-    let peers = crate::relay::list_known_peers()
-        .into_iter()
-        .map(|id| {
-            let addr = crate::relay::load_peer_meta(&id).and_then(|v| {
-                v.get("addr")
-                    .and_then(|a| a.as_str())
-                    .map(|s| s.to_string())
-            });
-            (id, addr)
-        })
-        .collect();
-    HiveViewSnapshot { identity, peers }
-}
-
-#[cfg(not(feature = "relay"))]
-fn load_hive_view_snapshot() -> HiveViewSnapshot {
-    HiveViewSnapshot {
-        identity: None,
-        peers: Vec::new(),
-    }
 }
 
 /// Shell out to `claudectl relay invite --json` and parse the result. We use

--- a/src/runtime/hive.rs
+++ b/src/runtime/hive.rs
@@ -1,0 +1,68 @@
+//! Bind `HiveActions` (knowledge-store + relay reads/writes) to the binary's
+//! real subsystems. When the `hive` or `relay` features are off the impl
+//! returns empty/no-op values so the TUI's render paths stay branchless.
+
+use std::collections::HashSet;
+
+use claudectl_core::runtime::{HiveActions, HiveViewSnapshot};
+use claudectl_core::skills::DiscoveredSkill;
+
+pub struct LiveHiveActions;
+
+impl HiveActions for LiveHiveActions {
+    fn shared_skill_keys(&self) -> HashSet<String> {
+        #[cfg(feature = "hive")]
+        {
+            let store = crate::hive::store::HiveStore::load();
+            let mut out = HashSet::new();
+            for unit in store.all_units() {
+                if let crate::hive::KnowledgeContent::Skill { name, .. } = &unit.content {
+                    out.insert(format!("skill:{}", name.to_lowercase().replace(' ', "-")));
+                }
+            }
+            out
+        }
+        #[cfg(not(feature = "hive"))]
+        {
+            HashSet::new()
+        }
+    }
+
+    fn share_skill(&self, skill: &DiscoveredSkill) -> Result<String, String> {
+        #[cfg(feature = "hive")]
+        {
+            let path_str = skill.path.to_string_lossy().to_string();
+            crate::hive::cli::share_artifact_from_path("skill", &path_str, "universal")
+                .map(|(unit_id, _summary)| unit_id)
+                .map_err(|e| e.to_string())
+        }
+        #[cfg(not(feature = "hive"))]
+        {
+            let _ = skill;
+            Err("hive feature not compiled in".into())
+        }
+    }
+
+    fn hive_view_snapshot(&self) -> HiveViewSnapshot {
+        #[cfg(feature = "relay")]
+        {
+            let identity = Some(crate::relay::load_or_create_identity().as_str().to_string());
+            let peers = crate::relay::list_known_peers()
+                .into_iter()
+                .map(|id| {
+                    let addr = crate::relay::load_peer_meta(&id).and_then(|v| {
+                        v.get("addr")
+                            .and_then(|a| a.as_str())
+                            .map(|s| s.to_string())
+                    });
+                    (id, addr)
+                })
+                .collect();
+            HiveViewSnapshot { identity, peers }
+        }
+        #[cfg(not(feature = "relay"))]
+        {
+            HiveViewSnapshot::default()
+        }
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -20,6 +20,7 @@ mod brain_driver;
 mod brain_review;
 mod bus;
 mod coord;
+mod hive;
 mod orchestrator;
 mod sessions;
 
@@ -32,6 +33,7 @@ pub use brain_driver::LiveBrainDriver;
 pub use brain_review::LiveBrainReviewView;
 pub use bus::LiveBusView;
 pub use coord::LiveCoordView;
+pub use hive::LiveHiveActions;
 pub use orchestrator::LiveOrchestrator;
 pub use sessions::LiveSessionSource;
 
@@ -51,5 +53,6 @@ pub fn build_runtime() -> Runtime {
         Arc::new(LiveActions),
         Arc::new(LiveBrainReviewView),
         Arc::new(LiveOrchestrator),
+        Arc::new(LiveHiveActions),
     )
 }


### PR DESCRIPTION
## Summary

* New `claudectl_core::runtime::HiveActions` trait with `shared_skill_keys`, `share_skill`, `hive_view_snapshot`, plus a `HiveViewSnapshot` DTO lifted out of `src/app.rs`.
* `Runtime` gains an `Arc<dyn HiveActions>` field. `LiveHiveActions` in `src/runtime/hive.rs` preserves the existing `#[cfg(feature = \"hive\"/\"relay\")]` branching inside trait method bodies.
* `App` now calls `self.runtime.hive.*` instead of three module-scope free functions that reached into `crate::hive` / `crate::relay`.

## Why

These three helpers were the last non-comment refs from app.rs into binary-only subsystems. Without removing them, a future move of app.rs into `crates/claudectl-tui` (#275) would have failed the layering grep. Now app.rs has **zero** binary-only crate refs outside of doc comments — confirmed by grep against `brain|coord|hive|relay`.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo test --all-features`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p claudectl-core --lib` (115 passed)
- [x] Local layering grep against the CI pattern → pass

Toward #275 (extract `claudectl-tui` crate). Epic: #279.