### PR TITLE
docs: refresh init/purge guidance across reference, configuration, troubleshooting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,7 +97,16 @@ We maintain a curated set at [mercurialsolo/claudectl-hooks](https://github.com/
 
 ## Claude Code Integration
 
-claudectl can install hooks directly into Claude Code's settings so sessions automatically notify claudectl on tool use:
+Easiest path is the **onboarding wizard** — it covers hooks alongside budget, brain, bus, and skills in one go:
+
+```bash
+claudectl init                          # Interactive five-phase wizard
+claudectl init --non-interactive        # Same flow, no prompts (for CI / dotfiles)
+```
+
+The Plugin phase writes hooks into Claude Code's settings (`~/.claude/settings.json` by default). See `claudectl init --help` for `--budget`, `--brain-url`, `--bus-role`, and the `--skip-*` overrides.
+
+For just the hook install (no other phases), the **legacy flags** still work:
 
 ```bash
 claudectl --init                    # Write hooks to ~/.claude/settings.json (user scope)
@@ -109,8 +118,10 @@ This adds `PreToolUse`, `PostToolUse`, and `Stop` hooks that call `claudectl --j
 To remove:
 
 ```bash
-claudectl --uninstall               # Remove claudectl hooks from user settings
-claudectl --uninstall -s project    # Remove from project-local settings
+claudectl init --remove             # Soft uninstall: hooks + onboarding marker (keeps user data)
+claudectl init --purge --yes        # Hard uninstall: --remove + wipe ~/.claudectl/ + config file
+claudectl --uninstall               # Legacy hook-only removal from user settings
+claudectl --uninstall -s project    # Legacy hook-only removal from project-local settings
 ```
 
 ### How it works

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -237,6 +237,23 @@ Share knowledge, distill learnings. Requires relay for transport.
 
 ### Setup
 
+Two layers. The **`init` subcommand** is the canonical onboarding wizard (five phases — budget, brain, hooks, bus, skills). The **legacy `--init`/`--uninstall` flags** install/remove only the Claude Code hook entries and remain supported as the hook-only escape hatch.
+
+#### `claudectl init` — onboarding wizard (preferred)
+
+| Form | Description |
+|------|-------------|
+| `claudectl init` | Interactive five-phase wizard |
+| `claudectl init --non-interactive [--budget N] [--brain-url URL] [--bus-role NAME] [--skip-*]` | Same flow, no prompts. For CI / dotfiles |
+| `claudectl init --check` | Drift report — compares the recorded marker against current state, exits non-zero on drift |
+| `claudectl init --reset` | Clear the onboarding marker so the next run prompts fresh. Does not touch installed artifacts |
+| `claudectl init --remove` | **Soft uninstall.** Strips Claude Code hooks + clears the marker. Preserves user data (bus DB roles, brain decision logs, hive knowledge, relay identity, config file) |
+| `claudectl init --purge [--yes]` | **Hard uninstall.** `--remove` PLUS wipe `~/.claudectl/` (bus DB, brain decisions, hive, relay, coord) and `~/.config/claudectl/config.toml`. Confirms by default; `--yes` skips the prompt. Idempotent |
+
+The wizard records what ran where at `~/.claudectl/onboarding.json` so `--check` can detect drift in later runs.
+
+#### `--init` / `--uninstall` — hook-only (legacy)
+
 | Flag | Description |
 |------|-------------|
 | `--init` | Wire up Claude Code hooks in settings and exit |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## No sessions found
 
-- Run `claudectl --init` if you haven't already -- this wires up the Claude Code hooks
+- Run `claudectl init` (or `claudectl --init` for hook-only install) if you haven't already — this wires up the Claude Code hooks
 - Ensure Claude Code is running (`claude` in another terminal)
 - Check that `~/.claude/sessions/` contains `.json` files
 - Run `claudectl --log /tmp/claudectl.log` and check the log
@@ -43,7 +43,7 @@ Increase the poll interval: `claudectl --interval 3000` (default is 2000ms).
 ## FAQ
 
 **Does claudectl modify Claude Code or its files?**
-Only `--init` and `--uninstall` write to `.claude/settings.json` (to add/remove hooks). Everything else is read-only. The only other writes are to claudectl's own history and log files.
+Only `claudectl init` (the Plugin phase), the legacy `--init`/`--uninstall` flags, and `init --remove`/`init --purge` write to `.claude/settings.json` (to add/remove hooks). Everything else is read-only. The only other writes are to claudectl's own state under `~/.claudectl/` (bus DB, brain decisions, hive knowledge, etc. — wipe with `claudectl init --purge`).
 
 **Does it need an API key?**
 No. It reads local files on disk. No network access required (unless you configure webhooks).


### PR DESCRIPTION
## Summary

User asked \"ensure you also update the docs\" alongside the 0.56.0 release (PR #316). PR #316 already merged + tagged with just the version bump, so this is the fast follow-up that brings the user docs in line with what shipped.

The three remaining doc surfaces still pointed at the legacy `--init` / `--uninstall` flags as if those were the only path, even though:
* `claudectl init` (the wizard from #257) has been the canonical onboarding flow since 0.53.0
* `init --remove` (soft uninstall) shipped in 0.53.0
* `init --purge` (hard uninstall) shipped in 0.56.0 / #315

## Changes

* **`docs/reference.md`** — new \"Setup\" subsection breaks the legacy flag table off from a new `claudectl init` subcommand table that documents the wizard (`init`, `--non-interactive`, `--check`, `--reset`) and both uninstall paths (`--remove` soft, `--purge` hard). The legacy table stays as the hook-only escape hatch.
* **`docs/configuration.md`** — \"Claude Code Integration\" section now leads with `claudectl init` and surfaces both uninstall paths alongside the legacy `--uninstall`.
* **`docs/troubleshooting.md`** — \"No sessions found\" hint mentions `claudectl init` first with the legacy flag in parens; FAQ row on \"Does claudectl modify Claude Code or its files?\" expanded to cover wizard-managed paths and the `~/.claudectl/` state directory.

## Test plan

- [x] No code changes; pure doc refresh
- [x] `cargo fmt --check` (no impact)
- [x] Spot-checked every flag/path mentioned against the on-disk implementation

Companion to PR #315 (`init --purge`) and PR #316 (v0.56.0 release).