### PR TITLE
chore(release): wire claudectl-core/tui publish into release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,18 +82,89 @@ jobs:
             claudectl-*.tar.gz
             claudectl-*.tar.gz.sha256
 
-  publish-crate:
-    name: Publish crate
+  # crates.io publish order: claudectl-core → claudectl-tui → claudectl.
+  # Each downstream publish needs the previous one to be visible on the
+  # crates.io index, which can lag the upload by 30s–2min. We poll
+  # `cargo search` between steps with a hard cap so a hung index never
+  # blocks the whole pipeline forever.
+  publish-crate-core:
+    name: Publish claudectl-core
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: dtolnay/rust-toolchain@stable
-
       - uses: Swatinem/rust-cache@v2
+      - name: Publish claudectl-core
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -e
+          VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/claudectl-core/Cargo.toml | head -n 1)
+          # Idempotent: skip if this version is already on the index.
+          if cargo search claudectl-core 2>/dev/null | grep -qE "^claudectl-core = \"${VERSION}\""; then
+            echo "claudectl-core ${VERSION} already on crates.io, skipping"
+          else
+            cargo publish -p claudectl-core --locked --token "$CARGO_REGISTRY_TOKEN"
+          fi
 
-      - name: Publish to crates.io
+  publish-crate-tui:
+    name: Publish claudectl-tui
+    needs: publish-crate-core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Wait for claudectl-core on index
+        run: |
+          set -e
+          VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/claudectl-core/Cargo.toml | head -n 1)
+          for i in $(seq 1 30); do
+            if cargo search claudectl-core 2>/dev/null | grep -qE "^claudectl-core = \"${VERSION}\""; then
+              echo "claudectl-core ${VERSION} visible on index"
+              exit 0
+            fi
+            echo "waiting for claudectl-core ${VERSION} (attempt ${i}/30)..."
+            sleep 10
+          done
+          echo "::error::claudectl-core ${VERSION} never appeared on crates.io after 5 minutes"
+          exit 1
+      - name: Publish claudectl-tui
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -e
+          VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/claudectl-tui/Cargo.toml | head -n 1)
+          if cargo search claudectl-tui 2>/dev/null | grep -qE "^claudectl-tui = \"${VERSION}\""; then
+            echo "claudectl-tui ${VERSION} already on crates.io, skipping"
+          else
+            cargo publish -p claudectl-tui --locked --token "$CARGO_REGISTRY_TOKEN"
+          fi
+
+  publish-crate:
+    name: Publish claudectl (binary)
+    needs: publish-crate-tui
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Wait for claudectl-tui on index
+        run: |
+          set -e
+          VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/claudectl-tui/Cargo.toml | head -n 1)
+          for i in $(seq 1 30); do
+            if cargo search claudectl-tui 2>/dev/null | grep -qE "^claudectl-tui = \"${VERSION}\""; then
+              echo "claudectl-tui ${VERSION} visible on index"
+              exit 0
+            fi
+            echo "waiting for claudectl-tui ${VERSION} (attempt ${i}/30)..."
+            sleep 10
+          done
+          echo "::error::claudectl-tui ${VERSION} never appeared on crates.io after 5 minutes"
+          exit 1
+      - name: Publish claudectl binary
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --locked --token "$CARGO_REGISTRY_TOKEN"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,12 @@ name = "claudectl"
 path = "src/lib.rs"
 
 [dependencies]
-claudectl-core = { path = "crates/claudectl-core" }
-claudectl-tui = { path = "crates/claudectl-tui" }
+# Workspace crates carry a `version` alongside `path` so the binary can be
+# published to crates.io. Local builds always use the path; crates.io strips
+# the path and resolves the published version. Bump both when the workspace
+# crates change.
+claudectl-core = { path = "crates/claudectl-core", version = "0.51.0" }
+claudectl-tui = { path = "crates/claudectl-tui", version = "0.51.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

The workspace refactor split the binary across three crates (#275), but the release workflow still runs a single `cargo publish` that fails on path-only deps. This PR wires up the missing pieces so a `v0.54.0` tag push actually ships.

* **Root `Cargo.toml`** — added `version = \"0.51.0\"` to the `claudectl-core` and `claudectl-tui` path deps. Local builds keep using the path; `cargo publish` now has the version it needs to upload.
* **`release.yml`** — split the old single `Publish crate` job into three sequential jobs:
  1. `Publish claudectl-core`
  2. `Publish claudectl-tui` (depends on core; polls crates.io index for up to 5 min before uploading)
  3. `Publish claudectl (binary)` (depends on tui; same poll)

  Each step is **idempotent**: skips the publish if `cargo search` already shows that version on the index, so a re-run after a partial failure doesn't error.

## Install story (unchanged for end users)

```bash
brew install mercurialsolo/tap/claudectl     # Homebrew (unchanged)
cargo install claudectl                       # Cargo — resolves the three crates transitively
curl -fsSL .../install.sh | sh                # Tarball installer (unchanged)
```

The workspace split is internal. The only people who notice are library consumers who want the runtime traits directly — they'd add `claudectl-core = \"0.51.0\"`.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo publish -p claudectl-core --dry-run --allow-dirty` (passes)
- [ ] Tag `v0.54.0` after this merges to verify the full workflow end-to-end

Blocker for tagging `v0.54.0`. Last release was `v0.51.0`; 0.52.0 and 0.53.0 were never tagged.