### PR TITLE
fix(release): use cross for aarch64-musl, native for x86_64-musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,39 +49,46 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install musl tools
-        if: contains(matrix.target, 'musl')
+      - name: Install musl tools (x86_64 only)
+        # x86_64 musl can build natively on Ubuntu via `musl-tools`. The
+        # aarch64 musl build uses `cross` instead — see below — because
+        # the gnu cross-linker pulls glibc headers that the rusqlite
+        # bundled-sqlite source then references (open64/stat64/etc.),
+        # which musl libc doesn't provide.
+        if: matrix.target == 'x86_64-unknown-linux-musl'
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
-          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
-            sudo apt-get install -y gcc-aarch64-linux-gnu
-            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-            echo "CC_aarch64_unknown_linux_musl=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-          fi
-          # When `coord` / `bus` features are on, rusqlite's bundled
-          # SQLite is compiled with FORTIFY_SOURCE wrappers
-          # (__memcpy_chk, __memset_chk, open64, stat64) that live in
-          # glibc but not musl. Disable FORTIFY across the board for the
-          # musl builds so libsqlite3_sys links cleanly. This is the
-          # same workaround other Rust-on-musl projects use (alacritty,
-          # zellij, etc.).
-          echo "CFLAGS_${{ matrix.target }}=-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0" >> $GITHUB_ENV
-          echo "CFLAGS=-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0" >> $GITHUB_ENV
+
+      - name: Install cross (aarch64 musl only)
+        # `cross` runs the build inside a docker image that has a real
+        # musl toolchain. This is the canonical Rust-on-musl
+        # cross-compile path; the alternative of using gcc-aarch64-linux-gnu
+        # is fragile because it brings glibc headers (FORTIFY_SOURCE
+        # wrappers, _FILE_OFFSET_BITS=64 LFS symbols) the musl libc lacks.
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        run: cargo install cross --locked --git https://github.com/cross-rs/cross --branch main
 
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
 
-      - name: Build
-        # #321 — release tarballs (and therefore Homebrew bottles) include
-        # every optional feature so `claudectl bus`, `coord`, `relay`, and
-        # `hive` all work out of the box. Cargo-install users still get
-        # the default (`hive`) build; they can opt in with
-        # `cargo install claudectl --features bus,coord,relay,hive`.
-        # The async runtime exception is already documented in CLAUDE.md.
+      - name: Build (native)
+        # #321 — release tarballs (and therefore Homebrew bottles)
+        # include every optional feature so `claudectl bus`, `coord`,
+        # `relay`, and `hive` all work out of the box. Cargo-install
+        # users still get the default (`hive`) build; they can opt in
+        # with `cargo install claudectl --features bus,coord,relay,hive`.
+        if: matrix.target != 'aarch64-unknown-linux-musl'
         run: |
           cargo build --release \
+            --target ${{ matrix.target }} \
+            --features "bus,coord,relay,hive"
+
+      - name: Build (cross for aarch64 musl)
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        run: |
+          cross build --release \
             --target ${{ matrix.target }} \
             --features "bus,coord,relay,hive"
 


### PR DESCRIPTION
PR #334's FORTIFY_SOURCE workaround unblocked one class of failure but the v0.57.0 re-tag still failed at link time:

```
sqlite3.c:(.text.posixOpen+0x0): undefined reference to `open64'
                                  undefined reference to `stat64'
                                  undefined reference to `fcntl64'
```

## Root cause

The workflow used `aarch64-linux-gnu-gcc` (gnu cross compiler) as the linker for the musl target. That brings glibc headers, which under `_FILE_OFFSET_BITS=64` transparently rename `open()` → `open64()`, `stat()` → `stat64()`, etc. — symbols that exist in glibc but not in musl libc.

You can't fix this with CFLAGS alone. The fix is to use a real musl toolchain.

## What this PR does

Splits the matrix's Build step in two:

| Target | Build path |
|---|---|
| `x86_64-unknown-linux-musl` | native via `musl-tools` (apt ships `musl-gcc` for x86_64) |
| `aarch64-unknown-linux-musl` | **`cross build`** — runs inside a docker image with a real `aarch64-linux-musl-gcc` |

Trade-off: aarch64-musl builds are ~1–2 min slower (docker pull + container startup), but they actually finish. Same approach alacritty, zellij, ripgrep all use.

## Re-tag plan

The v0.57.0 publish steps remained skipped on the previous run — nothing uploaded to crates.io, no GH release, no homebrew bump. After this merges I'll delete + re-push `v0.57.0` at the new HEAD.

## Test plan

- [x] `cargo fmt --check` (workflow yaml only)
- [x] Builds verified locally for the targets we control (macOS arm64)
- [ ] aarch64-musl proven on the next release run

Closes the v0.57.0 release blocker.