### PR TITLE
feat(init): add --purge for full uninstall + remnant cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to claudectl are documented here.
 
+## [Unreleased]
+
+### Added — `claudectl init --purge` for full uninstall
+- **`claudectl init --purge`** — hard uninstall. Does everything `--remove` does (strips Claude Code hooks + clears the onboarding marker) **plus** wipes `~/.claudectl/` entirely (bus DB, brain decisions, hive knowledge, relay identity, coord state) and removes `~/.config/claudectl/config.toml`. Idempotent — re-running after a successful purge is a no-op.
+- **`--yes`** flag pairs with `--purge` to skip the confirmation prompt for automation. Without it, you see a list of paths and confirm before anything is deleted.
+- `--remove` is unchanged: it remains the safe form that preserves user data. The CLI help text now spells out the data-preservation contract.
+- 3 new unit tests for the `remove_*_if_present` helpers (idempotency, recursive tree wipe, sibling preservation). Tested live end-to-end against a fake `$HOME`: plant fake artifacts → `--purge --yes` removes them → `init --non-interactive --skip-*` reinits cleanly.
+
 ## [0.55.0] - 2026-06-07
 
 ### Added — agent-bus role binding (closes #307, #310)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -132,8 +132,13 @@ The plugin and `--init` hooks are complementary. Use `--init` for dashboard obse
 Roll back the onboarding wizard's installed artifacts:
 
 ```bash
-claudectl init --remove                      # Removes hooks + onboarding marker
+claudectl init --remove                      # Soft uninstall: hooks + onboarding marker
+claudectl init --purge --yes                 # Hard uninstall: --remove + nuke ~/.claudectl/ + config
 ```
+
+`--remove` is the safe form — strips Claude Code hooks and the onboarding marker, but preserves user data (bus DB roles, brain decision logs, hive knowledge, relay identity, your budget config line). Use this when you want to stop the integration without losing what claudectl has learned.
+
+`--purge` is the hard reset — `--remove` plus `~/.claudectl/` (all subdirs) plus `~/.config/claudectl/config.toml`. Use this when reinstalling fresh, recovering from corrupted state, or fully uninstalling. Pair with `--yes` to skip the confirmation prompt; without it you'll see a list of paths and have to confirm.
 
 Or remove just the hooks (legacy flag, still supported):
 
