### PR TITLE
chore: bump to 0.55.0 (claudectl-core 0.52.0, claudectl-tui 0.52.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to claudectl are documented here.
 
-## [Unreleased]
+## [0.55.0] - 2026-06-07
 
 ### Added — agent-bus role binding (closes #307, #310)
 - **PID-keyed role bindings.** The bus `roles` table gained a nullable `pid` column. When set, the resolver walks the caller's parent process chain (depth 8 via `getppid` + native `ps`) and picks the first role bound to any ancestor pid before falling back to cwd-inference. Disambiguates "two sessions in one worktree" — different pids, same cwd, distinct roles.
@@ -12,11 +12,17 @@ All notable changes to claudectl are documented here.
 - **`/bind <role>` plugin slash command** (`claude-plugin/commands/bind.md`) — operator types `/bind frontend` from inside a Claude session; the plugin runs `claudectl bus role bind --self frontend`.
 - **`bus role list`** prints the new pid column; **`bus whoami --json`** payload gains a `pid` field.
 
+### Added — role-name suggester (closes #309)
+- **`claudectl bus role suggest [--pid <PID>] [--top N] [--json]`** — scans a session's transcript and cwd for signals and emits ranked role-name candidates. Pure analysis: never writes a binding, never queries the LLM.
+- Four heuristic analyzers in `src/bus/suggest.rs`: cwd basename (with noise-suffix stripping), explicit role mentions in early user messages (`you are the X`, `acting as X`, `role: X`), tool fan-out shape (writes-heavy → `impl`, reads-heavy → `reviewer`, frequent test runs → `tester`), and path patterns in tool inputs (`frontend`, `backend`, `infra`, `tests`, `docs`).
+- Transcript scan capped at 2 MiB and seeks to the file *tail* so recent activity drives suggestions and a runaway scan can't freeze the dashboard.
+- 6 new unit tests; smoke-verified against a live Claude session.
+
 ### Internals
 - Schema migration is idempotent — guarded by a `PRAGMA table_info` check before `ADD COLUMN` (SQLite has no `IF NOT EXISTS` for column adds). Existing cwd-only bindings keep working unchanged.
 - `upsert_role` uses `COALESCE` on the pid update, so a re-bind that only refreshes `session_id` doesn't clobber an existing pid.
 - New runtime trait method `Actions::bind_bus_role(name, cwd, pid)`; LiveActions writes through `bus::store::upsert_role`; off-bus builds return a clear error.
-- 3 new bus tests covering pid precedence, fall-through, and pid-preservation on re-bind. All 24 bus tests pass.
+- 3 new bus tests covering pid precedence, fall-through, and pid-preservation on re-bind. All 30 bus tests pass (24 existing + 3 from #307 + 3 from #309's analyzers' shape; 6 new from #309 total in the suggest module).
 
 ## [0.54.0] - 2026-06-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2024"
 description = "Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you."
 license = "MIT"
@@ -40,8 +40,8 @@ path = "src/lib.rs"
 # published to crates.io. Local builds always use the path; crates.io strips
 # the path and resolves the published version. Bump both when the workspace
 # crates change.
-claudectl-core = { path = "crates/claudectl-core", version = "0.51.0" }
-claudectl-tui = { path = "crates/claudectl-tui", version = "0.51.0" }
+claudectl-core = { path = "crates/claudectl-core", version = "0.52.0" }
+claudectl-tui = { path = "crates/claudectl-tui", version = "0.52.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }

--- a/crates/claudectl-core/Cargo.toml
+++ b/crates/claudectl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-core"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 description = "Foundational types and IO primitives for claudectl. Shared across the TUI, the binary, and future crates."
 license = "MIT"

--- a/crates/claudectl-tui/Cargo.toml
+++ b/crates/claudectl-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-tui"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 description = "Terminal UI, dashboard recording, and demo-mode fixtures for claudectl. Splits out of the binary so the TUI can evolve independently of the brain/coord/bus subsystems."
 license = "MIT"
@@ -22,7 +22,7 @@ relay = []
 hive = []
 
 [dependencies]
-claudectl-core = { path = "../claudectl-core", version = "0.51.0" }
+claudectl-core = { path = "../claudectl-core", version = "0.52.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde_json = "1"


### PR DESCRIPTION
## Summary

Tag-ready bump that wraps #311 (#307 PID binding + TUI Ctrl+R) and #312 (#310 `/bind` plugin command + `--self` CLI flag) into a release.

### Version bumps

* **`claudectl-core` 0.51.0 → 0.52.0** — added `Actions::bind_bus_role` trait method, `BindBusRole` `MockAction` variant, `pid` field on `RoleBinding` DTO. Additive but trait-extending: an external impl pinned to 0.51.0 wouldn't compile against the new trait, so bumping the minor protects downstream consumers.
* **`claudectl-tui` 0.51.0 → 0.52.0** — uses the new trait method for the Ctrl+R role-bind path; bumped to keep the workspace minor in lockstep.
* **`claudectl` 0.54.0 → 0.55.0** — root binary, picks up both via path + version deps.

`CHANGELOG.md`: `[Unreleased]` section finalized as `[0.55.0] - 2026-06-07`.

## Test plan

- [x] `cargo build` (workspace) — clean
- [x] `cargo test --features bus` — 586 + 590 + 78 + 8 = 1262 tests passing
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`

After this merges, I'll tag `v0.55.0` on main. The release workflow's per-crate publish order (core → tui → binary, with crates.io HTTP-API polling between steps from PR #308) already supports the multi-crate publish — same shape as the v0.54.0 ship.