### PR TITLE
fix(release): disable FORTIFY_SOURCE on musl builds for rusqlite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,15 @@ jobs:
             echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
             echo "CC_aarch64_unknown_linux_musl=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
           fi
+          # When `coord` / `bus` features are on, rusqlite's bundled
+          # SQLite is compiled with FORTIFY_SOURCE wrappers
+          # (__memcpy_chk, __memset_chk, open64, stat64) that live in
+          # glibc but not musl. Disable FORTIFY across the board for the
+          # musl builds so libsqlite3_sys links cleanly. This is the
+          # same workaround other Rust-on-musl projects use (alacritty,
+          # zellij, etc.).
+          echo "CFLAGS_${{ matrix.target }}=-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0" >> $GITHUB_ENV
+          echo "CFLAGS=-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0" >> $GITHUB_ENV
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
The v0.57.0 release tag triggered the workflow but `aarch64-unknown-linux-musl` failed at link time:

```
sqlite3.c:(.text.posixOpen+0x0): undefined reference to `open64'
sqlite3.c:(.text.fts5TriTokenize+0x334): undefined reference to `__memmove_chk'
sqlite3.c:(.text.fts5MergePrefixLists+0x6c): undefined reference to `__memset_chk'
```

## Root cause

PR #321 turned on `coord` + `bus` for the bottle. Those pull in `rusqlite` with bundled SQLite. The `cc` crate compiles `sqlite3.c` with the gcc default FORTIFY_SOURCE wrappers (`__memcpy_chk`, `__memset_chk`, `open64`, `stat64`) that live in glibc — but the musl target's libc doesn't carry them.

The default-feature bottle never linked against rusqlite so this was silent until #321. macOS Apple-darwin and gnu Linux are unaffected.

## Fix

Export `CFLAGS=-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0` in the workflow's musl-tools install step. Same workaround alacritty / zellij / other Rust-on-musl projects use.

No code or Cargo.toml change.

## Re-tag plan

The v0.57.0 publish steps were all skipped on the failed run (build matrix barrier) — nothing was uploaded to crates.io, no GH release was created, no homebrew bump. After this merges I'll:

1. Delete `v0.57.0` locally + remote
2. Re-tag `v0.57.0` at the new HEAD
3. Re-run release — `claudectl-core 0.52.1`, `claudectl-tui 0.52.1`, `claudectl 0.57.0` publish + GH release + homebrew

Same playbook as v0.54.0 when we hit the cargo-search index issue.