@@ -142,7 +147,7 @@ claudectl --uninstall                        # Remove from user settings
 claudectl --uninstall -s project             # Remove from project settings
 ```
 
-Both surgically remove only claudectl entries. All other settings and hooks are preserved. Phases that own user state (e.g. the bus database, your budget config line) deliberately decline to delete it.
+Both `--remove` and `--uninstall` surgically remove only claudectl entries. All other settings and hooks are preserved.
 
 To uninstall the binary:
 

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -204,6 +204,121 @@ pub fn run_reset() -> io::Result<()> {
     Ok(())
 }
 
+/// Hard uninstall: `--remove` plus delete `~/.claudectl/` and
+/// `~/.config/claudectl/config.toml`. Used to start from a truly clean
+/// slate (e.g. for reinstall testing or recovering from corrupted state).
+///
+/// User confirms before any deletion unless `assume_yes` is set. Each
+/// path that's missing is silently skipped so re-running `--purge` after
+/// a successful one is a no-op rather than an error.
+pub fn run_purge(assume_yes: bool) -> io::Result<()> {
+    let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
+    let claudectl_dir = home.as_ref().map(|h| h.join(".claudectl"));
+    let config_path = crate::config::Config::global_path();
+
+    println!("This will delete:");
+    println!("  • Claude Code hooks claudectl installed (`~/.claude/settings.json` entries)");
+    if let Some(dir) = claudectl_dir.as_ref() {
+        println!(
+            "  • {} (bus DB, brain decisions, hive, relay, coord)",
+            dir.display()
+        );
+    }
+    if let Some(cfg) = config_path.as_ref() {
+        println!("  • {} (claudectl config file)", cfg.display());
+    }
+    println!();
+    println!("User-edited files outside these paths are preserved. To remove only");
+    println!("the hooks and onboarding marker (keep user data), use `init --remove`.");
+    println!();
+
+    if !assume_yes && !prompt::yes_no("Proceed with purge?", false)? {
+        println!("Aborted.");
+        return Ok(());
+    }
+
+    // First, the soft uninstall — strips hook entries and clears the marker.
+    // We run this with `?` only after the destructive deletions so a failure
+    // here (e.g. settings.json edit conflict) doesn't abort the directory
+    // wipes that follow.
+    let remove_errors = match run_remove_silent() {
+        Ok(()) => Vec::new(),
+        Err(e) => vec![format!("hook/marker removal: {e}")],
+    };
+
+    let mut errors = remove_errors;
+    if let Some(dir) = claudectl_dir.as_ref() {
+        if let Err(e) = remove_dir_if_present(dir) {
+            errors.push(format!("{}: {e}", dir.display()));
+        } else {
+            println!("  removed: {}", dir.display());
+        }
+    }
+    if let Some(cfg) = config_path.as_ref() {
+        if let Err(e) = remove_file_if_present(cfg) {
+            errors.push(format!("{}: {e}", cfg.display()));
+        } else {
+            println!("  removed: {}", cfg.display());
+        }
+        // Also try the parent ~/.config/claudectl/ dir — only succeeds if
+        // it's now empty (we don't recursively delete the parent because
+        // it could contain user-authored files we don't know about).
+        if let Some(parent) = cfg.parent() {
+            let _ = std::fs::remove_dir(parent);
+        }
+    }
+
+    if errors.is_empty() {
+        println!();
+        println!("Purge complete. `claudectl init` will start fresh.");
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "purge errors: {}",
+            errors.join("; ")
+        )))
+    }
+}
+
+/// `run_remove` without printing the per-phase progress lines — used by
+/// `run_purge` so its UI doesn't have duplicated "removed: X" rows.
+fn run_remove_silent() -> io::Result<()> {
+    let registry = phases::registry();
+    let mut errors = Vec::new();
+    for phase in &registry {
+        if let Err(e) = phase.remove() {
+            errors.push(format!("{}: {e}", phase.id()));
+        }
+    }
+    marker::clear(&marker::default_path())?;
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "remove errors: {}",
+            errors.join("; ")
+        )))
+    }
+}
+
+/// `remove_dir_all` that treats a missing directory as success — same
+/// semantics as `rm -rf` without erroring on non-existence.
+fn remove_dir_if_present(path: &std::path::Path) -> io::Result<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+fn remove_file_if_present(path: &std::path::Path) -> io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
 // ---------------- internal helpers ------------------------------------------
 
 fn print_banner(registry: &[Box<dyn Phase>]) {
@@ -297,6 +412,49 @@ mod drift_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn remove_helpers_treat_missing_paths_as_success() {
+        // `remove_dir_if_present` / `remove_file_if_present` are the
+        // building blocks of --purge. Idempotency matters: re-running
+        // --purge after a successful one must not error.
+        let tmp = tempfile::tempdir().unwrap();
+        let missing_dir = tmp.path().join("nope");
+        let missing_file = tmp.path().join("nope.txt");
+        assert!(remove_dir_if_present(&missing_dir).is_ok());
+        assert!(remove_file_if_present(&missing_file).is_ok());
+    }
+
+    #[test]
+    fn remove_dir_if_present_wipes_existing_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("claudectl");
+        std::fs::create_dir_all(target.join("brain")).unwrap();
+        std::fs::create_dir_all(target.join("bus")).unwrap();
+        std::fs::write(target.join("brain").join("d.jsonl"), "{}").unwrap();
+        std::fs::write(target.join("bus").join("bus.db"), "x").unwrap();
+
+        assert!(target.exists());
+        remove_dir_if_present(&target).unwrap();
+        assert!(
+            !target.exists(),
+            "expected tree to be gone, but {} still exists",
+            target.display()
+        );
+    }
+
+    #[test]
+    fn remove_file_if_present_removes_just_that_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        let sibling = tmp.path().join("other.toml");
+        std::fs::write(&cfg, "budget = 25").unwrap();
+        std::fs::write(&sibling, "keep me").unwrap();
+
+        remove_file_if_present(&cfg).unwrap();
+        assert!(!cfg.exists(), "config.toml should be gone");
+        assert!(sibling.exists(), "sibling untouched");
+    }
 
     #[test]
     fn non_interactive_records_marker_for_every_phase() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,8 +93,20 @@ pub(crate) enum Command {
         #[arg(long, conflicts_with_all = ["check", "remove", "non_interactive"])]
         reset: bool,
         /// Uninstall every claudectl-managed artifact (hooks, marker).
-        #[arg(long, conflicts_with_all = ["check", "reset", "non_interactive"])]
+        /// Preserves user data: bus DB roles, brain decision logs, hive
+        /// knowledge, relay identity, config file. Pair with `--purge` to
+        /// wipe everything.
+        #[arg(long, conflicts_with_all = ["check", "reset", "non_interactive", "purge"])]
         remove: bool,
+        /// Hard uninstall: `--remove` PLUS delete `~/.claudectl/` entirely
+        /// (bus DB, brain decisions, hive knowledge, relay identity, coord
+        /// state) and `~/.config/claudectl/config.toml`. Use to start over
+        /// from a clean slate. Requires `--yes` to proceed without prompt.
+        #[arg(long, conflicts_with_all = ["check", "reset", "non_interactive", "remove"])]
+        purge: bool,
+        /// Skip the confirmation prompt for `--purge`.
+        #[arg(long)]
+        yes: bool,
         /// Run every phase without prompting. Combine with the per-phase
         /// flags below (`--budget`, `--brain-url`, `--bus-role`, etc.).
         #[arg(long)]
@@ -709,6 +721,8 @@ fn run_main(cli: Cli) -> io::Result<()> {
                 check,
                 reset,
                 remove,
+                purge,
+                yes,
                 non_interactive,
                 budget,
                 skip_budget,
@@ -729,6 +743,9 @@ fn run_main(cli: Cli) -> io::Result<()> {
                 }
                 if *remove {
                     return init::run_remove();
+                }
+                if *purge {
+                    return init::run_purge(*yes);
                 }
                 if *non_interactive {
                     let install_plugin_opt = if *skip_plugin {


### PR DESCRIPTION
## Summary

Per the user ask: \"we should be able to reinit, clean/uninstall prior installs and these should clean up remnant artifacts.\" `claudectl init --remove` currently keeps user data so re-running init reconnects to existing bus roles, brain decision history, hive knowledge, etc. That's the right default — but there was no escape hatch when you wanted a true fresh start.

## What's new

`claudectl init --purge`:
* Does everything `--remove` does (strips Claude Code hooks, clears the onboarding marker).
* **Plus** wipes `~/.claudectl/` entirely — bus DB, brain decisions, hive knowledge, relay identity, coord state.
* **Plus** removes `~/.config/claudectl/config.toml` (the parent dir too if it ends up empty).
* Interactive confirmation by default; `--yes` skips for automation.
* Idempotent: missing paths are treated as success.

`--remove` is unchanged — still the safe form that preserves user data. The CLI help text now spells out the data-preservation contract so the difference between the two commands is obvious.

## Implementation

* New `run_purge(assume_yes)` in `src/init/mod.rs` plus tiny `remove_dir_if_present` / `remove_file_if_present` helpers.
* `run_remove_silent` is a quiet variant `run_purge` chains to so the combined output doesn't print duplicate \"removed: X\" rows.
* 3 new tests cover helpers' idempotency, recursive tree wipe, and sibling preservation.

## Live smoke

Planted fake artifacts under a `mktemp -d` `$HOME`, ran `init --purge --yes`, confirmed everything was deleted, then ran `init --non-interactive --skip-*` and it reinitialized cleanly with no errors.

## Test plan

- [x] `cargo build --features bus`
- [x] `cargo test --features bus` — 595 + 599 + 78 + 8 = 1280+ passing
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Live end-to-end against fake `$HOME`

## Docs

* `docs/quickstart.md` — \"Uninstall\" section now documents both `--remove` (soft) and `--purge` (hard) with guidance on which to pick.
* `CHANGELOG.md` — `[Unreleased]` section captures this feature for the next tag.

Companion to #257 (init wizard), #307 + #310 (bus role binding), and the v0.55.0 release.