### PR TITLE
feat(dx): first-run banner + brain ollama install hint + MSRV (closes #322, #324, #328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to claudectl are documented here.
 
 ## [Unreleased]
 
+### Added — DX activation quick wins (closes #322, #324, #328)
+- **First-run banner (#322)** — running `claudectl` for the first time (no `~/.claudectl/onboarding.json` and no `claudectl` entries in `~/.claude/settings.json`) now prints a one-screen banner above the TUI explaining how to onboard. Skipped in `--demo`, in non-TUI output modes (`--json`, `--list`, `--watch`, `--summary`, `--headless`), and when `CLAUDECTL_SKIP_FIRST_RUN=1`.
+- **Brain phase ollama install hint (#324)** — when the Brain phase of `claudectl init` can't reach a local-LLM endpoint, it now prints concrete install steps (`brew install ollama && ollama serve &` + `ollama pull gemma4:e4b`) instead of silently recording `not_installed`. Non-interactive mode shows the hint too.
+- **MSRV declared in `Cargo.toml`** (#328) — all three crates set `rust-version = "1.88"`. Users on older toolchains get a clean MSRV error from cargo before the resolver tries to compile transitive deps (which would otherwise produce opaque `darling@0.23.0 requires rustc 1.88.0` errors).
+
+Part of the DX overhaul epic #320.
+
 ### Changed — bus role slash command renamed `/bind` → `/role`
 - The plugin slash command shipped in 0.55.0 as `/bind <name>` is renamed to `/role <name>` (e.g. `/role frontend`, `/role tester`). Reads better — it matches the CLI noun (`claudectl bus role …`) and reflects what the operator is actually doing (setting a role, not binding to one).
 - `claude-plugin/commands/bind.md` is removed in favour of `claude-plugin/commands/role.md`. The command instructions and `--self` ancestor-walk behaviour are unchanged; only the user-facing name changed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 name = "claudectl"
 version = "0.56.0"
 edition = "2024"
+# MSRV — bumped to 1.88 in #328 so cargo-install on older toolchains
+# emits a clean "rustc too old" error instead of opaque transitive-dep
+# errors from `darling` and `instability`.
+rust-version = "1.88"
 description = "Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns from you."
 license = "MIT"
 repository = "https://github.com/mercurialsolo/claudectl"

--- a/crates/claudectl-core/Cargo.toml
+++ b/crates/claudectl-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "claudectl-core"
 version = "0.52.0"
 edition = "2024"
+rust-version = "1.88"
 description = "Foundational types and IO primitives for claudectl. Shared across the TUI, the binary, and future crates."
 license = "MIT"
 repository = "https://github.com/mercurialsolo/claudectl"

--- a/crates/claudectl-tui/Cargo.toml
+++ b/crates/claudectl-tui/Cargo.toml
@@ -2,6 +2,7 @@
 name = "claudectl-tui"
 version = "0.52.0"
 edition = "2024"
+rust-version = "1.88"
 description = "Terminal UI, dashboard recording, and demo-mode fixtures for claudectl. Splits out of the binary so the TUI can evolve independently of the brain/coord/bus subsystems."
 license = "MIT"
 repository = "https://github.com/mercurialsolo/claudectl"

--- a/src/bus/suggest.rs
+++ b/src/bus/suggest.rs
@@ -396,7 +396,7 @@ mod tests {
             "You are the planner. Coordinate the other agents.",
         )];
         let mut mentions = from_explicit_mentions(&messages);
-        mentions.sort_by(|a, b| b.1.cmp(&a.1));
+        mentions.sort_by_key(|m| std::cmp::Reverse(m.1));
         assert_eq!(mentions[0].0, "planner");
         // Score should be the configured 10 for an explicit mention; the
         // cwd basename only scores 3, so a merge would rank planner first.

--- a/src/init/phases.rs
+++ b/src/init/phases.rs
@@ -211,7 +211,10 @@ impl Phase for BrainPhase {
                 return Ok(detected);
             }
         } else {
-            println!("  No local-LLM endpoint detected on the common ports.");
+            // #324 — print a concrete install hint when no endpoint is
+            // reachable, instead of silently moving on. Most users hitting
+            // this won't know ollama exists.
+            print_ollama_install_hint();
         }
 
         if !prompt::yes_no("Configure a custom endpoint?", false)? {
@@ -233,7 +236,15 @@ impl Phase for BrainPhase {
                 details: format!("endpoint at {url}"),
             });
         }
-        Ok(state::detect_brain())
+        let status = state::detect_brain();
+        // #324 — even non-interactive mode should surface the install hint
+        // (printed once, doesn't change the recorded status). CI / dotfile
+        // users skim the output; they shouldn't have to guess why brain
+        // recorded `not_installed`.
+        if !matches!(status, PhaseStatus::Installed { .. }) {
+            print_ollama_install_hint();
+        }
+        Ok(status)
     }
 
     fn remove(&self) -> io::Result<()> {
@@ -241,6 +252,17 @@ impl Phase for BrainPhase {
         // handled by the orchestrator.
         Ok(())
     }
+}
+
+/// Three-line install hint shown when the Brain phase can't reach any
+/// local-LLM endpoint. Mirrors `docs/quickstart.md` "Optional: add the
+/// local LLM brain" so the wizard and the docs say the same thing.
+fn print_ollama_install_hint() {
+    println!("  No local-LLM endpoint detected on the common ports.");
+    println!("  To enable the brain, install ollama and a small model:");
+    println!("    brew install ollama && ollama serve &");
+    println!("    ollama pull gemma4:e4b");
+    println!("  Then re-run `claudectl init` to wire it up.");
 }
 
 // ===================== Plugin (Claude Code hooks) =======================

