### PR TITLE
chore: bump to 0.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to claudectl are documented here.
 
-## [Unreleased]
+## [0.56.0] - 2026-06-07
 
 ### Added — `claudectl init --purge` for full uninstall
 - **`claudectl init --purge`** — hard uninstall. Does everything `--remove` does (strips Claude Code hooks + clears the onboarding marker) **plus** wipes `~/.claudectl/` entirely (bus DB, brain decisions, hive knowledge, relay identity, coord state) and removes `~/.config/claudectl/config.toml`. Idempotent — re-running after a successful purge is a no-op.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2024"
 description = "Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you."
 license = "MIT"


### PR DESCRIPTION
## Summary

Wraps PR #315 (`init --purge` for full uninstall) into a tagged release.

* **`claudectl` 0.55.0 → 0.56.0** — binary-only bump.
* **`claudectl-core` 0.52.0 → 0.52.0** (unchanged) — no trait surface or DTO changes.
* **`claudectl-tui` 0.52.0 → 0.52.0** (unchanged) — same.

`CHANGELOG.md` `[Unreleased]` section finalized as `[0.56.0] - 2026-06-07`.

## Test plan

- [x] `cargo build` — clean

After merge, I'll tag `v0.56.0`. The release workflow's per-crate publish path is idempotent (existing `claudectl-core 0.52.0` and `claudectl-tui 0.52.0` skips will short-circuit immediately via the crates.io HTTP-API checks); only `claudectl 0.56.0` is a new publish.