### PR TITLE
feat(release): full-featured Homebrew bottle (closes #321)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,16 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        # #321 — release tarballs (and therefore Homebrew bottles) include
+        # every optional feature so `claudectl bus`, `coord`, `relay`, and
+        # `hive` all work out of the box. Cargo-install users still get
+        # the default (`hive`) build; they can opt in with
+        # `cargo install claudectl --features bus,coord,relay,hive`.
+        # The async runtime exception is already documented in CLAUDE.md.
+        run: |
+          cargo build --release \
+            --target ${{ matrix.target }} \
+            --features "bus,coord,relay,hive"
 
       - name: Package
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to claudectl are documented here.
 
 ## [Unreleased]
 
+### Changed — Homebrew bottle now ships with all features (closes #321)
+- **`brew install mercurialsolo/tap/claudectl`** now produces a binary with `bus`, `coord`, `relay`, and `hive` all compiled in. `claudectl bus`, `claudectl coord`, `claudectl relay`, `claudectl hive` work end-to-end with no source rebuild. Binary grows from ~1.7 MB → ~6.3 MB; the async runtime exception for the `bus` feature is already documented in CLAUDE.md.
+- **`cargo install claudectl`** still defaults to the minimal build (`hive` only). Users who want the full feature set use `cargo install claudectl --features bus,coord,relay,hive`.
+- README and quickstart docs updated to surface both choices and call out the size trade-off.
+
+Part of the DX overhaul epic #320.
+
 ### Added — Plugin embedded in binary (closes #325)
 - **Plugin files now ship inside the `claudectl` binary** via `include_str!` — 17 files, ~29 KB total. `claudectl init` writes them to `~/.claude/plugins/claudectl/` automatically. No repo clone, no manual `.mcp.json` copy. The biggest single Homebrew-user UX win.
 - **`claudectl init --plugin-only`** — install (or re-install) just the plugin without re-running the rest of the wizard. Useful after `brew upgrade claudectl`.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,12 @@ Run `claudectl --brain-stats impact` to see your numbers:
 ## Install
 
 ```bash
-brew install mercurialsolo/tap/claudectl     # Homebrew (macOS / Linux)
-cargo install claudectl                       # Cargo (any platform)
+brew install mercurialsolo/tap/claudectl     # Homebrew (macOS / Linux) — ships with bus/coord/relay/hive
+cargo install claudectl                       # Cargo (any platform) — default features (hive only)
+cargo install claudectl --features bus,coord,relay,hive    # Cargo with all features
 ```
+
+Homebrew ships the full-feature binary so `claudectl bus`, `coord`, `relay`, and `hive` work out of the box (~6 MB). `cargo install` defaults to the minimal build (`hive` only, ~3.5 MB) — opt in to the rest with `--features` as shown.
 
 <details>
 <summary>Other methods</summary>

--- a/docs/agent-bus.md
+++ b/docs/agent-bus.md
@@ -30,16 +30,12 @@ If you only ever run one Claude session at a time, the bus is overhead. The win 
 
 Three steps: build with the feature, register the MCP server with Claude Code, bind roles.
 
-### 1. Build with the `bus` feature
-
-The bus stack (rmcp + Tokio runtime) is opt-in to keep the default binary small. Pick the install path you want:
+### 1. Install with the `bus` feature
 
 ```bash
-cargo install claudectl --features bus
+brew install mercurialsolo/tap/claudectl   # Homebrew — bus is included (since 0.57.0)
 # or
-brew install mercurialsolo/tap/claudectl  # Homebrew bottle ships with default features —
-                                          # bus support requires building from source until
-                                          # the bottled build flips on
+cargo install claudectl --features bus,coord,relay,hive    # Cargo — opt in to all features
 ```
 
 Verify:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,9 +5,10 @@ Get claudectl running in under two minutes.
 ## 1. Install
 
 ```bash
-brew install mercurialsolo/tap/claudectl     # Homebrew (macOS / Linux)
+brew install mercurialsolo/tap/claudectl     # Homebrew — ships with bus/coord/relay/hive built in
 # or
-cargo install claudectl                       # Cargo (any platform)
+cargo install claudectl                                          # Cargo — default features only (hive)
+cargo install claudectl --features bus,coord,relay,hive          # Cargo with all features
 ```
 
 Verify it works:


### PR DESCRIPTION
PR C of the DX overhaul (#320). **Pure release-pipeline change.**

## What

The release workflow's `cargo build --release` now adds `--features bus,coord,relay,hive`. The tarballs Homebrew downloads contain a binary where `claudectl bus stdio`, `coord`, `relay`, and `hive` all work end-to-end.

## Before / after

| Path | Before | After |
|---|---|---|
| `brew install claudectl && claudectl bus stdio` | `error: unrecognized subcommand 'bus'` | works |
| `brew install claudectl && claudectl coord events` | same error | works |
| `brew install claudectl && claudectl relay invite` | same error | works |
| Binary size | ~1.7 MB | ~6.3 MB (locally verified) |
| `cargo install claudectl` | default features (hive) | unchanged |

## cargo install story

Unchanged. Defaults stay minimal so a TUI-only user doesn't pull in the async runtime. README and quickstart now document both:

```bash
cargo install claudectl                                          # default — hive only
cargo install claudectl --features bus,coord,relay,hive          # full feature set
```

## Files

* `.github/workflows/release.yml` — Build step adds `--features "bus,coord,relay,hive"`.
* `README.md` — Install section shows both paths with size trade-off.
* `docs/quickstart.md` — same two-line note.
* `docs/agent-bus.md` "Step 1" — \"build with --features bus\" → \"brew install — bus is included\".
* `CHANGELOG.md` — new `[Unreleased]` entry.

## Test plan

- [x] Local full-feature release build: succeeded in 1m41s, 6.28 MB binary
- [x] All four subcommands' `--help` outputs verified locally
- [x] `cargo test --features bus` — full suite still green
- [x] `cargo fmt --check`

Closes #321. Part of epic #320. Next: #326 (`claudectl doctor`).