--- a/src/main.rs
+++ b/src/main.rs
@@ -538,6 +538,46 @@ fn maybe_print_star_prompt(is_demo: bool) {
     }
 }
 
+/// First-run detection for the activation nudge (#322). Returns true when
+/// the user has neither onboarded (`~/.claudectl/onboarding.json` absent)
+/// nor installed Claude Code hooks (`~/.claude/settings.json` lacks any
+/// `claudectl` entries). When either is present, we assume the operator
+/// knows what they're doing and stay quiet.
+fn is_first_run() -> bool {
+    let Some(home) = std::env::var_os("HOME").map(std::path::PathBuf::from) else {
+        return false;
+    };
+    let marker = home.join(".claudectl").join("onboarding.json");
+    let settings = home.join(".claude").join("settings.json");
+    let onboarded = marker.exists();
+    let hooked = std::fs::read_to_string(&settings)
+        .map(|s| s.contains("claudectl"))
+        .unwrap_or(false);
+    !onboarded && !hooked
+}
+
+/// One-screen banner shown above the empty TUI when the user hasn't
+/// onboarded yet (#322). Goes to stderr so it doesn't pollute stdout
+/// piping; appears before the alt-screen swap.
+fn print_first_run_banner() {
+    eprintln!();
+    eprintln!("┌─────────────────────────────────────────────────────────────────┐");
+    eprintln!("│  Welcome to claudectl.                                          │");
+    eprintln!("│                                                                 │");
+    eprintln!("│  You haven't onboarded yet — the dashboard will be empty until  │");
+    eprintln!("│  Claude Code hooks are installed. Quit and run one of:          │");
+    eprintln!("│                                                                 │");
+    eprintln!("│    claudectl init        Interactive 5-phase wizard (preferred) │");
+    eprintln!("│    claudectl --demo      Explore with fake sessions             │");
+    eprintln!("│                                                                 │");
+    eprintln!("│  Silence this with CLAUDECTL_SKIP_FIRST_RUN=1.                  │");
+    eprintln!("└─────────────────────────────────────────────────────────────────┘");
+    eprintln!();
+    // Tiny delay so the user actually reads the banner before the TUI
+    // grabs the alt-screen and hides it.
+    std::thread::sleep(std::time::Duration::from_millis(800));
+}
+
 fn run_main(cli: Cli) -> io::Result<()> {
     // Initialize diagnostic logger if --log is set
     if let Some(ref log_path) = cli.log {
@@ -912,6 +952,15 @@ fn run_main(cli: Cli) -> io::Result<()> {
     let theme_mode = theme::ThemeMode::detect(cli.theme.as_deref());
     let app_theme = theme::Theme::from_mode(theme_mode);
 
+    // #322 — first-run nudge. If the user has neither onboarded nor
+    // installed hooks, drop a hint above the TUI before launching so
+    // they understand why the dashboard is going to be empty. Skipped in
+    // --demo (the wizard's whole point is moot there) and when the
+    // operator opts out via env.
+    if !cli.demo && std::env::var("CLAUDECTL_SKIP_FIRST_RUN").is_err() && is_first_run() {
+        print_first_run_banner();
+    }
+
     if let Some(ref record_path) = cli.record {
         // Recording mode: use TeeWriter to capture exact ANSI output
         let term_size = crossterm::terminal::size().unwrap_or((120, 40));
@@ -1198,5 +1247,75 @@ fn run_tui<W: io::Write>(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod first_run_tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+
+    // is_first_run reads HOME and the filesystem; serialize so concurrent
+    // tests don't clobber each other when they set HOME.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn set_home(p: &std::path::Path) {
+        // Cargo's test harness shares a process; reset HOME after each test
+        // by calling this with the original value (we just leak temp dirs
+        // since they're under /tmp anyway).
+        // SAFETY: tests are serialized via ENV_LOCK above; nothing else
+        // here races on env reads inside the lock window.
+        unsafe { std::env::set_var("HOME", p) };
+    }
+
+    #[test]
+    fn first_run_when_neither_marker_nor_hooks_present() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        set_home(tmp.path());
+        assert!(is_first_run(), "fresh home should be first-run");
+    }
+
+    #[test]
+    fn not_first_run_when_onboarding_marker_present() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join(".claudectl")).unwrap();
+        fs::write(tmp.path().join(".claudectl").join("onboarding.json"), "{}").unwrap();
+        set_home(tmp.path());
+        assert!(
+            !is_first_run(),
+            "onboarding marker present should suppress first-run"
+        );
+    }
+
+    #[test]
+    fn not_first_run_when_settings_mentions_claudectl() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+        fs::write(
+            tmp.path().join(".claude").join("settings.json"),
+            r#"{"hooks":{"PostToolUse":[{"hooks":[{"command":"claudectl --json"}]}]}}"#,
+        )
+        .unwrap();
+        set_home(tmp.path());
+        assert!(
+            !is_first_run(),
+            "hook install should suppress first-run even without onboarding marker"
+        );
+    }
+
+    #[test]
+    fn not_first_run_when_home_missing() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized via ENV_LOCK; nothing else reads HOME inside
+        // this critical section.
+        unsafe { std::env::remove_var("HOME") };
+        assert!(
+            !is_first_run(),
+            "no HOME should be treated as not-first-run (no nudge possible)"
+        );
     }
 }


