### PR TITLE
feat(bus): /bind plugin slash command + --self CLI flag (closes #310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to claudectl are documented here.
 
+## [Unreleased]
+
+### Added — agent-bus role binding (closes #307, #310)
+- **PID-keyed role bindings.** The bus `roles` table gained a nullable `pid` column. When set, the resolver walks the caller's parent process chain (depth 8 via `getppid` + native `ps`) and picks the first role bound to any ancestor pid before falling back to cwd-inference. Disambiguates "two sessions in one worktree" — different pids, same cwd, distinct roles.
+- **`claudectl bus role bind <NAME> <CWD> --pid <PID>`** — explicit pid binding for orchestrator scripts.
+- **`claudectl bus role bind <NAME> --self`** — auto-detects Claude's pid by walking the ancestor chain looking for a process whose `ps -o command=` contains `claude`. Captures the current cwd. Used by the new `/bind` slash command.
+- **TUI `Ctrl+R`** on the selected session opens a `role>` prompt and binds the selected session's pid + cwd through the new `Actions::bind_bus_role` trait method. Detail panel now shows `Bus role: <name> (bound by pid|cwd)` so the current binding is visible at a glance.
+- **`/bind <role>` plugin slash command** (`claude-plugin/commands/bind.md`) — operator types `/bind frontend` from inside a Claude session; the plugin runs `claudectl bus role bind --self frontend`.
+- **`bus role list`** prints the new pid column; **`bus whoami --json`** payload gains a `pid` field.
+
+### Internals
+- Schema migration is idempotent — guarded by a `PRAGMA table_info` check before `ADD COLUMN` (SQLite has no `IF NOT EXISTS` for column adds). Existing cwd-only bindings keep working unchanged.
+- `upsert_role` uses `COALESCE` on the pid update, so a re-bind that only refreshes `session_id` doesn't clobber an existing pid.
+- New runtime trait method `Actions::bind_bus_role(name, cwd, pid)`; LiveActions writes through `bus::store::upsert_role`; off-bus builds return a clear error.
+- 3 new bus tests covering pid precedence, fall-through, and pid-preservation on re-bind. All 24 bus tests pass.
+
 ## [0.54.0] - 2026-06-06
 
 ### Internals (workspace refactor — closes epic #279)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Integrates the brain directly into Claude Code sessions — no TUI required.
 | `/spend` | Cost breakdown by project and time window |
 | `/brain-stats` | Brain learning metrics and accuracy |
 | `/auto-insights` | Auto-generated workflow insights |
+| `/inbox` | Drain pending agent-bus messages addressed to this session's role |
+| `/bind <role>` | Attach this session to an agent-bus role (auto-detects pid) |
 
 ## Headless Mode
 
@@ -217,11 +219,11 @@ claudectl bus whoami
 claudectl bus stdio
 ```
 
-The Claude Code plugin registers the bus as an MCP server (`claude-plugin/.mcp.json`) and ships an `/inbox` slash command that drains the caller's mailbox through the `read_inbox` tool. Roles are inferred from each session's cwd; override per-session with `CLAUDECTL_BUS_ROLE`.
+The Claude Code plugin registers the bus as an MCP server (`claude-plugin/.mcp.json`) and ships two slash commands: `/inbox` (drain mailbox) and `/bind <role>` (attach this session to a role). Bindings are PID-keyed when made through the TUI's `Ctrl+R` or `/bind --self`; cwd-keyed for the legacy `claudectl bus role bind <name> <cwd>` flow. The resolver prefers a PID match over cwd-inference, which disambiguates "two sessions in one worktree".
 
 Mailboxes live in `~/.claudectl/bus/bus.db` (SQLite WAL). Message bodies are sanitized at the boundary — a leading `/` is neutralized so a queued message cannot smuggle a slash command into the recipient.
 
-Not yet built: `Stop`-hook auto-delivery (continue-in-turn), pub/sub subscribe + claim protocol, flow guards, and the supervisor for long-horizon role persistence. See [AGENT_BUS.md](docs/AGENT_BUS.md#implementation-status) for the per-phase status table.
+Not yet built: pub/sub subscribe + claim protocol, flow guards, and the supervisor for long-horizon role persistence. See [AGENT_BUS.md](docs/AGENT_BUS.md#implementation-status) for the per-phase status table.
 
 ## Hive Mind & Relay
 

--- a/claude-plugin/commands/bind.md
+++ b/claude-plugin/commands/bind.md
@@ -1,0 +1,31 @@
+---
+name: bind
+description: Bind this Claude session to an agent-bus role so other sessions can address it
+args: "<role-name>"
+---
+
+Attach this session to an agent-bus role so peers can send it directed messages with `claudectl bus send <role> …`. The binding is **PID-keyed** — it follows this exact Claude Code process, so re-runs in the same project don't get confused by other sessions sharing the cwd.
+
+## What to do
+
+1. The user supplied a role name as `{{args}}`. If it's empty, ask them what to name the role and stop until they reply.
+
+2. Run:
+
+   ```bash
+   claudectl bus role bind --self {{args}}
+   ```
+
+   The `--self` flag tells the CLI to walk the ancestor process chain, find this Claude Code process, and bind the role to that pid + the current working directory. No need to look up the pid yourself.
+
+3. On success the command prints `bound role <name> -> <cwd> (pid=<pid>)`. Echo that confirmation back to the user.
+
+4. If the command errors with "could not find a Claude Code process in the ancestor chain", the plugin was invoked outside the normal `claude` execution context. Tell the user to try again from inside a Claude session, or pass an explicit pid via `claudectl bus role bind <name> <cwd> --pid <pid>`.
+
+5. If the user wants to verify the binding, suggest `claudectl bus role list` or `claudectl bus whoami --json`.
+
+## Why pid-binding
+
+Cwd-only bindings get ambiguous when two Claude sessions run in the same folder (e.g. worktrees, or one session in `/repo` and another in `/repo/sub`). The pid binding picks the specific session you ran `/bind` from, so directed messages land where you expect.
+
+See issues #307 (pid binding) and #310 (this slash command).

--- a/docs/AGENT_BUS.md
+++ b/docs/AGENT_BUS.md
@@ -142,17 +142,29 @@ messages(id, subject, type, sender_role, addressed_to,
          thread_id, body, priority, status,
          claimed_by, created_at, delivered_at, acked_at)
 subscriptions(role, subject_pattern)
-roles(role, cwd_selector, last_session_id, last_seen)
+roles(role, cwd_selector, last_session_id, last_seen, pid)
 ```
+
+`roles.pid` is nullable (#307 migration). When set, the resolver prefers it over cwd-inference for any caller whose ancestor pid chain contains that pid — see §5.
 
 ---
 
 ## 5. Self-registration / addressing
 
-An agent needs to know its own address. Two mechanisms, first preferred:
+An agent needs to know its own address. Resolution order, first match wins:
 
-1. **cwd/PID inference (zero agent cooperation):** the MCP call arrives from a known session; claudectl maps the calling session's cwd to a role via config selectors. Works without the agent doing anything.
-2. **Explicit `--role` at launch:** `claudectl --new --role planner ...`; the agent reads it back via `whoami()`. Required as a fallback when multiple sessions share one cwd (e.g. two agents in the same worktree), where cwd inference is ambiguous.
+1. **Explicit `--role`** (CLI) / `CLAUDECTL_BUS_ROLE` env at launch — used by `claudectl --new --role planner ...` and ambient scripting. Always wins when set.
+2. **PID-binding** (#307) — any role bound to a pid in the caller's parent process chain. The resolver walks ancestor pids (depth 8 via `getppid` + native `ps`) and picks the first match. This is the disambiguator for "two sessions in one worktree" — they have different pids even when their cwd matches.
+3. **cwd inference** — literal-prefix match against bound `cwd_selector`s. Zero agent cooperation; the fallback for cwd-only bindings.
+
+Four ways to create a binding:
+
+| How | When | Mnemonic |
+|---|---|---|
+| `claudectl bus role bind <name> <cwd>` | provisioning a worktree, CI scripts | cwd-keyed (original) |
+| `claudectl bus role bind <name> <cwd> --pid <pid>` | known pid (orchestrator path) | cwd + pid pinned |
+| TUI **`Ctrl+R`** on the selected session | dashboard operator | binds selected session's pid + cwd |
+| `/bind <name>` (Claude Code slash command) | inside a running session | `--self` walks ancestry to find Claude's pid + uses current cwd |
 
 Roles are the stable names everything else references. Session IDs are ephemeral and never used as durable addresses.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -121,6 +121,8 @@ The `claude-plugin/` directory in the claudectl repo is a Claude Code plugin tha
 - `/spend` — cost breakdown
 - `/brain on|off|auto` — toggle brain mid-session
 - `/auto-insights` — view or configure auto-generated workflow insights
+- `/inbox` — drain pending agent-bus messages addressed to this session's role
+- `/bind <role>` — attach this session to an agent-bus role (auto-detects Claude's pid)
 - **Automatic brain gate** — the plugin hook queries the brain before every Bash/Write/Edit call
 
 The plugin and `--init` hooks are complementary. Use `--init` for dashboard observability, the plugin for inline brain decisions.

--- a/src/bus/cli.rs
+++ b/src/bus/cli.rs
@@ -82,15 +82,21 @@ pub enum RoleCommand {
         /// Role name.
         name: String,
         /// cwd selector (literal path prefix or trailing `*` wildcard).
-        cwd: String,
+        /// Optional when `--self` is set; otherwise required.
+        cwd: Option<String>,
         /// Optional session_id to bind initially.
         #[arg(long)]
         session_id: Option<String>,
         /// Process ID to bind this role to (#307). When set, the resolver
         /// prefers this binding over cwd-inference for any caller whose
         /// ancestor chain contains this pid.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "self_bind")]
         pid: Option<u32>,
+        /// Bind from inside a Claude Code session: auto-detect Claude's pid
+        /// by walking the caller's ancestor chain, and capture the current
+        /// cwd. Used by the plugin `/bind` slash command (#310).
+        #[arg(long = "self", conflicts_with = "cwd")]
+        self_bind: bool,
     },
     /// List registered roles.
     List,
@@ -126,11 +132,38 @@ fn dispatch_role(cmd: &RoleCommand) -> Result<(), String> {
             cwd,
             session_id,
             pid,
+            self_bind,
         } => {
-            store::upsert_role(&conn, name, cwd, session_id.as_deref(), *pid)?;
-            match pid {
-                Some(p) => println!("bound role {name} -> {cwd} (pid={p})"),
-                None => println!("bound role {name} -> {cwd}"),
+            // Resolve (cwd, pid) up front. --self auto-detects both from the
+            // caller's process tree; the explicit form takes the positional
+            // CWD and any --pid override.
+            let (cwd_resolved, pid_resolved) = if *self_bind {
+                let detected = roles::find_claude_ancestor_pid().ok_or_else(|| {
+                    "--self: could not find a Claude Code process in the ancestor chain. \
+                     Run this from inside a Claude session, or pass --pid explicitly."
+                        .to_string()
+                })?;
+                let cwd = std::env::current_dir()
+                    .map_err(|e| format!("--self: read current dir: {e}"))?
+                    .to_string_lossy()
+                    .into_owned();
+                (cwd, Some(detected))
+            } else {
+                let cwd = cwd
+                    .clone()
+                    .ok_or_else(|| "cwd argument required (or pass --self)".to_string())?;
+                (cwd, *pid)
+            };
+            store::upsert_role(
+                &conn,
+                name,
+                &cwd_resolved,
+                session_id.as_deref(),
+                pid_resolved,
+            )?;
+            match pid_resolved {
+                Some(p) => println!("bound role {name} -> {cwd_resolved} (pid={p})"),
+                None => println!("bound role {name} -> {cwd_resolved}"),
             }
             Ok(())
         }

--- a/src/bus/roles.rs
+++ b/src/bus/roles.rs
@@ -109,6 +109,29 @@ fn ancestor_pids() -> Vec<u32> {
     out
 }
 
+/// Walk the caller's ancestor pid chain and return the first one whose
+/// `ps`-reported command line contains `claude` (case-insensitive). Used
+/// by `bus role bind --self` to attach a role to the right session
+/// without making the operator look up Claude's pid (#310).
+pub fn find_claude_ancestor_pid() -> Option<u32> {
+    ancestor_pids()
+        .into_iter()
+        .find(|pid| process_command_for(*pid).is_some_and(|c| c.to_lowercase().contains("claude")))
+}
+
+/// Fetch `ps -o command=` for a pid. Returns `None` when the pid is gone.
+fn process_command_for(pid: u32) -> Option<String> {
+    let output = std::process::Command::new("ps")
+        .args(["-o", "command=", "-p", &pid.to_string()])
+        .env_clear()
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8(output.stdout).ok()?.trim().to_string())
+}
+
 /// Look up `ppid` for `pid` via `ps`. Returns `None` when the pid is gone
 /// or `ps` fails. Native `ps` keeps us off the sysinfo crate.
 fn parent_pid_of(pid: u32) -> Option<u32> {


### PR DESCRIPTION
## Summary

In-session counterpart to PR #311's TUI Ctrl+R. From inside a running Claude Code session the operator can now type `/bind frontend` and have the role attached without leaving the terminal.

### CLI

* New `claudectl bus role bind --self <name>` walks the caller's ancestor pid chain (depth 8 via `getppid` + native `ps`), finds the first process whose `ps -o command=` contains \"claude\", and binds the role to that pid + the current cwd.
* Positional `cwd` argument is now optional; required when `--self` is absent, mutually exclusive with `--self` otherwise. `--pid` also conflicts with `--self`. Clap surfaces friendly errors for the bad combinations.
* Existing `bus role bind <name> <cwd>` and `bus role bind <name> <cwd> --pid <p>` invocations keep working unchanged.

### Library

* `bus::roles::find_claude_ancestor_pid()` exported as the shared helper. Composed on top of the existing `ancestor_pids()` from #307.

### Plugin

* `claude-plugin/commands/bind.md` — slash command that walks the operator through the bind flow: prompt for a role name if no arg, run `claudectl bus role bind --self <name>`, echo confirmation, fall-back guidance when the ancestor walk misses Claude.

### Live smoke

Tested from inside this Claude session — `--self` correctly detected pid 54050 (the claude process) and bound a test role. Cleanup ran post-test.

## Test plan

- [x] `cargo build --features bus`
- [x] `cargo test --features bus --lib bus::` — 24 passed
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Live smoke against my running Claude session: `bus role bind --self` found claude pid via ancestor walk
- [x] Clap conflict errors verified for `--self` + cwd and `--self` + `--pid`

Closes #310. Companion to #307 (PID binding) and #311 (TUI Ctrl+R).