### PR TITLE
chore(release): poll crates.io HTTP API instead of cargo search

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,9 +83,10 @@ jobs:
             claudectl-*.tar.gz.sha256
 
   # crates.io publish order: claudectl-core → claudectl-tui → claudectl.
-  # Each downstream publish needs the previous one to be visible on the
-  # crates.io index, which can lag the upload by 30s–2min. We poll
-  # `cargo search` between steps with a hard cap so a hung index never
+  # Each downstream publish needs the previous one to be visible on
+  # crates.io, which can lag the upload by 30s–2min. We poll the
+  # crates.io HTTP API (not `cargo search` — Actions caches its
+  # registry index aggressively) with a hard cap so a hung index never
   # blocks the whole pipeline forever.
   publish-crate-core:
     name: Publish claudectl-core
@@ -101,8 +102,11 @@ jobs:
         run: |
           set -e
           VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/claudectl-core/Cargo.toml | head -n 1)
-          # Idempotent: skip if this version is already on the index.
-          if cargo search claudectl-core 2>/dev/null | grep -qE "^claudectl-core = \"${VERSION}\""; then
+          # Idempotent: skip if this version is already on crates.io.
+          FOUND=$(curl -sS -A "claudectl-release-workflow" \
+            "https://crates.io/api/v1/crates/claudectl-core/${VERSION}" \
+            | grep -o "\"num\":\"${VERSION}\"" | head -n 1 || true)
+          if [ -n "$FOUND" ]; then
             echo "claudectl-core ${VERSION} already on crates.io, skipping"
           else
             cargo publish -p claudectl-core --locked --token "$CARGO_REGISTRY_TOKEN"
@@ -116,13 +120,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Wait for claudectl-core on index
+      - name: Wait for claudectl-core on crates.io
+        # `cargo search` reads the local registry index, which the GitHub
+        # Actions runner caches and is slow to refresh. Hit the crates.io
+        # HTTP API directly so we see a fresh result every call.
         run: |
           set -e
           VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/claudectl-core/Cargo.toml | head -n 1)
           for i in $(seq 1 30); do
-            if cargo search claudectl-core 2>/dev/null | grep -qE "^claudectl-core = \"${VERSION}\""; then
-              echo "claudectl-core ${VERSION} visible on index"
+            FOUND=$(curl -sS -A "claudectl-release-workflow" \
+              "https://crates.io/api/v1/crates/claudectl-core/${VERSION}" \
+              | grep -o "\"num\":\"${VERSION}\"" | head -n 1 || true)
+            if [ -n "$FOUND" ]; then
+              echo "claudectl-core ${VERSION} visible on crates.io"
               exit 0
             fi
             echo "waiting for claudectl-core ${VERSION} (attempt ${i}/30)..."
@@ -136,7 +146,10 @@ jobs:
         run: |
           set -e
           VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/claudectl-tui/Cargo.toml | head -n 1)
-          if cargo search claudectl-tui 2>/dev/null | grep -qE "^claudectl-tui = \"${VERSION}\""; then
+          FOUND=$(curl -sS -A "claudectl-release-workflow" \
+            "https://crates.io/api/v1/crates/claudectl-tui/${VERSION}" \
+            | grep -o "\"num\":\"${VERSION}\"" | head -n 1 || true)
+          if [ -n "$FOUND" ]; then
             echo "claudectl-tui ${VERSION} already on crates.io, skipping"
           else
             cargo publish -p claudectl-tui --locked --token "$CARGO_REGISTRY_TOKEN"
@@ -150,13 +163,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Wait for claudectl-tui on index
+      - name: Wait for claudectl-tui on crates.io
         run: |
           set -e
           VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/claudectl-tui/Cargo.toml | head -n 1)
           for i in $(seq 1 30); do
-            if cargo search claudectl-tui 2>/dev/null | grep -qE "^claudectl-tui = \"${VERSION}\""; then
-              echo "claudectl-tui ${VERSION} visible on index"
+            FOUND=$(curl -sS -A "claudectl-release-workflow" \
+              "https://crates.io/api/v1/crates/claudectl-tui/${VERSION}" \
+              | grep -o "\"num\":\"${VERSION}\"" | head -n 1 || true)
+            if [ -n "$FOUND" ]; then
+              echo "claudectl-tui ${VERSION} visible on crates.io"
               exit 0
             fi
             echo "waiting for claudectl-tui ${VERSION} (attempt ${i}/30)..."


### PR DESCRIPTION
## Summary

The 0.54.0 release workflow's \`Publish claudectl-tui\` job timed out waiting for \`claudectl-core\` to appear on the index, even though the publish succeeded. Root cause: GitHub Actions caches the cargo registry index aggressively, so \`cargo search\` on the runner kept reading a stale view well after the upload.

Switched both wait steps and both idempotency checks to hit the crates.io HTTP API directly via \`curl\`. Each call is cache-free, so the poll sees the upload within seconds.

## Test plan

- [x] Locally: \`curl https://crates.io/api/v1/crates/claudectl-core/0.51.0\` returns the version immediately

Unblocks the v0.54.0 release. After this merges, the v0.54.0 tag will be re-pointed at the new HEAD so the release workflow re-runs against the fixed YAML.