### PR TITLE
docs: workspace refactor wrap-up — CLAUDE.md + contributing/AGENTS/README/quickstart + CHANGELOG + 0.54.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,28 +44,23 @@ cargo fmt --check            # Check formatting
 
 ## Architecture
 
-**Core modules** (`src/`):
-- `main.rs` — CLI entry point, mode dispatch (TUI, watch, JSON, list, history, stats, orchestrator, clean, doctor, brain-eval)
-- `app.rs` — TUI app state, refresh loop, keyboard event handling
-- `session.rs` — Session data structures and formatting
-- `discovery.rs` — Scans `~/.claude/sessions/*.json` and resolves JSONL paths
-- `monitor.rs` — Parses JSONL conversation logs for tokens, cost, status events
-- `process.rs` — Process introspection via native `ps` (not sysinfo crate)
-- `config.rs` — Layered TOML config: CLI flags > `.claudectl.toml` > `~/.config/claudectl/config.toml` > defaults
-- `history.rs` — Session history persistence and cost analytics
-- `hooks.rs` — Event hook system (shell commands fired on session events)
-- `orchestrator.rs` — Multi-session task runner with dependency ordering
-- `health.rs` — Session health monitoring (cache ratio, cost spikes, loop detection, stalls, context saturation)
-- `rules.rs` — Auto-rule engine: match sessions by status/tool/command/project/cost, then approve/deny/send/terminate/route/spawn/delegate
-- `launch.rs` — Launch and resume Claude Code sessions from the TUI or CLI
-- `models.rs` — Model pricing profiles (built-in + user overrides) for cost tracking
-- `recorder.rs` — Dashboard recording (asciicast/GIF capture of full TUI)
-- `session_recorder.rs` — Per-session highlight reel recording (extracts edits, commands, errors; strips idle time)
-- `transcript.rs` — JSONL transcript parser (messages, tool use, tool results, usage data)
-- `metrics.rs` — Brain effectiveness metrics: learning curve, accuracy breakdown, rules baseline comparison, false-approve rate
-- `demo.rs` — Deterministic fake sessions for screenshots, recordings, and demos
-- `theme.rs` — Color theming (dark/light/monochrome, respects NO_COLOR)
-- `logger.rs` — Structured diagnostic logging
+claudectl is a three-crate Cargo workspace. Dependencies flow `claudectl → claudectl-tui → claudectl-core`; CI rejects upward references via grep + standalone build jobs. The runtime trait contract in `claudectl-core/src/runtime.rs` is the only seam the TUI uses to read or write brain / coord / bus state.
+
+```
+crates/
+├── claudectl-core/    # foundations: types, IO, runtime traits, MockRuntime
+│                      #   session, discovery, monitor, process, transcript,
+│                      #   models, theme, logger, helpers, history, terminals/,
+│                      #   health, rules, hooks, launch, skills, config, runtime
+└── claudectl-tui/     # terminal UI + recording + demo fixtures
+                       #   app.rs, ui/*, recorder.rs, session_recorder.rs, demo.rs
+src/                   # the binary
+                       #   main.rs + brain/ + bus/ + coord/ + hive/ + relay/ +
+                       #   orchestrator + init/ + commands + brain_screen.rs.
+                       #   Implements the runtime traits via `src/runtime/`.
+```
+
+**Runtime traits** in `claudectl-core::runtime`: `SessionSource`, `BrainView`, `BrainReviewView`, `CoordView`, `BusView`, `Actions`, `HiveActions`, `Orchestrator`, plus the stateful `BrainDriver`. Core-owned DTOs (`SessionSnapshot`, `DecisionSummary`, `LeaseSummary`, `HiveViewSnapshot`, etc.) keep brain/coord/bus types from leaking upward. Tests drive `MockRuntime`.
 
 **Brain** (`src/brain/`): Local LLM auto-pilot subsystem.
 - `engine.rs` — Main brain loop: observes sessions, evaluates rules, queries LLM, executes decisions
@@ -76,10 +71,9 @@ cargo fmt --check            # Check formatting
 - `mailbox.rs` — Message passing between brain and TUI
 - `prompts.rs` — Prompt templates (built-in + user overrides via `~/.claudectl/brain/prompts/`)
 - `evals.rs` — Eval harness for testing brain decision quality against scenarios
