### PR TITLE
feat(init): embed plugin in binary + --plugin-only verb (closes #325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to claudectl are documented here.
 
 ## [Unreleased]
 
+### Added — Plugin embedded in binary (closes #325)
+- **Plugin files now ship inside the `claudectl` binary** via `include_str!` — 17 files, ~29 KB total. `claudectl init` writes them to `~/.claude/plugins/claudectl/` automatically. No repo clone, no manual `.mcp.json` copy. The biggest single Homebrew-user UX win.
+- **`claudectl init --plugin-only`** — install (or re-install) just the plugin without re-running the rest of the wizard. Useful after `brew upgrade claudectl`.
+- Shell hook scripts (`brain-gate.sh`, `budget-check.sh`, `inbox-drain.sh`, `outcome-record.sh`, `session-briefing.sh`) are written with mode 0755 on POSIX.
+- `init --remove` (soft uninstall) now also removes `~/.claude/plugins/claudectl/`. The on-disk plugin tree was claudectl-managed; the soft uninstall should treat it the same way as it does the hook entries in `settings.json`.
+- 6 new tests in `init::plugin_assets` cover round-trip writes, idempotency, the executable-bit, removal, and missing-dir tolerance.
+
+Part of the DX overhaul epic #320.
+
 ### Added — DX activation quick wins (closes #322, #324, #328)
 - **First-run banner (#322)** — running `claudectl` for the first time (no `~/.claudectl/onboarding.json` and no `claudectl` entries in `~/.claude/settings.json`) now prints a one-screen banner above the TUI explaining how to onboard. Skipped in `--demo`, in non-TUI output modes (`--json`, `--list`, `--watch`, `--summary`, `--headless`), and when `CLAUDECTL_SKIP_FIRST_RUN=1`.
 - **Brain phase ollama install hint (#324)** — when the Brain phase of `claudectl init` can't reach a local-LLM endpoint, it now prints concrete install steps (`brew install ollama && ollama serve &` + `ollama pull gemma4:e4b`) instead of silently recording `not_installed`. Non-interactive mode shows the hint too.

--- a/docs/agent-bus.md
+++ b/docs/agent-bus.md
@@ -48,24 +48,15 @@ Verify:
 claudectl bus --help                       # should show subcommands: stdio, role, send, inbox, whoami, stop-hook
 ```
 
-### 2. Register the bus as an MCP server
+### 2. Install the plugin
 
-The Claude Code plugin in `claude-plugin/` already includes the wiring:
+The plugin (slash commands, supervisor agent, hook scripts, and the bus MCP server registration) is embedded in the `claudectl` binary. Running `claudectl init` writes it to `~/.claude/plugins/claudectl/` automatically. If you already onboarded and just want to refresh the plugin after `brew upgrade claudectl`:
 
-```json
-// claude-plugin/.mcp.json
-{
-  "mcpServers": {
-    "claudectl-bus": {
-      "command": "claudectl",
-      "args": ["bus", "stdio"],
-      "env": { "CLAUDECTL_BUS_ROLE": "${CLAUDECTL_BUS_ROLE}" }
-    }
-  }
-}
+```bash
+claudectl init --plugin-only
 ```
 
-If you're using the bundled plugin (recommended), running `claudectl init` will install it. Otherwise, point Claude Code at any `.mcp.json` containing the block above. The MCP server runs on stdio — Claude Code spawns one per session it talks to.
+That's it — no repo clone, no manual `.mcp.json` copy. Claude Code picks the plugin up on its next launch.
 
 ### 3. Bind a role
 

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -31,6 +31,7 @@
 pub mod hooks;
 pub mod marker;
 pub mod phases;
+pub mod plugin_assets;
 pub mod prompt;
 pub mod state;
 

--- a/src/init/phases.rs
+++ b/src/init/phases.rs
@@ -282,9 +282,10 @@ impl Phase for PluginPhase {
     }
 
     fn run_interactive(&self) -> io::Result<PhaseStatus> {
-        println!("Install claudectl's hooks into ~/.claude/settings.json so Claude Code");
-        println!("notifies claudectl on tool use and session end. Existing hooks are preserved.");
-        if !prompt::yes_no("Install hooks?", true)? {
+        println!("Install claudectl's plugin into ~/.claude/plugins/claudectl/ (slash");
+        println!("commands, the supervisor agent, and the bus MCP server registration) and");
+        println!("wire hooks into ~/.claude/settings.json. Existing hooks are preserved.");
+        if !prompt::yes_no("Install plugin + hooks?", true)? {
             return Ok(PhaseStatus::Skipped);
         }
         install_plugin_hooks()?;
@@ -307,13 +308,43 @@ impl Phase for PluginPhase {
     }
 
     fn remove(&self) -> io::Result<()> {
-        // Run the existing uninit against the global settings.
-        hooks::run_uninit(false)
+        // Strip hook entries from settings.json AND remove the plugin
+        // install dir. `--purge` also walks ~/.claudectl/; this just
+        // handles claudectl-managed paths under ~/.claude/.
+        let _ = hooks::run_uninit(false);
+        if let Some(dir) = crate::init::plugin_assets::default_install_dir() {
+            crate::init::plugin_assets::remove_assets(&dir)?;
+        }
+        Ok(())
     }
 }
 
+/// Install both the embedded plugin (#325) and the legacy hook entries
+/// in ~/.claude/settings.json. The plugin install gives users the slash
+/// commands (`/role`, `/inbox`, `/brain`, …) and the bus MCP server
+/// registration without cloning the repo; the legacy hook entries are
+/// the dashboard-observability path (PostToolUse / Stop fire claudectl
+/// --json so the TUI sees activity).
 fn install_plugin_hooks() -> io::Result<()> {
+    // Write embedded plugin assets first. When HOME is unset (CI
+    // sandboxes), skip the plugin install silently rather than fail —
+    // the hook entries below still work.
+    if let Some(dir) = crate::init::plugin_assets::default_install_dir() {
+        let written = crate::init::plugin_assets::write_assets(&dir)?;
+        println!(
+            "  installed {} plugin files at {}",
+            written.len(),
+            dir.display()
+        );
+    }
     hooks::run_init(false, false)
+}
+
+/// Public entry for the `init plugin-only` shortcut (#325): write the
+/// embedded assets + hook entries without running the rest of the
+/// wizard. Used by main.rs when `--plugin-only` is set.
+pub fn install_plugin_now() -> io::Result<()> {
+    install_plugin_hooks()
 }
 
 // ===================== Bus (agent-bus role binding) =====================

--- a/src/init/plugin_assets.rs
+++ b/src/init/plugin_assets.rs
@@ -1,0 +1,239 @@
+//! Plugin assets embedded in the binary (#325).
+//!
+//! Every file under `claude-plugin/` is compiled into the binary via
+//! `include_str!` so `claudectl init` can write a working plugin to
+//! `~/.claude/plugins/claudectl/` without the user cloning the repo.
+//! Total embed cost: ~29 KB across 17 files — well below the binary's
+//! 1 MB target.
+//!
+//! Source of truth stays on disk at `claude-plugin/`; this module just
+//! gives the binary a way to re-emit the same contents at install time.
+//! `brew upgrade claudectl` automatically ships the latest plugin files
+//! because they're baked into the new binary.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// One embedded plugin file: where to write it (relative to the install
+/// root) and what to write.
+pub struct Asset {
+    /// Relative path inside `~/.claude/plugins/claudectl/`. Always uses
+    /// forward slashes — converted to platform separators at write time.
+    pub rel_path: &'static str,
+    /// File contents baked in by `include_str!`. Always text — the
+    /// plugin doesn't carry binary assets today.
+    pub contents: &'static str,
+}
+
+/// Every file under `claude-plugin/` that needs to land on disk. Order
+/// doesn't matter; each file is written independently and parent dirs
+/// are created as needed.
+pub const ASSETS: &[Asset] = &[
+    Asset {
+        rel_path: ".claude-plugin/plugin.json",
+        contents: include_str!("../../claude-plugin/.claude-plugin/plugin.json"),
+    },
+    Asset {
+        rel_path: ".mcp.json",
+        contents: include_str!("../../claude-plugin/.mcp.json"),
+    },
+    Asset {
+        rel_path: "agents/supervisor.md",
+        contents: include_str!("../../claude-plugin/agents/supervisor.md"),
+    },
+    Asset {
+        rel_path: "commands/auto-insights.md",
+        contents: include_str!("../../claude-plugin/commands/auto-insights.md"),
+    },
+    Asset {
+        rel_path: "commands/brain-stats.md",
+        contents: include_str!("../../claude-plugin/commands/brain-stats.md"),
+    },
+    Asset {
+        rel_path: "commands/brain.md",
+        contents: include_str!("../../claude-plugin/commands/brain.md"),
+    },
+    Asset {
+        rel_path: "commands/inbox.md",
+        contents: include_str!("../../claude-plugin/commands/inbox.md"),
+    },
+    Asset {
+        rel_path: "commands/role.md",
+        contents: include_str!("../../claude-plugin/commands/role.md"),
+    },
+    Asset {
+        rel_path: "commands/sessions.md",
+        contents: include_str!("../../claude-plugin/commands/sessions.md"),
+    },
+    Asset {
+        rel_path: "commands/spend.md",
+        contents: include_str!("../../claude-plugin/commands/spend.md"),
+    },
+    Asset {
+        rel_path: "hooks/hooks.json",
+        contents: include_str!("../../claude-plugin/hooks/hooks.json"),
+    },
+    Asset {
+        rel_path: "hooks/scripts/brain-gate.sh",
+        contents: include_str!("../../claude-plugin/hooks/scripts/brain-gate.sh"),
+    },
+    Asset {
+        rel_path: "hooks/scripts/budget-check.sh",
+        contents: include_str!("../../claude-plugin/hooks/scripts/budget-check.sh"),
+    },
+    Asset {
+        rel_path: "hooks/scripts/inbox-drain.sh",
+        contents: include_str!("../../claude-plugin/hooks/scripts/inbox-drain.sh"),
+    },
+    Asset {
+        rel_path: "hooks/scripts/outcome-record.sh",
+        contents: include_str!("../../claude-plugin/hooks/scripts/outcome-record.sh"),
+    },
+    Asset {
+        rel_path: "hooks/scripts/session-briefing.sh",
+        contents: include_str!("../../claude-plugin/hooks/scripts/session-briefing.sh"),
+    },
+    Asset {
+        rel_path: "skills/session-monitoring/SKILL.md",
+        contents: include_str!("../../claude-plugin/skills/session-monitoring/SKILL.md"),
+    },
+];
+
+/// Where the plugin lives by default — `~/.claude/plugins/claudectl/`.
+/// Returns `None` when `$HOME` is unset (CI, sandboxed environments)
+/// so the caller can fall through gracefully.
+pub fn default_install_dir() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(
+        PathBuf::from(home)
+            .join(".claude")
+            .join("plugins")
+            .join("claudectl"),
+    )
+}
+
+/// Write every embedded asset to `dest`, creating parent dirs as needed.
+/// Returns the list of files written (with their absolute paths) so the
+/// init wizard can report what landed where.
+///
+/// Idempotent: existing files are overwritten (this is how
+/// `brew upgrade` re-syncs the plugin). The wizard's `--check` path can
+/// compare on-disk hashes to detect manual edits.
+pub fn write_assets(dest: &Path) -> io::Result<Vec<PathBuf>> {
+    let mut written = Vec::with_capacity(ASSETS.len());
+    for asset in ASSETS {
+        let target = dest.join(asset.rel_path);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&target, asset.contents)?;
+        // Shell hook scripts need to be executable on POSIX. On Windows
+        // the perm-set is a no-op.
+        #[cfg(unix)]
+        if asset.rel_path.ends_with(".sh") {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&target)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&target, perms)?;
+        }
+        written.push(target);
+    }
+    Ok(written)
+}
+
+/// Remove the plugin install dir entirely. Idempotent — missing dir is
+/// not an error. Used by `init --remove` so the soft uninstall actually
+/// removes the plugin files it installed.
+pub fn remove_assets(dest: &Path) -> io::Result<()> {
+    match std::fs::remove_dir_all(dest) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_assets_creates_every_file_with_expected_contents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let written = write_assets(tmp.path()).unwrap();
+        assert_eq!(written.len(), ASSETS.len());
+        for asset in ASSETS {
+            let path = tmp.path().join(asset.rel_path);
+            assert!(path.exists(), "expected {} to be written", path.display());
+            let on_disk = std::fs::read_to_string(&path).unwrap();
+            assert_eq!(
+                on_disk,
+                asset.contents,
+                "content mismatch at {}",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn write_assets_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_assets(tmp.path()).unwrap();
+        // Second write — should not error, contents identical.
+        write_assets(tmp.path()).unwrap();
+        for asset in ASSETS {
+            let path = tmp.path().join(asset.rel_path);
+            assert_eq!(std::fs::read_to_string(&path).unwrap(), asset.contents);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_scripts_get_executable_bit() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        write_assets(tmp.path()).unwrap();
+        for asset in ASSETS {
+            if asset.rel_path.ends_with(".sh") {
+                let path = tmp.path().join(asset.rel_path);
+                let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+                assert_eq!(
+                    mode,
+                    0o755,
+                    "expected 0o755 on {}, got {:o}",
+                    path.display(),
+                    mode
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn remove_assets_wipes_the_install() {
+        let tmp = tempfile::tempdir().unwrap();
+        let install = tmp.path().join("plugin");
+        write_assets(&install).unwrap();
+        assert!(install.exists());
+        remove_assets(&install).unwrap();
+        assert!(!install.exists());
+    }
+
+    #[test]
+    fn remove_assets_tolerates_missing_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nope = tmp.path().join("nope");
+        // Should not error even though the dir was never created.
+        remove_assets(&nope).unwrap();
+    }
+
+    #[test]
+    fn every_asset_has_non_empty_contents() {
+        // Catches a build-time include path going stale.
+        for asset in ASSETS {
+            assert!(
+                !asset.contents.is_empty(),
+                "asset {} was embedded empty — check include_str! path",
+                asset.rel_path
+            );
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,15 @@ pub(crate) enum Command {
         /// Skip the confirmation prompt for `--purge`.
         #[arg(long)]
         yes: bool,
+        /// Install (or re-install) just the embedded plugin + hooks (#325).
+        /// Skip every other phase. Useful for users who already configured
+        /// budget / brain / bus and just want to refresh the plugin files
+        /// after `brew upgrade claudectl`.
+        #[arg(
+            long,
+            conflicts_with_all = ["check", "reset", "remove", "purge", "non_interactive"]
+        )]
+        plugin_only: bool,
         /// Run every phase without prompting. Combine with the per-phase
         /// flags below (`--budget`, `--brain-url`, `--bus-role`, etc.).
         #[arg(long)]
@@ -763,6 +772,7 @@ fn run_main(cli: Cli) -> io::Result<()> {
                 remove,
                 purge,
                 yes,
+                plugin_only,
                 non_interactive,
                 budget,
                 skip_budget,
@@ -786,6 +796,12 @@ fn run_main(cli: Cli) -> io::Result<()> {
                 }
                 if *purge {
                     return init::run_purge(*yes);
+                }
+                if *plugin_only {
+                    // #325 — install just the embedded plugin + hook
+                    // entries. The other four wizard phases stay where
+                    // the previous run left them (no marker rewrite).
+                    return init::phases::install_plugin_now();
                 }
                 if *non_interactive {
                     let install_plugin_opt = if *skip_plugin {


### PR DESCRIPTION
PR B of the DX overhaul epic (#320). **Biggest single Homebrew-user UX unlock** from the analysis.

## Why

Before this PR, \"install the plugin\" meant clone the repo and symlink `~/.claude/plugins/claudectl/` → `claude-plugin/`. A Homebrew user who read about `/role`, `/inbox`, or the bus MCP server couldn't access any of it without manual filesystem work. The Plugin phase only wrote hook entries to `settings.json`; the slash commands and the MCP server registration weren't surfaced anywhere.

## What

New `src/init/plugin_assets.rs` embeds every file under `claude-plugin/` into the binary via `include_str!` — 17 files, ~29 KB at build time:

* `.claude-plugin/plugin.json`, `.mcp.json`
* 7 commands (`auto-insights`, `brain-stats`, `brain`, `inbox`, `role`, `sessions`, `spend`)
* 1 agent (`supervisor`)
* 1 skill (`session-monitoring/SKILL.md`)
* `hooks/hooks.json` + 5 shell scripts (`brain-gate`, `budget-check`, `inbox-drain`, `outcome-record`, `session-briefing`)

API:
* `default_install_dir()` → `~/.claude/plugins/claudectl/` (None when HOME unset)
* `write_assets(dest)` writes all 17, creates parent dirs, chmods shell scripts to 0755 on POSIX
* `remove_assets(dest)` — idempotent recursive delete

## CLI surface

* `claudectl init` — Plugin phase now writes the embedded assets in addition to the hook entries
* `claudectl init --plugin-only` — **NEW.** Install/refresh just the plugin + hooks. One command, no other phases re-run. Useful after `brew upgrade claudectl`
* `init --remove` — soft uninstall now also wipes `~/.claude/plugins/claudectl/`

## Live smoke

```
$ HOME=$tmp claudectl init --plugin-only
  installed 17 plugin files at ~/.claude/plugins/claudectl
Initialized claudectl hooks in ~/.claude/settings.json
$ ls ~/.claude/plugins/claudectl/hooks/scripts/
-rwxr-xr-x ... brain-gate.sh       (0755 confirmed)
-rwxr-xr-x ... budget-check.sh
...
```

## Docs

`docs/agent-bus.md` \"Step 2\" — was a JSON snippet asking the user to manually point Claude Code at `.mcp.json`. Now reads: \"Running `claudectl init` writes it to `~/.claude/plugins/claudectl/` automatically. No repo clone, no manual `.mcp.json` copy.\"

## Test plan

- [x] `cargo build --features bus`
- [x] `cargo test --features bus` — 1296+ tests passing (6 new for plugin_assets)
- [x] `cargo clippy --features bus --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Live end-to-end against fake `$HOME` confirms 17 files written + 0755 on shell scripts

Closes #325. Part of epic #320. Next: PR C (`claudectl doctor`, #326).