### PR TITLE
chore: bump to 0.57.0 + sync docs for the DX overhaul release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to claudectl are documented here.
 
-## [Unreleased]
+## [0.57.0] - 2026-06-07
+
+The **DX overhaul release**. Closes #322, #324, #328, #325, #321, #326 — six issues from epic #320. A fresh Homebrew install now activates in three commands:
+
+```bash
+brew install mercurialsolo/tap/claudectl   # full feature set, bus included
+claudectl init                              # writes plugin + hooks (slash commands, MCP, agent)
+claudectl doctor                            # ✓ confirms everything is wired up
+```
+
+No repo clone. No manual MCP server registration. No "but how do I get the bus subcommand?"
 
 ### Added — `claudectl doctor` for unified install + runtime health (closes #326)
 - **`claudectl doctor`** — top-down checklist answering "is everything wired up?" in one command. Replaces what was scattered across `--doctor` (terminal compat only), `init --check` (onboarding marker only), and ad-hoc probes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2024"
 # MSRV — bumped to 1.88 in #328 so cargo-install on older toolchains
 # emits a clean "rustc too old" error instead of opaque transitive-dep
@@ -44,8 +44,8 @@ path = "src/lib.rs"
 # published to crates.io. Local builds always use the path; crates.io strips
 # the path and resolves the published version. Bump both when the workspace
 # crates change.