### PR DESCRIPTION
First wave of DX overhaul (epic #320). Three independently-useful changes that together cut activation friction for new users.

## #322 — First-run banner

Running `claudectl` with no onboarding and no hooks installed launched the TUI showing zero sessions — silent, with no hint that you needed to run `init`. New users assumed the tool was broken and bounced.

* New `is_first_run()` helper: true iff `~/.claudectl/onboarding.json` is absent AND `~/.claude/settings.json` doesn't contain `claudectl` hook entries.
* When true (and we're about to launch the TUI, not a non-TUI output mode), print a 12-line banner above the TUI explaining the next step.
* Skipped in `--demo`, non-TUI output modes (`--json`, `--list`, `--watch`, `--summary`, `--headless`), and when `CLAUDECTL_SKIP_FIRST_RUN=1`.
* 4 unit tests covering: fresh state, post-onboard, hooks-installed-no-marker, missing-HOME edge cases.

## #324 — Brain phase ollama install hint

The init wizard's Brain phase probed `localhost:11434` and silently recorded `not_installed` when no endpoint was reachable. Users new to local LLMs don't know what ollama is.

* When detection returns anything but `Installed`, the wizard now prints a 4-line install hint with `brew install ollama && ollama serve` + `ollama pull gemma4:e4b`.
* Fires in both interactive and non-interactive paths.

## #328 — Cargo MSRV declared

End users on rustc 1.86 / 1.87 hit opaque transitive-dep errors. `rust-version = "1.88"` now declared in all three crates so cargo emits a clean MSRV error before the resolver runs.

## Drive-by

`src/bus/suggest.rs` had a `sort_by` that newer clippy flags — converted to `sort_by_key(|m| Reverse(m.1))`.

## Test plan

- [x] `cargo build --features bus`
- [x] `cargo test --features bus` — 1284+ tests passing (4 new for first-run gating)
- [x] `cargo clippy --features bus --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Smoke tested first-run banner gating via `HOME=$tmp` runs

Closes #322, #324, #328. Next in the epic: #325 (embed plugin in binary — biggest UX unlock), #326 (`claudectl doctor`).