+- `metrics.rs` / `risk.rs` — Effectiveness scorecard + per-tool risk classification (consumed by `src/brain_screen.rs`)
 
-**TUI** (`src/ui/`): `table.rs` (session list), `detail.rs` (expanded panel), `help.rs` (overlay), `status_bar.rs` (footer)
-
-**Terminal backends** (`src/terminals/`): Ghostty, Kitty, tmux, WezTerm, Warp, iTerm2, Terminal.app, Gnome Terminal, Windows Terminal — auto-detected, used for tab switching and input sending.
+**Terminal backends** (`crates/claudectl-core/src/terminals/`): Ghostty, Kitty, tmux, WezTerm, Warp, iTerm2, Terminal.app, Gnome Terminal, Windows Terminal — auto-detected, used for tab switching and input sending.
 
 ## Key Design Decisions
 
@@ -96,7 +90,8 @@ cargo fmt --check            # Check formatting
 - Run `cargo fmt` and `cargo clippy -- -D warnings` before committing.
 - Tests live in `tests/integration_tests.rs` and `tests/unit_tests.rs`.
 - Status inference logic has extensive test coverage — do not change status detection without updating tests.
-- Health checks in `health.rs` have full unit test coverage — add tests for new checks.
-- Terminal backends implement the pattern in `src/terminals/mod.rs` — add new terminals there.
-- Config fields must be added to all three layers (CLI args in `main.rs`, TOML struct in `config.rs`, merge logic in `config.rs`).
+- Health checks in `crates/claudectl-core/src/health.rs` have full unit test coverage — add tests for new checks.
+- Terminal backends implement the pattern in `crates/claudectl-core/src/terminals/mod.rs` — add new terminals there.
+- Config fields must be added to all three layers (CLI args in `main.rs`, TOML struct in `src/config.rs`, merge logic in `src/config.rs`). Plain data structs (`BrainConfig`, `IdleConfig`) live in `crates/claudectl-core/src/config.rs`.
+- **Dependency direction:** `claudectl` may depend on `claudectl-tui` and `claudectl-core`. `claudectl-tui` may depend on `claudectl-core` only. `claudectl-core` may depend on nothing claudectl-specific. CI enforces this with a grep guard plus per-crate standalone build jobs (`Core (standalone)`, `TUI (standalone)`).
 - Brain prompt templates can be overridden by placing files in `~/.claudectl/brain/prompts/` — run `--brain-prompts` to list sources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.54.0] - 2026-06-06
