### PR TITLE
feat(bus): bind roles by PID + TUI Ctrl+R keybinding (closes #307)

### DIFF
--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -305,6 +305,8 @@ pub struct RoleBinding {
     pub cwd_selector: String,
     pub last_session_id: Option<String>,
     pub last_seen: String,
+    /// PID this role is bound to (#307). `None` for cwd-only bindings.
+    pub pid: Option<u32>,
 }
 
 /// Read access to the agent-bus roster + role table. Disabled implementations
@@ -430,6 +432,13 @@ pub trait Actions: Send + Sync {
     /// Mark a past brain decision as canonical for teaching. Optional `note`
     /// is the operator's annotation. Used by the Brain Review surface.
     fn mark_canonical(&self, decision_id: &str, note: Option<String>) -> Result<(), String>;
+
+    /// Bind an agent-bus role to a `(cwd, pid)` pair. The TUI calls this from
+    /// the new role-bind key (Ctrl+R) so the operator can attach a role to a
+    /// specific running Claude session without dropping to another terminal.
+    /// Returns `Err` when the bus feature is compiled out or the DB write
+    /// fails. See issue #307.
+    fn bind_bus_role(&self, name: &str, cwd: &str, pid: u32) -> Result<(), String>;
 }
 
 // ============================================================================
@@ -679,6 +688,11 @@ pub enum MockAction {
         decision_id: String,
         note: Option<String>,
     },
+    BindBusRole {
+        name: String,
+        cwd: String,
+        pid: u32,
+    },
 }
 
 impl PartialEq for ObservationInput {
@@ -855,6 +869,17 @@ impl Actions for MockRuntime {
             .push(MockAction::MarkCanonical {
                 decision_id: decision_id.into(),
                 note,
+            });
+        Ok(())
+    }
+    fn bind_bus_role(&self, name: &str, cwd: &str, pid: u32) -> Result<(), String> {
+        self.actions_log
+            .lock()
+            .expect("actions_log poisoned")
+            .push(MockAction::BindBusRole {
+                name: name.into(),
+                cwd: cwd.into(),
+                pid,
             });
         Ok(())
     }

--- a/crates/claudectl-tui/src/app.rs
+++ b/crates/claudectl-tui/src/app.rs
@@ -2976,14 +2976,13 @@ impl App {
             KeyCode::Backspace => {
                 self.role_bind_buffer.pop();
             }
-            KeyCode::Char(c) => {
-                // Role names are short, alpha-numeric with - and _. Cap at
-                // 64 so a runaway paste doesn't take the prompt hostage.
+            // Role names are short, alpha-numeric with - and _. Cap at 64
+            // so a runaway paste can't take the prompt hostage.
+            KeyCode::Char(c)
                 if self.role_bind_buffer.len() < 64
-                    && (c.is_ascii_alphanumeric() || c == '-' || c == '_')
-                {
-                    self.role_bind_buffer.push(c);
-                }
+                    && (c.is_ascii_alphanumeric() || c == '-' || c == '_') =>
+            {
+                self.role_bind_buffer.push(c);
             }
             _ => {}
         }

--- a/crates/claudectl-tui/src/app.rs
+++ b/crates/claudectl-tui/src/app.rs
@@ -257,6 +257,14 @@ pub struct App {
     pub input_mode: bool,
     pub input_buffer: String,
     pub input_target_pid: Option<u32>,
+    // ── Role-bind input mode (#307) ──────────────────────────────────────
+    /// When true, keystrokes accumulate in `role_bind_buffer` instead of
+    /// triggering normal-mode handlers. Entered via Ctrl+R on the
+    /// dashboard; Esc cancels, Enter commits via `Actions::bind_bus_role`.
+    pub role_bind_mode: bool,
+    pub role_bind_buffer: String,
+    pub role_bind_target_pid: Option<u32>,
+    pub role_bind_target_cwd: Option<String>,
     pub notify: bool,
     pub prev_statuses: HashMap<u32, SessionStatus>,
     pub show_help: bool,
@@ -527,6 +535,10 @@ impl App {
             status_msg: String::new(),
             pending_kill: None,
             input_mode: false,
+            role_bind_mode: false,
+            role_bind_buffer: String::new(),
+            role_bind_target_pid: None,
+            role_bind_target_cwd: None,
             input_buffer: String::new(),
             input_target_pid: None,
             notify: false,
@@ -1868,6 +1880,12 @@ impl App {
             return true;
         }
 
+        // Role-bind mode: capture role name for the selected session (#307)
+        if self.role_bind_mode {
+            self.handle_role_bind_key(key);
+            return true;
+        }
+
         // Skills overlay: dedicated keymap (j/k navigate, s share, h serve, r rescan, Esc/K close)
         if self.show_skills {
             self.handle_skills_key(key);
@@ -2332,6 +2350,14 @@ impl App {
                 self.cancel_pending_kill();
                 self.cancel_pending_auto_approve();
                 self.previous();
+            }
+            (KeyCode::Char('r'), KeyModifiers::CONTROL) => {
+                // Bus role bind (#307). Ctrl+R because plain `r` is refresh.
+                // Match before the unconditional `r` arm below, otherwise
+                // the wildcard modifier swallows the Control modifier.
+                self.cancel_pending_kill();
+                self.cancel_pending_auto_approve();
+                self.enter_role_bind_mode();
             }
             (KeyCode::Char('r'), _) => {
                 self.cancel_pending_kill();
@@ -2887,6 +2913,79 @@ impl App {
             self.input_buffer.clear();
             self.input_target_pid = Some(pid);
             self.status_msg = format!("Input to {name} (Enter to send, Esc to cancel): ");
+        }
+    }
+
+    /// Open the role-bind prompt for the selected session (#307). Captures
+    /// the session's pid and cwd at entry time so a refresh tick or row
+    /// move during typing can't change the target.
+    fn enter_role_bind_mode(&mut self) {
+        let Some(session) = self.selected_session() else {
+            self.status_msg = "No session selected".into();
+            return;
+        };
+        if session.is_remote() {
+            self.status_msg = "Remote session \u{2014} bind locally instead".into();
+            return;
+        }
+        let pid = session.pid;
+        let cwd = session.cwd.clone();
+        let name = session.display_name().to_string();
+        self.role_bind_mode = true;
+        self.role_bind_buffer.clear();
+        self.role_bind_target_pid = Some(pid);
+        self.role_bind_target_cwd = Some(cwd);
+        self.status_msg =
+            format!("Bind role for {name} (pid={pid}, Enter to bind, Esc to cancel): ");
+    }
+
+    fn handle_role_bind_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Enter => {
+                let role = self.role_bind_buffer.trim().to_string();
+                let pid = self.role_bind_target_pid;
+                let cwd = self.role_bind_target_cwd.clone();
+                self.role_bind_mode = false;
+                self.role_bind_buffer.clear();
+                self.role_bind_target_pid = None;
+                self.role_bind_target_cwd = None;
+                if role.is_empty() {
+                    self.status_msg = "Role name required".into();
+                    return;
+                }
+                let (Some(pid), Some(cwd)) = (pid, cwd) else {
+                    self.status_msg = "Lost bind target — re-select the session".into();
+                    return;
+                };
+                match self.runtime.actions.bind_bus_role(&role, &cwd, pid) {
+                    Ok(()) => {
+                        self.status_msg = format!("Bound role {role} -> pid={pid} cwd={cwd}");
+                    }
+                    Err(e) => {
+                        self.status_msg = format!("Bind failed: {e}");
+                    }
+                }
+            }
+            KeyCode::Esc => {
+                self.role_bind_mode = false;
+                self.role_bind_buffer.clear();
+                self.role_bind_target_pid = None;
+                self.role_bind_target_cwd = None;
+                self.status_msg = "Role bind cancelled".into();
+            }
+            KeyCode::Backspace => {
+                self.role_bind_buffer.pop();
+            }
+            KeyCode::Char(c) => {
+                // Role names are short, alpha-numeric with - and _. Cap at
+                // 64 so a runaway paste doesn't take the prompt hostage.
+                if self.role_bind_buffer.len() < 64
+                    && (c.is_ascii_alphanumeric() || c == '-' || c == '_')
+                {
+                    self.role_bind_buffer.push(c);
+                }
+            }
+            _ => {}
         }
     }
 

--- a/crates/claudectl-tui/src/ui/detail.rs
+++ b/crates/claudectl-tui/src/ui/detail.rs
@@ -64,6 +64,34 @@ pub fn render_detail_panel(frame: &mut Frame, area: Rect, session: &ClaudeSessio
         session.telemetry_label().to_string()
     };
 
+    // Bus role binding (#307). Look up by pid first — TUI-bound roles attach
+    // by pid so this catches the bind without an extra cwd-prefix lookup. We
+    // fall back to cwd_selector matching for cwd-only bindings made via
+    // `claudectl bus role bind <name> <cwd>` outside the TUI.
+    let bus_role_line = {
+        let roles = app.runtime.bus.list_roles();
+        let by_pid = roles.iter().find(|r| r.pid == Some(session.pid));
+        let by_cwd = roles
+            .iter()
+            .find(|r| !r.cwd_selector.is_empty() && session.cwd.starts_with(&r.cwd_selector));
+        match by_pid.or(by_cwd) {
+            Some(r) => detail_line(
+                "Bus role",
+                &format!(
+                    "{} (bound by {})",
+                    r.name,
+                    if r.pid == Some(session.pid) {
+                        "pid"
+                    } else {
+                        "cwd"
+                    }
+                ),
+                t,
+            ),
+            None => detail_line("Bus role", "— (Ctrl+R to bind)", t),
+        }
+    };
+
     let mut lines = vec![
         detail_line("PID", &pid, t),
         detail_line("Session ID", &session.session_id, t),
@@ -71,6 +99,7 @@ pub fn render_detail_panel(frame: &mut Frame, area: Rect, session: &ClaudeSessio
         detail_line("Project", &session.project_name, t),
         detail_line("Model", &model, t),
         detail_line("Status", &status, t),
+        bus_role_line,
         detail_line("Telemetry", &telemetry, t),
         detail_line("TTY", &tty, t),
         detail_line("Elapsed", &elapsed, t),

--- a/crates/claudectl-tui/src/ui/help.rs
+++ b/crates/claudectl-tui/src/ui/help.rs
@@ -99,6 +99,10 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
             Span::raw("  Toggle brain on/off"),
         ]),
         Line::from(vec![
+            Span::styled("  Ctrl+r         ", Style::default().fg(t.highlight_key)),
+            Span::raw("  Bind agent-bus role to selected session"),
+        ]),
+        Line::from(vec![
             Span::styled("  g              ", Style::default().fg(t.highlight_key)),
             Span::raw("  Toggle grouped view by project"),
         ]),

--- a/crates/claudectl-tui/src/ui/status_bar.rs
+++ b/crates/claudectl-tui/src/ui/status_bar.rs
@@ -55,6 +55,21 @@ pub fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
             Span::styled("_", Style::default().fg(t.text_muted)),
         ]));
         frame.render_widget(msg, area);