-claudectl-core = { path = "crates/claudectl-core", version = "0.52.0" }
-claudectl-tui = { path = "crates/claudectl-tui", version = "0.52.0" }
+claudectl-core = { path = "crates/claudectl-core", version = "0.52.1" }
+claudectl-tui = { path = "crates/claudectl-tui", version = "0.52.1" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ git clone https://github.com/mercurialsolo/claudectl.git && cd claudectl && carg
 ## Get started
 
 ```bash
-claudectl                     # Live dashboard — see all sessions at a glance
 claudectl init                # Onboarding wizard (budget, brain, hooks, bus, skills)
+claudectl doctor              # Verify install + runtime health (✓ checklist)
+claudectl                     # Live dashboard — see all sessions at a glance
 claudectl --brain             # Enable local LLM auto-pilot
 ```
 
-The `init` wizard walks five phases — weekly budget, local-LLM brain detection, Claude Code hook install, agent-bus role, and curated skill suggestions. Run `claudectl init --check` later to see drift, or `claudectl init --non-interactive` to script it.
+The `init` wizard walks five phases — weekly budget, local-LLM brain detection, Claude Code hook install, agent-bus role, and curated skill suggestions. Plugin files (slash commands, supervisor agent, bus MCP server registration) are embedded in the binary and written to `~/.claude/plugins/claudectl/` automatically — no repo clone. Run `claudectl doctor` to verify every piece is wired up, or `claudectl init --check` for the drift report against the onboarding marker.
 
 ## Why claudectl
 

--- a/crates/claudectl-core/Cargo.toml
+++ b/crates/claudectl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-core"
-version = "0.52.0"
+version = "0.52.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Foundational types and IO primitives for claudectl. Shared across the TUI, the binary, and future crates."

--- a/crates/claudectl-tui/Cargo.toml
+++ b/crates/claudectl-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-tui"
-version = "0.52.0"
+version = "0.52.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Terminal UI, dashboard recording, and demo-mode fixtures for claudectl. Splits out of the binary so the TUI can evolve independently of the brain/coord/bus subsystems."
@@ -23,7 +23,7 @@ relay = []
 hive = []
 
 [dependencies]
-claudectl-core = { path = "../claudectl-core", version = "0.52.0" }
+claudectl-core = { path = "../claudectl-core", version = "0.52.1" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde_json = "1"

--- a/docs/index.md
+++ b/docs/index.md
@@ -176,7 +176,7 @@ Multi-signal inference from CPU usage, JSONL events, and timestamps:
 | WezTerm | Yes | Yes | - | - |
 | GNOME Terminal | Yes | - | - | - |
 
-Run `claudectl --doctor` to verify support in your terminal. See [Terminal Support](terminal-support.md) for setup notes.
+Run `claudectl doctor` to verify your install + terminal support in one command. See [Terminal Support](terminal-support.md) for setup notes.
 
 ## How It Works
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -45,7 +45,15 @@ Your existing Claude Code settings are preserved; the hook install only adds cla
 
 The hooks call `claudectl --json 2>/dev/null || true` — if claudectl isn't running, Claude Code continues normally.
 
-## 3. Start the dashboard
+## 3. Verify the install
+
+```bash
+claudectl doctor
+```
+
+This runs a top-down checklist: PATH, hooks, plugin files, brain endpoint, bus feature, bus DB, session discovery, terminal integration. Green means you're ready. If anything fails, the doctor names the exact command to fix it.
+
+## 4. Start the dashboard
 
 Open one or more Claude Code sessions in separate terminals, then:
 
@@ -53,9 +61,9 @@ Open one or more Claude Code sessions in separate terminals, then:
 claudectl
 ```
 
-You'll see every session in a live table with status, cost, context usage, burn rate, and more.
+You'll see every session in a live table with status, cost, context usage, burn rate, and more. (Forgot step 2 + 3? On first run you'll see a banner pointing you back to `claudectl init`.)
 
-## 4. Try demo mode (no Claude Code needed)
+## 5. Try demo mode (no Claude Code needed)
 
 ```bash
 claudectl --demo

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -232,8 +232,30 @@ Share knowledge, distill learnings. Requires relay for transport.
 | `--config` | Show resolved configuration and exit |
 | `--config-template` | Print annotated default config template to stdout |
 | `--hooks` | List configured event hooks and exit |
-| `--doctor` | Diagnose terminal integration and setup |
+| `--doctor` | **Deprecated.** Use `claudectl doctor` instead. Legacy report (terminal compat only) follows after the deprecation note |
 | `--log <path>` | Write diagnostic logs to a file |
+
+### Doctor — install + runtime health check
+
+`claudectl doctor` runs eight checks top-down and reports Pass / Advisory / Fail / Skipped with a one-line message and a fix hint for anything broken.
+
+| Check | What it verifies |
+|---|---|
+| binary on PATH | `which claudectl` matches the running binary |
+| Claude Code hooks | `~/.claude/settings.json` contains claudectl entries |
+| plugin files | `~/.claude/plugins/claudectl/` is populated |
+| brain endpoint | `localhost:11434` (ollama) is reachable |
+| bus feature | compiled into the binary |
+| bus DB | `~/.claudectl/bus/bus.db` opens and is writable |
+| session discovery | at least one Claude session detected |
+| terminal integration | tab switching / input automation supported |
+
+```bash
+claudectl doctor               # human-readable checklist
+claudectl doctor --json        # machine-readable for scripting
+```
+
+Exit code 0 when every check is Pass / Advisory / Skipped; non-zero on any Fail. Failure messages include the exact command to run (e.g. `claudectl init --plugin-only` when plugin files are missing).
 
 ### Setup
 

--- a/docs/terminal-support.md
+++ b/docs/terminal-support.md
@@ -1,6 +1,6 @@
 # Terminal Support
 
-Run `claudectl --doctor` to check your terminal's capabilities.
+Run `claudectl doctor` to check your terminal's capabilities along with the rest of the install (PATH, hooks, plugin files, brain endpoint, bus, session discovery). The legacy `claudectl --doctor` flag still works for the terminal-only report.
 
 ## Compatibility Matrix
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,7 @@
 
 ## Tab switching doesn't work
 
-Run `claudectl --doctor` first to see the detected terminal, missing prerequisites, and supported actions.
+Run `claudectl doctor` first — it checks everything (PATH, hooks, plugin install, brain endpoint, bus, session discovery, terminal) and tells you the exact command to fix anything broken. For terminal-specific diagnostics, the legacy `claudectl --doctor` flag still works.
 
 - **GNOME Terminal**: Launch support is available; use tmux or Kitty if you need remote switching or input automation
 - **Windows Terminal on WSL**: Launch support is available when `cmd.exe /c wt.exe` works; use tmux or Kitty inside WSL for switching and input automation
@@ -31,7 +31,7 @@ Increase the poll interval: `claudectl --interval 3000` (default is 2000ms).
 - Check the brain endpoint is running: `curl http://localhost:11434/api/tags`
 - Check brain gate mode: `claudectl --mode status` (if `off`, the brain is disabled)
 - Check the brain model is loaded: `ollama list`
-- Run `claudectl --doctor` for a full diagnostic
+- Run `claudectl doctor` for the full install + runtime checklist
 
 ## Plugin hook not firing
 


### PR DESCRIPTION
Wraps the four DX overhaul PRs (#329 quick wins, #330 plugin embed, #331 full bottle, #332 doctor) into a tagged release.

## Version bumps

* **`claudectl` 0.56.0 → 0.57.0** — binary, new features + new subcommand.
* **`claudectl-core` 0.52.0 → 0.52.1** — patch bump so the published crate carries the `rust-version = \"1.88\"` MSRV declaration from #329.
* **`claudectl-tui` 0.52.0 → 0.52.1** — same reason.

## Doc sync (per user ask)

Five surfaces had stale `--doctor` flag references that pre-date the new `claudectl doctor` subcommand from #326. All updated:

| File | Change |
|---|---|
| `docs/reference.md` | New \"Doctor — install + runtime health check\" subsection with the 8-check table; flag entry marked deprecated |
| `docs/terminal-support.md` | `--doctor` → `doctor`, with a note that the legacy flag still works for the terminal-only report |
| `docs/troubleshooting.md` | Both `--doctor` mentions point at the new subcommand |
| `docs/index.md` | Landing-page mention updated |
| `docs/quickstart.md` | New \"3. Verify the install\" step between onboarding and dashboard launch |
| `README.md` | `claudectl doctor` added to the Get Started snippet; paragraph mentions plugin files are now embedded |

The three remaining `--doctor` references are deliberate (\"legacy flag still works\" notes).

CHANGELOG `[Unreleased]` becomes `[0.57.0] - 2026-06-07` with a paragraph framing the DX overhaul: \"A fresh Homebrew install now activates in three commands.\"

## Test plan

- [x] `cargo build` (full workspace)
- [x] `cargo test --features bus` — 1312+ tests passing
- [x] `cargo fmt --check`
- [x] Doc sweep confirms no remaining stale `--doctor` references

After merge: tag `v0.57.0` → release workflow runs (publish core 0.52.1, tui 0.52.1, claudectl 0.57.0 + GH release with full-feature tarballs from #321 + homebrew bump).