+
+### Internals (workspace refactor — closes epic #279)
+- **`claudectl-tui` extracted into its own crate (closes #275).** The `App` state struct (3300 LoC), every `ui/*` render module (table, detail, help, status_bar, peers, skills), the recorder pair, and the demo fixtures now live in `crates/claudectl-tui/`. Depends on `claudectl-core` only. The binary keeps `brain_screen.rs` (the full-screen Brain Review surface) because it imports `brain::metrics` and `brain::risk`.
+- **Dependency direction enforced at three levels.** `claudectl → claudectl-tui → claudectl-core` is checked by (a) a grep guard against `crate::{brain,bus,coord,hive,relay,…}` inside `claudectl-core/src/`, and (b) two standalone build jobs (`Core (standalone)`, `TUI (standalone)`) that catch creeping cross-deps even when the workspace happens to compile.
+- **Eight runtime traits + DTOs in `claudectl-core::runtime`** are the only surface between the TUI and the binary's brain/bus/coord subsystems: `SessionSource`, `BrainView`, `BrainReviewView`, `CoordView`, `BusView`, `Actions`, `HiveActions`, `Orchestrator`, plus the stateful `BrainDriver`. The binary's `src/runtime/` provides `Live*` adapters; `MockRuntime` drives in-crate tests.
+- **`hooks.rs`, `launch.rs`, `skills.rs` moved into core** (#300), as did the `BrainConfig` and `IdleConfig` data structs (#301). The binary still owns TOML parsing and CLI flag layering; only the value types are downstreamed.
+- **Feature propagation:** the binary's `coord`, `relay`, `hive` features now cascade into `claudectl-tui` via the `claudectl-tui/coord` notation in `[features]`, so the same `#[cfg(feature = "…")]` gates resolve consistently across both crates.
+- **CLAUDE.md updated** to describe the post-refactor layout and the no-upward-deps rule (closes #278).
+
+### Compatibility
+- No user-facing CLI changes. Existing `crate::*` paths inside the binary continue to resolve unchanged thanks to a thin re-export bridge in `src/lib.rs` (`pub use claudectl_tui::{app, demo, recorder, session_recorder, ui};`).
+- No new dependencies. `claudectl-tui` pulls only what the TUI already used (`ratatui`, `crossterm`, `serde_json`).
+
 ## [0.53.0] - 2026-06-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,25 +16,30 @@ cargo fmt --check            # Check formatting
 
 ### Workspace layout
 
-This is a Cargo workspace. Crates depend in one direction only — `claudectl → claudectl-core` — and the rule is non-negotiable; CI enforces it (see #277). Adding upward arrows is what the workspace exists to prevent.
+This is a Cargo workspace with three crates. Dependencies flow strictly downward — `claudectl → claudectl-tui → claudectl-core` — and CI enforces it (Layering grep on core, plus standalone build jobs for each crate). Adding upward arrows is what the workspace exists to prevent.
 
 ```
 crates/
 ├── claudectl-core/    # foundational types, IO, the UI↔runtime trait contract
 │                      #   session, discovery, monitor, process, transcript,
 │                      #   models, theme, logger, helpers, history, terminals/,
-│                      #   health, rules, runtime
-└── (future: claudectl-tui — extracts the TUI per #275)
+│                      #   health, rules, config, hooks, launch, skills, runtime
+└── claudectl-tui/     # terminal UI + recording + demo fixtures
+                       #   app.rs, ui/*, recorder.rs, session_recorder.rs, demo.rs
+                       #   Depends on claudectl-core. Never on the binary.
 src/                   # the binary crate `claudectl`
-                       #   main.rs + brain/ + bus/ + coord/ + orchestrator +
-                       #   hive + relay + app + ui + recorder + init + config.
+                       #   main.rs + brain/ + bus/ + coord/ + hive/ + relay/ +
+                       #   orchestrator + init + commands + config.rs +
+                       #   brain_screen.rs.
                        #   Implements the runtime traits over the real
                        #   subsystems via `src/runtime/`.
 ```
 
-**UI ↔ runtime contract** lives at `crates/claudectl-core/src/runtime.rs`. Five read-only view traits (`SessionSource`, `BrainView`, `CoordView`, `BusView`) plus the `Runtime` aggregate; core-owned DTOs so the contract doesn't drag brain / coord / bus types upward. The binary's `src/runtime/` adapts each subsystem onto the traits.
+**UI ↔ runtime contract** lives at `crates/claudectl-core/src/runtime.rs`. Eight traits — `SessionSource`, `BrainView`, `CoordView`, `BusView`, `Actions`, `BrainReviewView`, `Orchestrator`, `HiveActions`, plus the stateful `BrainDriver` — wrapped in a `Runtime` aggregate. Core-owned DTOs (`SessionSnapshot`, `DecisionSummary`, `LeaseSummary`, `HiveViewSnapshot`, etc.) so the contract doesn't drag brain / coord / bus types upward. The binary's `src/runtime/` provides `Live*` adapters that implement each trait over the real subsystem.
 
-**Re-export trick** (transitional): `src/lib.rs` does `pub use claudectl_core::{session, discovery, …, health, rules};` so existing `crate::session::*` paths in the binary keep resolving without rewriting every import. These aliases collapse once #275 extracts `claudectl-tui` and the binary depends on `claudectl-core` directly.
+**Re-export bridge:** `src/lib.rs` and `src/main.rs` both do `pub use claudectl_core::{session, discovery, …};` and `pub use claudectl_tui::{app, demo, recorder, session_recorder, ui};` so existing `crate::session::*` / `crate::app::*` paths in the binary keep resolving without rewriting every import.
+
+**Feature propagation:** the binary's `coord`, `relay`, `hive` features propagate to `claudectl-tui` via `claudectl-tui/coord` etc. in `[features]`, so a single `#[cfg(feature = "...")]` gate resolves consistently across both crates.
 
 ### Core modules — `claudectl-core` (`crates/claudectl-core/src/`)
 
@@ -51,45 +56,31 @@ src/                   # the binary crate `claudectl`
 - `theme.rs` — Color theming (dark/light/monochrome, respects NO_COLOR)
 - `logger.rs` — Structured diagnostic logging
 - `helpers.rs` — Shared utilities (webhook, notification, kill_process, aggregate session)
+- `hooks.rs` — Event hook system (shell commands fired on session events)
+- `launch.rs` — Launch and resume Claude Code sessions from the TUI or CLI
+- `skills.rs` — Skill registry + claude-plugin metadata
+- `config.rs` — `BrainConfig` / `IdleConfig` data structs (the binary still owns TOML parsing in `src/config.rs`; only the value types live here)
 - `terminals/` — Terminal backends; see below.
+
+### TUI modules — `claudectl-tui` (`crates/claudectl-tui/src/`)
+
+- `app.rs` — `App` state struct, refresh loop, keyboard event handling. Holds a `claudectl_core::runtime::Runtime` for all brain/coord/bus reads and writes; never touches binary-only modules directly.
+- `ui/` — Render functions: `table.rs` (session list), `detail.rs` (expanded panel), `help.rs` (overlay), `status_bar.rs` (footer), `peers.rs` (relay peers panel, feature `relay`), `skills.rs` (skills overlay).
+- `recorder.rs` — Dashboard recording (asciicast/GIF capture of full TUI).
+- `session_recorder.rs` — Per-session highlight reel recording (extracts edits, commands, errors; strips idle time).
+- `demo.rs` — Deterministic fake sessions for screenshots, recordings, demos. Includes `DemoHighlightState` and `demo_peers` (feature `relay`).
+
+Feature flags: `coord`, `relay`, `hive` mirror the binary's same-named features and gate `App` fields and ui panels.
 
 ### Binary modules — `claudectl` (`src/`)
 
-- `main.rs` — CLI entry point, mode dispatch (TUI, watch, JSON, list, history, stats, orchestrator, clean, doctor, brain-eval, brain-query, mode, insights, init)
-- `app.rs` — TUI app state, refresh loop, keyboard event handling
-- `config.rs` — Layered TOML config: CLI flags > `.claudectl.toml` > `~/.config/claudectl/config.toml` > defaults. Re-exports `HealthThresholds` from core.
-- `hooks.rs` — Event hook system (shell commands fired on session events)
-- `orchestrator.rs` — Multi-session task runner with dependency ordering
-- `launch.rs` — Launch and resume Claude Code sessions from the TUI or CLI
-- `recorder.rs` — Dashboard recording (asciicast/GIF capture of full TUI)
-- `session_recorder.rs` — Per-session highlight reel recording (extracts edits, commands, errors; strips idle time)
-- `demo.rs` — Deterministic fake sessions for screenshots, recordings, and demos. Includes `DemoHighlightState` which drip-feeds scripted JSONL events so session recording works in demo mode.
-- `init/` — `claudectl init` opinionated onboarding wizard (5 phases: budget, brain, plugin, bus, skills); see `docs/AGENT_BUS.md` §8 and issue #257.
-- `runtime/` — `Live*` adapters that implement the `claudectl-core::runtime` traits against the real subsystems (brain decisions, coord SQLite, bus SQLite, discovery+monitor).
+- `main.rs` — CLI entry point, mode dispatch (TUI, watch, JSON, list, history, stats, orchestrator, clean, doctor, brain-eval, brain-query, mode, insights, init).
+- `brain_screen.rs` — Full-screen Brain Review surface (scorecard + interactive review). Stays in the binary because it depends on `brain::metrics` and `brain::risk`; `main.rs` calls `brain_screen::render_brain_screen` for the brain panel. Every other ui render goes through `claudectl_tui::ui::*`.
+- `config.rs` — Layered TOML config: CLI flags > `.claudectl.toml` > `~/.config/claudectl/config.toml` > defaults. Re-exports `BrainConfig`, `IdleConfig`, `HealthThresholds` from `claudectl-core`.
+- `orchestrator.rs` — Multi-session task runner with dependency ordering.
 - `commands.rs` — CLI command dispatch shared between modes.
-- `skills.rs` — Skill registry + claude-plugin metadata.
-- `main.rs` — CLI entry point, mode dispatch (TUI, watch, JSON, list, history, stats, orchestrator, clean, doctor, brain-eval, brain-query, mode, insights, init)
-- `app.rs` — TUI app state, refresh loop, keyboard event handling
-- `session.rs` — Session data structures and formatting
-- `discovery.rs` — Scans `~/.claude/sessions/*.json` and resolves JSONL paths
-- `monitor.rs` — Parses JSONL conversation logs for tokens, cost, status events
-- `process.rs` — Process introspection via native `ps` (not sysinfo crate)
-- `config.rs` — Layered TOML config: CLI flags > `.claudectl.toml` > `~/.config/claudectl/config.toml` > defaults
-- `history.rs` — Session history persistence and cost analytics
-- `hooks.rs` — Event hook system (shell commands fired on session events)
-- `orchestrator.rs` — Multi-session task runner with dependency ordering
-- `health.rs` — Session health monitoring (cache ratio, cost spikes, loop detection, stalls, context saturation)
-- `rules.rs` — Auto-rule engine: match sessions by status/tool/command/project/cost, then approve/deny/send/terminate/route/spawn/delegate
-- `launch.rs` — Launch and resume Claude Code sessions from the TUI or CLI
-- `models.rs` — Model pricing profiles (built-in + user overrides) for cost tracking
-- `recorder.rs` — Dashboard recording (asciicast/GIF capture of full TUI)
-- `session_recorder.rs` — Per-session highlight reel recording (extracts edits, commands, errors; strips idle time)
-- `transcript.rs` — JSONL transcript parser (messages, tool use, tool results, usage data)
-- `metrics.rs` — Brain effectiveness metrics: learning curve, accuracy breakdown, rules baseline comparison, false-approve rate
-- `demo.rs` — Deterministic fake sessions for screenshots, recordings, and demos. Includes `DemoHighlightState` which drip-feeds scripted JSONL events so session recording works in demo mode.
-- `theme.rs` — Color theming (dark/light/monochrome, respects NO_COLOR)
-- `logger.rs` — Structured diagnostic logging
-- `init.rs` — `--init` / `--uninstall`: writes/removes Claude Code hooks in `.claude/settings.json`
+- `init/` — `claudectl init` opinionated onboarding wizard (5 phases: budget, brain, plugin, bus, skills); see `docs/AGENT_BUS.md` §8 and issue #257.
+- `runtime/` — `Live*` adapters that implement the `claudectl-core::runtime` traits against the real subsystems (sessions, brain, coord SQLite, bus SQLite, orchestrator, hive). See `runtime/{sessions,brain,brain_driver,brain_review,coord,bus,actions,orchestrator,hive}.rs`.
 
 **Claude Code Plugin** (`claude-plugin/`): Integrates the brain directly into Claude Code sessions.
 - `hooks/scripts/brain-gate.sh` — PreToolUse hook: queries brain for approve/deny on Bash/Write/Edit calls
@@ -140,8 +131,6 @@ src/                   # the binary crate `claudectl`
 - `injection.rs` — Brain prompt integration with trust labels, concordance checking for drift
 - `cli.rs` — CLI dispatch for hive subcommands (status, knowledge, export, import, trust)
 
-**TUI** (`src/ui/`): `table.rs` (session list), `detail.rs` (expanded panel), `help.rs` (overlay), `status_bar.rs` (footer), `peers.rs` (relay peers panel). Will move to `crates/claudectl-tui/` in #275; today still depends on the binary crate directly.
-
 **Terminal backends** (`crates/claudectl-core/src/terminals/`): Ghostty, Kitty, tmux, WezTerm, Warp, iTerm2, Terminal.app, Gnome Terminal, Windows Terminal — auto-detected, used for tab switching and input sending.
 
 ## Key Design Decisions
@@ -164,8 +153,8 @@ src/                   # the binary crate `claudectl`
 - Health checks in `crates/claudectl-core/src/health.rs` have full unit test coverage — add tests for new checks.
 - Terminal backends implement the pattern in `crates/claudectl-core/src/terminals/mod.rs` — add new terminals there.
 - Config fields must be added to all three layers (CLI args in `main.rs`, TOML struct in `config.rs`, merge logic in `config.rs`).
-- **Dependency direction:** `claudectl` (binary) may depend on `claudectl-core`. `claudectl-core` may NOT depend on anything claudectl-specific — no `crate::brain`, `crate::bus`, `crate::coord`, etc. references from inside core. CI rejects this.
-- Foundational modules in core never have `pub(crate)` on items the binary needs to call — promote to `pub` instead. The binary is now a downstream consumer.
+- **Dependency direction:** `claudectl` (binary) depends on `claudectl-tui` and `claudectl-core`. `claudectl-tui` depends on `claudectl-core` only. `claudectl-core` depends on nothing claudectl-specific — no `crate::brain`, `crate::bus`, `crate::coord`, `crate::hive`, etc. references from inside core. CI rejects upward references via a grep guard plus standalone build jobs (`Core (standalone)`, `TUI (standalone)`).
+- Foundational modules in core (and now TUI) never have `pub(crate)` on items downstream needs to call — promote to `pub` instead. The binary is a downstream consumer of both other crates.
 - Brain prompt templates can be overridden by placing files in `~/.claudectl/brain/prompts/` — run `--brain-prompts` to list sources.
 - Plugin hook scripts must check for `claudectl` availability and exit 0 on failure — never block Claude Code.
 - Plugin commands call `claudectl` CLI modes and format output — they don't implement logic directly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2024"
 description = "Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ git clone https://github.com/mercurialsolo/claudectl.git && cd claudectl && carg
 
 ```bash
 claudectl                     # Live dashboard — see all sessions at a glance
-claudectl --init              # Wire up Claude Code hooks (one-time)
+claudectl init                # Onboarding wizard (budget, brain, hooks, bus, skills)
 claudectl --brain             # Enable local LLM auto-pilot
 ```
+
+The `init` wizard walks five phases — weekly budget, local-LLM brain detection, Claude Code hook install, agent-bus role, and curated skill suggestions. Run `claudectl init --check` later to see drift, or `claudectl init --non-interactive` to script it.
 
 ## Why claudectl
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,7 +7,7 @@ Contributions are welcome.
 ```bash
 git clone https://github.com/mercurialsolo/claudectl.git
 cd claudectl
-cargo build
+cargo build                    # whole workspace
 cargo test --all-targets
 ```
 
@@ -17,6 +17,14 @@ cargo test --all-targets
 cargo test --all-targets
 cargo clippy --all-targets -- -D warnings
 cargo fmt --all -- --check
+
+# Standalone per-crate checks — same as CI. Catches creeping cross-deps
+# that happen to compile inside the workspace but break the dependency
+# direction.
+cargo build -p claudectl-core
+cargo build -p claudectl-tui
+cargo test  -p claudectl-core
+cargo test  -p claudectl-tui
 ```
 
 ## Guidelines
@@ -28,38 +36,69 @@ cargo fmt --all -- --check
 
 Not all contributions are code. Hooks, docs, config presets, terminal compatibility fixes, and packaging help are all valuable.
 
-## Architecture
+## Workspace layout
 
+claudectl is a three-crate Cargo workspace. Dependencies flow strictly downward — `claudectl → claudectl-tui → claudectl-core`. The runtime trait contract in `claudectl-core/src/runtime.rs` is the only seam the TUI uses to read or write brain / coord / bus state.
+
+```
+crates/
+├── claudectl-core/    # foundations: types, IO, runtime traits, MockRuntime
+└── claudectl-tui/     # the terminal UI + recording + demo fixtures
+src/                   # the binary: glue + brain/bus/coord/hive/relay + runtime adapters
+```
+
+CI rejects upward references in three ways: a grep guard against `crate::{brain,bus,coord,hive,relay,…}` inside `claudectl-core/src/`, plus the two standalone build jobs above. If you find yourself wanting to reach across, add a trait method to `runtime.rs` and implement it in `src/runtime/` instead.
+
+## Where things live
+
+### `crates/claudectl-core/src/` — foundations
 | Module | Purpose |
 |--------|---------|
-| `main.rs` | CLI entry point, mode dispatch |
-| `app.rs` | Core app state, refresh loop, event handling |
+| `runtime.rs` | UI ↔ runtime trait contract (8 traits + `BrainDriver`), DTOs, `Runtime` aggregate, `MockRuntime` |
 | `session.rs` | Session data structures and formatting |
 | `discovery.rs` | Session file scanning and JSONL path resolution |
 | `monitor.rs` | JSONL parsing, token counting, status inference |
 | `process.rs` | Process introspection via `ps` |
-| `config.rs` | TOML config file loading and layering |
-| `commands.rs` | Non-TUI command dispatch (headless, autopsy, context rot) |
-| `health.rs` | Session health monitoring (10 automated checks) |
-| `rules.rs` | Auto-rule engine (approve/deny/send/terminate/route/spawn) |
-| `models.rs` | Model pricing profiles for cost tracking |
-| `transcript.rs` | JSONL transcript parser (messages, tool use, usage data) |
-| `launch.rs` | Launch and resume Claude Code sessions |
 | `history.rs` | Session history persistence and analytics |
-| `orchestrator.rs` | Multi-session task runner with dependency ordering |
-| `hooks.rs` | Event hooks system and execution |
-| `init.rs` | `--init` / `--uninstall` for Claude Code hooks integration |
-| `brain/` | Local LLM auto-pilot (engine, decisions, insights, evals, preferences, risk, autopsy, metrics) |
-| `relay/` | Cross-machine TCP transport, invite codes, LAN discovery, task delegation (feature-gated) |
-| `hive/` | Gossip-based knowledge sharing, trust tiers, distillation (feature-gated) |
-| `coord/` | Multi-session coordination: leases, blockers, handoffs, interrupts, memory (feature-gated) |
+| `health.rs` | Session health monitoring (10 automated checks). Owns `HealthThresholds`. |
+| `rules.rs` | Auto-rule engine (approve/deny/send/terminate/route/spawn/delegate) |
+| `models.rs` | Model pricing profiles for cost tracking |
+| `transcript.rs` | JSONL transcript parser |
 | `theme.rs` | Color palette and theme modes |
 | `logger.rs` | Diagnostic file logging |
-| `demo.rs` | Deterministic fake sessions for demo mode |
-| `recorder.rs` | Asciicast recording with tee writer |
-| `session_recorder.rs` | Per-session highlight reel generator |
+| `helpers.rs` | Webhook, notification, kill_process, aggregate session |
+| `hooks.rs` | Event hooks system and execution |
+| `launch.rs` | Launch and resume Claude Code sessions |
+| `skills.rs` | Skill registry + claude-plugin metadata |
+| `config.rs` | `BrainConfig`, `IdleConfig`, `IdleTask` data structs |
 | `terminals/` | Terminal-specific switching and input injection |
-| `ui/` | TUI rendering (table, detail, help, status bar, peers) |
+
+### `crates/claudectl-tui/src/` — terminal UI
+| Module | Purpose |
+|--------|---------|
+| `app.rs` | `App` state struct, refresh loop, event handling — talks to brain/bus/coord only through the runtime traits |
+| `ui/` | Render modules: `table`, `detail`, `help`, `status_bar`, `peers` (feature `relay`), `skills` |
+| `recorder.rs` | Asciicast / GIF recording |
+| `session_recorder.rs` | Per-session highlight reel generator |
+| `demo.rs` | Deterministic fake sessions for demo mode + `demo_peers` (feature `relay`) |
+
+Features: `coord`, `relay`, `hive` mirror the binary's same-named features.
+
+### `src/` — the binary
+| Module | Purpose |
+|--------|---------|
+| `main.rs` | CLI entry point, mode dispatch |
+| `brain_screen.rs` | Full-screen Brain Review surface (kept here because it depends on `brain::metrics` + `brain::risk`) |
+| `commands.rs` | Non-TUI command dispatch |
+| `config.rs` | Layered TOML config parsing (CLI > project > global > defaults). Re-exports the data structs from `claudectl-core::config`. |
+| `init/` | `claudectl init` onboarding wizard (5 phases) |
+| `orchestrator.rs` | Multi-session task runner with dependency ordering |
+| `runtime/` | `Live*` adapters wiring the runtime traits to the real subsystems |
+| `brain/` | Local LLM auto-pilot (engine, decisions, insights, evals, preferences, risk, metrics) |
+| `relay/` | Cross-machine TCP transport, invite codes, LAN discovery, task delegation (feature `relay`) |
+| `hive/` | Gossip-based knowledge sharing, trust tiers, distillation (feature `hive`) |
+| `coord/` | Multi-session coordination: leases, blockers, handoffs, interrupts (feature `coord`) |
+| `bus/` | Agent bus MCP server + SQLite mailbox (feature `bus`) |
 
 ## Reporting Issues
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,15 +16,23 @@ Verify it works:
 claudectl --version
 ```
 
-## 2. Wire up Claude Code hooks
+## 2. Onboard with `claudectl init`
 
 ```bash
-claudectl --init
+claudectl init
 ```
 
-This writes three hooks into `~/.claude/settings.json` so Claude Code notifies claudectl on every tool use. Your existing settings are preserved.
+The wizard walks five phases — weekly budget cap, local-LLM brain auto-detection (probes ollama / llama.cpp / LM Studio / vLLM), Claude Code hook install, agent-bus role binding, and curated skill suggestions. Each phase is skippable (`s` at the prompt) and the result is recorded at `~/.claudectl/onboarding.json` so later runs of `claudectl init --check` can show drift.
 
-You only need to run this once. The hooks persist across sessions and Claude Code restarts.
+For dotfile automation:
+
+```bash
+claudectl init --non-interactive --budget 25 --skip-brain --skip-bus --skip-skills
+```
+
+If you only want the hook install (the previous `--init` flag), that's the **Plugin** phase — accept it and skip the others.
+
+Your existing Claude Code settings are preserved; the hook install only adds claudectl entries.
 
 **What gets added:**
 
@@ -68,13 +76,13 @@ Runs with fake sessions so you can explore the dashboard, keybindings, and featu
 
 ## Optional: project-scoped hooks
 
-If you only want claudectl hooks in specific projects (not globally):
+If you only want claudectl hooks in specific projects (not globally), the `--init` legacy flag still works for hook-only installs:
 
 ```bash
 claudectl --init -s project
 ```
 
-This writes to `.claude/settings.local.json` (gitignored) instead of the global file. The `-s project` flag matches Claude Code's own `--scope` convention.
+This writes to `.claude/settings.local.json` (gitignored) instead of the global file. The `-s project` flag matches Claude Code's own `--scope` convention. `--init` is otherwise deprecated — prefer `claudectl init` for new setups.
 
 ## Optional: add the local LLM brain
 
@@ -119,14 +127,20 @@ The plugin and `--init` hooks are complementary. Use `--init` for dashboard obse
 
 ## Uninstall
 
-Remove claudectl hooks from Claude Code:
+Roll back the onboarding wizard's installed artifacts:
+
+```bash
+claudectl init --remove                      # Removes hooks + onboarding marker
+```
+
+Or remove just the hooks (legacy flag, still supported):
 
 ```bash
 claudectl --uninstall                        # Remove from user settings
 claudectl --uninstall -s project             # Remove from project settings
 ```
 
-This surgically removes only claudectl entries. All other settings and hooks are preserved.
+Both surgically remove only claudectl entries. All other settings and hooks are preserved. Phases that own user state (e.g. the bus database, your budget config line) deliberately decline to delete it.
 
 To uninstall the binary:
 


### PR DESCRIPTION
## Summary

Closes #278 (the last open sub-issue of epic #279). Wraps the workspace refactor with a full documentation pass and the version bump.

### Internal docs
* **CLAUDE.md** — three-crate workspace layout, 8 runtime traits, re-export bridge, feature propagation. Dropped the stale "(future: claudectl-tui)" marker. Slimmed the duplicate Binary modules section.
* **AGENTS.md** — replaced the single-crate Core modules listing with the new workspace map. Conventions section updated for the dependency direction and per-crate standalone CI jobs.
* **docs/contributing.md** — three-crate workspace map with per-crate module tables. Added the standalone build commands contributors should run before submitting (mirrors CI).

### User docs
* **README.md** — "Get started" now points at `claudectl init` (the onboarding wizard from #257) rather than the legacy `--init` flag, with a one-line description of what the wizard walks.
* **docs/quickstart.md** — Step 2 rewritten around `claudectl init` (including `--non-interactive` for automation and `--check` for drift). Uninstall section now leads with `claudectl init --remove`. The legacy `--init -s project` form stays documented because it's still the hook-only escape hatch.

### Release notes
* **CHANGELOG.md** — new 0.54.0 entry covering the workspace refactor: TUI extraction (#275), dependency-direction enforcement, the 8 runtime traits + `HiveActions` surface, `hooks`/`launch`/`skills`/`BrainConfig`/`IdleConfig` moves into core, feature propagation, and the CLAUDE.md update (#278).

### Version
* `claudectl` 0.53.0 → 0.54.0 to mark the workspace milestone.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] Spot-checked every module path mentioned in the new docs against the on-disk layout.

Closes #278. Epic #279 ready to close after this lands.