+    } else if app.role_bind_mode {
+        // #307 role-bind prompt — same shape as the input prompt but with a
+        // distinct prefix so the operator sees they're naming a role, not
+        // sending text to the session.
+        let msg = Paragraph::new(Line::from(vec![
+            Span::styled(
+                " role> ",
+                Style::default()
+                    .fg(t.input_accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(&*app.role_bind_buffer, Style::default().fg(t.text_primary)),
+            Span::styled("_", Style::default().fg(t.text_muted)),
+        ]));
+        frame.render_widget(msg, area);
     } else if app.idle_mode_active {
         let idle_mins = app.last_user_interaction.elapsed().as_secs() / 60;
         let tasks = if app.idle_tasks_launched.is_empty() {

--- a/src/bus/cli.rs
+++ b/src/bus/cli.rs
@@ -77,7 +77,7 @@ pub enum BusCommand {
 
 #[derive(Subcommand)]
 pub enum RoleCommand {
-    /// Bind (create or update) a role to a cwd selector.
+    /// Bind (create or update) a role to a cwd selector and/or process id.
     Bind {
         /// Role name.
         name: String,
@@ -86,6 +86,11 @@ pub enum RoleCommand {
         /// Optional session_id to bind initially.
         #[arg(long)]
         session_id: Option<String>,
+        /// Process ID to bind this role to (#307). When set, the resolver
+        /// prefers this binding over cwd-inference for any caller whose
+        /// ancestor chain contains this pid.
+        #[arg(long)]
+        pid: Option<u32>,
     },
     /// List registered roles.
     List,
@@ -120,9 +125,13 @@ fn dispatch_role(cmd: &RoleCommand) -> Result<(), String> {
             name,
             cwd,
             session_id,
+            pid,
         } => {
-            store::upsert_role(&conn, name, cwd, session_id.as_deref())?;
-            println!("bound role {name} -> {cwd}");
+            store::upsert_role(&conn, name, cwd, session_id.as_deref(), *pid)?;
+            match pid {
+                Some(p) => println!("bound role {name} -> {cwd} (pid={p})"),
+                None => println!("bound role {name} -> {cwd}"),
+            }
             Ok(())
         }
         RoleCommand::List => {
@@ -133,9 +142,10 @@ fn dispatch_role(cmd: &RoleCommand) -> Result<(), String> {
             }
             for r in rows {
                 println!(
-                    "{name:<20} {sel:<40} last_seen={ts} session={sess}",
+                    "{name:<20} {sel:<40} pid={pid} last_seen={ts} session={sess}",
                     name = r.role,
                     sel = r.cwd_selector,
+                    pid = r.pid.map(|p| p.to_string()).unwrap_or_else(|| "-".into()),
                     ts = r.last_seen,
                     sess = r.last_session_id.unwrap_or_else(|| "-".into()),
                 );
@@ -293,6 +303,8 @@ struct WhoamiJson {
     role: Option<String>,
     cwd_selector: Option<String>,
     last_session_id: Option<String>,
+    /// PID this role is bound to (#307). `None` for cwd-only bindings.
+    pid: Option<u32>,
     note: Option<String>,
 }
 
@@ -328,18 +340,21 @@ fn dispatch_whoami(role: Option<&str>, json: bool) -> Result<(), String> {
                 role: Some(r.name),
                 cwd_selector: Some(r.cwd_selector),
                 last_session_id: r.last_session_id,
+                pid: r.pid,
                 note: None,
             },
             RoleResolution::Ambiguous { candidates } => WhoamiJson {
                 role: None,
                 cwd_selector: None,
                 last_session_id: None,
+                pid: None,
                 note: Some(format!("ambiguous: {}", candidates.join(", "))),
             },
             RoleResolution::Unbound { cwd } => WhoamiJson {
                 role: None,
                 cwd_selector: None,
                 last_session_id: None,
+                pid: None,
                 note: Some(format!("unbound (cwd={cwd})")),
             },
         };

--- a/src/bus/roles.rs
+++ b/src/bus/roles.rs
@@ -26,6 +26,8 @@ pub struct Role {
     pub last_session_id: Option<String>,
     pub last_seen: String,
     pub subscriptions: Vec<String>,
+    /// PID this role is bound to, if any (#307).
+    pub pid: Option<u32>,
 }
 
 impl From<RoleRow> for Role {
@@ -36,6 +38,7 @@ impl From<RoleRow> for Role {
             last_session_id: r.last_session_id,
             last_seen: r.last_seen,
             subscriptions: r.subscriptions,
+            pid: r.pid,
         }
     }
 }
@@ -50,8 +53,13 @@ pub enum RoleResolution {
 
 pub const ROLE_ENV: &str = "CLAUDECTL_BUS_ROLE";
 
-/// Resolve the caller's role. `explicit` wins if set; otherwise we look in
-/// `CLAUDECTL_BUS_ROLE` and then fall back to cwd-inference.
+/// Resolve the caller's role. Order:
+/// 1. `explicit` (CLI `--role`)
+/// 2. `CLAUDECTL_BUS_ROLE` env
+/// 3. **PID-binding** (#307) — any role bound to a pid in the caller's
+///    ancestor chain (starting at the caller's parent — for the bus stdio
+///    server, that's the Claude Code process).
+/// 4. cwd-inference (literal-prefix match against bound `cwd_selector`s)
 pub fn resolve(
     conn: &Connection,
     explicit: Option<&str>,
@@ -65,7 +73,58 @@ pub fn resolve(
             return resolve_by_name(conn, name.trim(), cwd);
         }
     }
+    if let Some(role) = resolve_by_pid_chain(conn, &ancestor_pids())? {
+        return Ok(RoleResolution::Resolved(role));
+    }
     resolve_by_cwd(conn, cwd)
+}
+
+/// Pick the first role bound to any pid in `chain`. Split out from
+/// `ancestor_pids()` so tests can drive it with a synthetic chain.
+fn resolve_by_pid_chain(conn: &Connection, chain: &[u32]) -> Result<Option<Role>, String> {
+    for pid in chain {
+        if let Some(row) = store::get_role_by_pid(conn, *pid)? {
+            return Ok(Some(row.into()));
+        }
+    }
+    Ok(None)
+}
+
+/// Caller's parent pid chain, capped at depth 8 so we don't walk to init.
+/// Depth 8 comfortably covers `claude → bash → mcp-stdio-server` plus
+/// nested shells, tmux, etc.
+fn ancestor_pids() -> Vec<u32> {
+    let mut out = Vec::new();
+    let mut pid = unsafe { libc::getppid() } as u32;
+    for _ in 0..8 {
+        if pid <= 1 {
+            break;
+        }
+        out.push(pid);
+        pid = match parent_pid_of(pid) {
+            Some(p) if p > 1 => p,
+            _ => break,
+        };
+    }
+    out
+}
+
+/// Look up `ppid` for `pid` via `ps`. Returns `None` when the pid is gone
+/// or `ps` fails. Native `ps` keeps us off the sysinfo crate.
+fn parent_pid_of(pid: u32) -> Option<u32> {
+    let output = std::process::Command::new("ps")
+        .args(["-o", "ppid=", "-p", &pid.to_string()])
+        .env_clear()
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()?
+        .trim()
+        .parse::<u32>()
+        .ok()
 }
 
 fn resolve_by_name(conn: &Connection, name: &str, _cwd: &Path) -> Result<RoleResolution, String> {
@@ -128,8 +187,8 @@ mod tests {
     #[test]
     fn cwd_inference_picks_single_match() {
         let conn = open_memory();
-        upsert_role(&conn, "planner", "/work/proj-plan", None).unwrap();
-        upsert_role(&conn, "impl", "/work/proj-impl", None).unwrap();
+        upsert_role(&conn, "planner", "/work/proj-plan", None, None).unwrap();
+        upsert_role(&conn, "impl", "/work/proj-impl", None, None).unwrap();
         let r = resolve(&conn, None, &PathBuf::from("/work/proj-impl/src")).unwrap();
         match r {
             RoleResolution::Resolved(role) => assert_eq!(role.name, "impl"),
@@ -140,8 +199,8 @@ mod tests {
     #[test]
     fn shared_cwd_is_ambiguous() {
         let conn = open_memory();
-        upsert_role(&conn, "planner", "/shared/repo", None).unwrap();
-        upsert_role(&conn, "impl", "/shared/repo", None).unwrap();
+        upsert_role(&conn, "planner", "/shared/repo", None, None).unwrap();
+        upsert_role(&conn, "impl", "/shared/repo", None, None).unwrap();
         let r = resolve(&conn, None, &PathBuf::from("/shared/repo")).unwrap();
         match r {
             RoleResolution::Ambiguous { candidates } => assert_eq!(candidates.len(), 2),
@@ -152,8 +211,8 @@ mod tests {
     #[test]
     fn explicit_role_overrides_cwd() {
         let conn = open_memory();
-        upsert_role(&conn, "planner", "/work/proj", None).unwrap();
-        upsert_role(&conn, "impl", "/other/place", None).unwrap();
+        upsert_role(&conn, "planner", "/work/proj", None, None).unwrap();
+        upsert_role(&conn, "impl", "/other/place", None, None).unwrap();
         let r = resolve(&conn, Some("impl"), &PathBuf::from("/work/proj")).unwrap();
         assert!(matches!(r, RoleResolution::Resolved(role) if role.name == "impl"));
     }
@@ -163,5 +222,46 @@ mod tests {
         let conn = open_memory();
         let r = resolve(&conn, None, &PathBuf::from("/nowhere")).unwrap();
         assert!(matches!(r, RoleResolution::Unbound { .. }));
+    }
+
+    #[test]
+    fn pid_binding_takes_precedence_over_cwd_match() {
+        // #307: a role bound to pid 12345 should win over a role whose
+        // cwd_selector matches the caller's cwd, when 12345 is in the
+        // caller's ancestor chain.
+        let conn = open_memory();
+        upsert_role(&conn, "cwd-role", "/work/proj", None, None).unwrap();
+        upsert_role(&conn, "pid-role", "/work/proj", None, Some(12345)).unwrap();
+        let role = resolve_by_pid_chain(&conn, &[99999, 12345, 1])
+            .unwrap()
+            .expect("expected pid match");
+        assert_eq!(role.name, "pid-role");
+        assert_eq!(role.pid, Some(12345));
+    }
+
+    #[test]
+    fn pid_chain_with_no_match_falls_through() {
+        // Resolver returns None so the caller falls back to cwd inference.
+        let conn = open_memory();
+        upsert_role(&conn, "cwd-role", "/work/proj", None, Some(11111)).unwrap();
+        assert!(
+            resolve_by_pid_chain(&conn, &[22222, 33333])
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn upsert_keeps_existing_pid_when_rebinding_without_one() {
+        // Re-binding a role for a new session_id shouldn't clobber the pid
+        // — otherwise the TUI's resume flow would silently lose the binding.
+        let conn = open_memory();
+        upsert_role(&conn, "frontend", "/work/proj", None, Some(7777)).unwrap();
+        upsert_role(&conn, "frontend", "/work/proj", Some("sess_42"), None).unwrap();
+        let row = crate::bus::store::get_role(&conn, "frontend")
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.pid, Some(7777));
+        assert_eq!(row.last_session_id.as_deref(), Some("sess_42"));
     }
 }

--- a/src/bus/store.rs
+++ b/src/bus/store.rs
@@ -76,6 +76,18 @@ fn migrate(conn: &Connection) -> Result<(), rusqlite::Error> {
         );
         CREATE INDEX IF NOT EXISTS idx_roles_cwd ON roles(cwd_selector);
 
+        -- Migration #2: pid binding (issue #307). Stored as a nullable
+        -- INTEGER so older bindings (cwd-only) keep working. The resolver
+        -- prefers pid match when the caller's ancestor chain contains a
+        -- bound pid. `ADD COLUMN` is idempotent if guarded by a check on
+        -- table_info — SQLite has no `ADD COLUMN IF NOT EXISTS`.
+        ",
+    )?;
+    add_column_if_missing(conn, "roles", "pid", "INTEGER")?;
+    conn.execute_batch(
+        "
+        CREATE INDEX IF NOT EXISTS idx_roles_pid ON roles(pid) WHERE pid IS NOT NULL;
+
         CREATE TABLE IF NOT EXISTS messages (
             id              TEXT PRIMARY KEY,
             subject         TEXT NOT NULL,
@@ -107,23 +119,34 @@ pub struct RoleRow {
     pub last_session_id: Option<String>,
     pub last_seen: String,
     pub subscriptions: Vec<String>,
+    /// Process ID this role is bound to (#307). When the caller's parent
+    /// chain contains this pid, the resolver picks this role over any
+    /// cwd-inferred match. `None` for cwd-only bindings.
+    pub pid: Option<u32>,
 }
 
+/// Insert or update a role binding. `pid` is optional: when supplied, the
+/// resolver matches the caller's ancestor pids against it; without it the
+/// role behaves exactly like the pre-#307 cwd-only binding. Passing `None`
+/// on an update keeps the existing pid (so a re-bind that only refreshes
+/// `session_id` doesn't clobber a pid set elsewhere).
 pub fn upsert_role(
     conn: &Connection,
     role: &str,
     cwd_selector: &str,
     session_id: Option<&str>,
+    pid: Option<u32>,
 ) -> Result<(), String> {
     let now = now_iso();
     conn.execute(
-        "INSERT INTO roles(role, cwd_selector, last_session_id, last_seen, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?4)
+        "INSERT INTO roles(role, cwd_selector, last_session_id, last_seen, created_at, pid)
+         VALUES (?1, ?2, ?3, ?4, ?4, ?5)
          ON CONFLICT(role) DO UPDATE SET
              cwd_selector = excluded.cwd_selector,
              last_session_id = COALESCE(excluded.last_session_id, roles.last_session_id),
-             last_seen = excluded.last_seen",
-        params![role, cwd_selector, session_id, now],
+             last_seen = excluded.last_seen,
+             pid = COALESCE(excluded.pid, roles.pid)",
+        params![role, cwd_selector, session_id, now, pid],
     )
     .map_err(|e| format!("upsert role: {e}"))?;
     Ok(())
@@ -132,21 +155,12 @@ pub fn upsert_role(
 pub fn list_roles(conn: &Connection) -> Result<Vec<RoleRow>, String> {
     let mut stmt = conn
         .prepare(
-            "SELECT role, cwd_selector, last_session_id, last_seen, subscriptions
+            "SELECT role, cwd_selector, last_session_id, last_seen, subscriptions, pid
              FROM roles ORDER BY role",
         )
         .map_err(|e| format!("prepare: {e}"))?;
     let rows = stmt
-        .query_map([], |row| {
-            let subs: String = row.get(4)?;
-            Ok(RoleRow {
-                role: row.get(0)?,
-                cwd_selector: row.get(1)?,
-                last_session_id: row.get(2)?,
-                last_seen: row.get(3)?,
-                subscriptions: serde_json::from_str(&subs).unwrap_or_default(),
-            })
-        })
+        .query_map([], row_to_role)
         .map_err(|e| format!("query roles: {e}"))?;
     let mut out = Vec::new();
     for r in rows {
@@ -157,22 +171,60 @@ pub fn list_roles(conn: &Connection) -> Result<Vec<RoleRow>, String> {
 
 pub fn get_role(conn: &Connection, role: &str) -> Result<Option<RoleRow>, String> {
     conn.query_row(
-        "SELECT role, cwd_selector, last_session_id, last_seen, subscriptions
+        "SELECT role, cwd_selector, last_session_id, last_seen, subscriptions, pid
          FROM roles WHERE role = ?1",
         params![role],
-        |row| {
-            let subs: String = row.get(4)?;
-            Ok(RoleRow {
-                role: row.get(0)?,
-                cwd_selector: row.get(1)?,
-                last_session_id: row.get(2)?,
-                last_seen: row.get(3)?,
-                subscriptions: serde_json::from_str(&subs).unwrap_or_default(),
-            })
-        },
+        row_to_role,
     )
     .optional()
     .map_err(|e| format!("get role: {e}"))
+}
+
+/// Lookup the role bound to `pid`, if any. Used by the resolver to pick a
+/// pid-match over a cwd-match (#307).
+pub fn get_role_by_pid(conn: &Connection, pid: u32) -> Result<Option<RoleRow>, String> {
+    conn.query_row(
+        "SELECT role, cwd_selector, last_session_id, last_seen, subscriptions, pid
+         FROM roles WHERE pid = ?1 LIMIT 1",
+        params![pid],
+        row_to_role,
+    )
+    .optional()
+    .map_err(|e| format!("get role by pid: {e}"))
+}
+
+fn row_to_role(row: &rusqlite::Row<'_>) -> rusqlite::Result<RoleRow> {
+    let subs: String = row.get(4)?;
+    Ok(RoleRow {
+        role: row.get(0)?,
+        cwd_selector: row.get(1)?,
+        last_session_id: row.get(2)?,
+        last_seen: row.get(3)?,
+        subscriptions: serde_json::from_str(&subs).unwrap_or_default(),
+        pid: row.get::<_, Option<i64>>(5)?.map(|v| v as u32),
+    })
+}
+
+/// Idempotent `ALTER TABLE ... ADD COLUMN` — SQLite has no native
+/// `IF NOT EXISTS` form here, so we check `pragma_table_info` first.
+fn add_column_if_missing(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    type_decl: &str,
+) -> Result<(), rusqlite::Error> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let name: String = row.get(1)?;
+        if name == column {
+            return Ok(());
+        }
+    }
+    conn.execute_batch(&format!(
+        "ALTER TABLE {table} ADD COLUMN {column} {type_decl}"
+    ))?;
+    Ok(())
 }
 
 // ---------------- Messages ---------------------------------------------------
@@ -289,8 +341,8 @@ mod tests {
     #[test]
     fn upserts_and_lists_roles() {
         let conn = open_memory();
-        upsert_role(&conn, "planner", "/work/proj-plan", Some("sess_a")).unwrap();
-        upsert_role(&conn, "impl", "/work/proj-impl", Some("sess_b")).unwrap();
+        upsert_role(&conn, "planner", "/work/proj-plan", Some("sess_a"), None).unwrap();
+        upsert_role(&conn, "impl", "/work/proj-impl", Some("sess_b"), None).unwrap();
         let rs = list_roles(&conn).unwrap();
         assert_eq!(rs.len(), 2);
         let names: Vec<_> = rs.iter().map(|r| r.role.as_str()).collect();

--- a/src/init/phases.rs
+++ b/src/init/phases.rs
@@ -371,7 +371,7 @@ impl Phase for BusPhase {
 #[cfg(feature = "bus")]
 fn bind_bus_role(role: &str, cwd: &Path) -> io::Result<()> {
     let conn = crate::bus::store::open().map_err(io::Error::other)?;
-    crate::bus::store::upsert_role(&conn, role, &cwd.to_string_lossy(), None)
+    crate::bus::store::upsert_role(&conn, role, &cwd.to_string_lossy(), None, None)
         .map_err(io::Error::other)?;
     Ok(())
 }

--- a/src/runtime/actions.rs
+++ b/src/runtime/actions.rs
@@ -99,6 +99,19 @@ impl Actions for LiveActions {
     fn mark_canonical(&self, decision_id: &str, note: Option<String>) -> Result<(), String> {
         brain::review::mark_by_id(decision_id, note.as_deref())
     }
+
+    fn bind_bus_role(&self, name: &str, cwd: &str, pid: u32) -> Result<(), String> {
+        #[cfg(feature = "bus")]
+        {
+            let conn = crate::bus::store::open()?;
+            crate::bus::store::upsert_role(&conn, name, cwd, None, Some(pid))
+        }
+        #[cfg(not(feature = "bus"))]
+        {
+            let _ = (name, cwd, pid);
+            Err("bus feature not compiled in this build".into())
+        }
+    }
 }
 
 /// Inverse of `crate::runtime::brain::parse_gate_mode` — writes the canonical

--- a/src/runtime/bus.rs
+++ b/src/runtime/bus.rs
@@ -53,6 +53,7 @@ impl BusView for LiveBusView {
                 cwd_selector: r.cwd_selector,
                 last_session_id: r.last_session_id,
                 last_seen: r.last_seen,
+                pid: r.pid,
             })
             .collect()
     }


### PR DESCRIPTION
## Summary

Role binding used to be cwd-keyed only — operators had to run `claudectl bus role bind` in each project directory and deal with cwd-ambiguity on top. This PR adds PID-keyed binding so the operator can attach a role to a specific running Claude Code session straight from the dashboard.

### Storage
* `roles` table gains a nullable `pid INTEGER` column via an idempotent `ADD COLUMN` migration. Existing cwd-only bindings keep working unchanged.
* New `get_role_by_pid()` for the resolver's pid-match path.

### Resolver
* `resolve()` now walks the caller's parent pid chain (depth 8 via `getppid` + native `ps`) and picks the first role bound to any ancestor pid. Falls through to cwd-inference when no match. Inner `resolve_by_pid_chain()` takes the chain explicitly so tests can drive it deterministically.

### CLI
* `claudectl bus role bind <NAME> <CWD> [--pid <PID>]`
* `bus role list` prints the new pid column
* `bus whoami --json` payload gains a `pid` field

### Runtime / TUI
* New `Actions::bind_bus_role(name, cwd, pid)` trait method. `LiveActions` writes through `bus::store::upsert_role`; off-bus builds return a clear error.
* **`Ctrl+R`** on the dashboard captures the selected session's pid + cwd, opens a `role>` prompt in the status bar, and on Enter calls `bind_bus_role`. Input is alphanumerics / `-_`, capped at 64 chars.
* `ui/detail.rs` shows `Bus role: <name> (bound by pid/cwd)` or `— (Ctrl+R to bind)` so the current binding is visible at a glance. Lookup prefers pid, falls back to `cwd_selector` prefix.
* Help overlay lists the new Ctrl+R binding.

### Tests
3 new tests covering pid-precedence, fall-through, and pid-preservation across re-binds. All 24 bus tests pass, full suite green.

### What was *not* done here (captured as follow-ups)
* **#309** — auto-suggest a role from transcript analysis (pre-fill the Ctrl+R prompt with a top candidate).
* **#310** — `/bind` plugin slash command for in-session self-binding.

## Test plan

- [x] `cargo build --features bus`
- [x] `cargo test --features bus --lib bus::` — 24 passed
- [x] `cargo test` — all green
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build -p claudectl-tui` standalone
- [x] Layering grep on `claudectl-core/src` — PASS

Closes #307. Follow-ups: #309, #310.