### PR TITLE
docs: sync binary-size claims + module list after 0.57.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ claudectl is the missing control plane for Claude Code. If you're building tools
 | Local LLM brain that learns | Yes — adapts per-tool, per-project | No |
 | Cross-session orchestration | Yes — routing, conflict detection, spawn | No |
 | Cognitive rot detection | Yes — composite decay scoring | No |
-| Binary size | <1 MB (7 deps, no async runtime) | Typically 10-50 MB |
+| Binary size | ~3.5 MB default, ~6.3 MB with all features compiled in | Typically 10-50 MB |
 | Startup time | <50 ms | Varies |
 | Data sovereignty | 100% local, zero telemetry | Often requires cloud |
 
@@ -36,7 +36,8 @@ claudectl is the missing control plane for Claude Code. If you're building tools
 
 ```bash
 cargo build                  # Debug build
-cargo build --release        # Release build (optimized, <1MB binary)
+cargo build --release        # Release build, default features (hive only) — ~3.5 MB
+cargo build --release --features "bus,coord,relay,hive"   # Full feature set — ~6.3 MB; what the Homebrew bottle ships
 cargo test                   # Run all tests
 cargo clippy -- -D warnings  # Lint (warnings are errors in CI)
 cargo fmt --check            # Check formatting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@ Orchestrate a swarm of Claude Code agents with a local-LLM brain that learns fro
 
 ```bash
 cargo build                  # Debug build
-cargo build --release        # Release build (optimized, <1MB binary)
+cargo build --release        # Release build, default features (hive only) — ~3.5 MB
+cargo build --release --features "bus,coord,relay,hive"   # Full feature set — ~6.3 MB; what the Homebrew bottle ships
 cargo test                   # Run all tests
 cargo clippy -- -D warnings  # Lint (warnings are errors in CI)
 cargo fmt --check            # Check formatting
@@ -74,12 +75,13 @@ Feature flags: `coord`, `relay`, `hive` mirror the binary's same-named features 
 
 ### Binary modules — `claudectl` (`src/`)
 
-- `main.rs` — CLI entry point, mode dispatch (TUI, watch, JSON, list, history, stats, orchestrator, clean, doctor, brain-eval, brain-query, mode, insights, init).
+- `main.rs` — CLI entry point, mode dispatch (TUI, watch, JSON, list, history, stats, orchestrator, clean, brain-eval, brain-query, mode, insights, init, doctor).
 - `brain_screen.rs` — Full-screen Brain Review surface (scorecard + interactive review). Stays in the binary because it depends on `brain::metrics` and `brain::risk`; `main.rs` calls `brain_screen::render_brain_screen` for the brain panel. Every other ui render goes through `claudectl_tui::ui::*`.
+- `doctor.rs` — `claudectl doctor` (#326). Unified install + runtime health checklist (PATH, hooks, plugin files, brain endpoint, bus feature, bus DB, session discovery, terminal integration). Returns `Check` rows with Pass/Advisory/Fail/Skipped + fix hints; `--json` form for scripting. Replaces the scattered `--doctor` flag and `init --check` paths.
 - `config.rs` — Layered TOML config: CLI flags > `.claudectl.toml` > `~/.config/claudectl/config.toml` > defaults. Re-exports `BrainConfig`, `IdleConfig`, `HealthThresholds` from `claudectl-core`.
 - `orchestrator.rs` — Multi-session task runner with dependency ordering.
 - `commands.rs` — CLI command dispatch shared between modes.
-- `init/` — `claudectl init` opinionated onboarding wizard (5 phases: budget, brain, plugin, bus, skills); see `docs/AGENT_BUS.md` §8 and issue #257.
+- `init/` — `claudectl init` opinionated onboarding wizard (5 phases: budget, brain, plugin, bus, skills); see `docs/AGENT_BUS.md` §8 and issue #257. `init/plugin_assets.rs` (#325) embeds every `claude-plugin/` file via `include_str!` so the Plugin phase writes a working install to `~/.claude/plugins/claudectl/` without a repo clone.
 - `runtime/` — `Live*` adapters that implement the `claudectl-core::runtime` traits against the real subsystems (sessions, brain, coord SQLite, bus SQLite, orchestrator, hive). See `runtime/{sessions,brain,brain_driver,brain_review,coord,bus,actions,orchestrator,hive}.rs`.
 
 **Claude Code Plugin** (`claude-plugin/`): Integrates the brain directly into Claude Code sessions.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Downloads](https://img.shields.io/crates/d/claudectl)](https://crates.io/crates/claudectl)
 [![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)]()
 
-<sub>~1 MB binary. Sub-50ms startup. Zero config required.</sub>
+<sub>~6 MB binary (full features, Homebrew bottle). Sub-50ms startup. Zero config required.</sub>
 
 [Website](https://mercurialsolo.github.io/claudectl/) | [Demo](https://asciinema.org/a/AJP33vbmHGFVW6zL) | [Blog: Why a local brain?](blog/local-brain-architecture.md) | [Releases](https://github.com/mercurialsolo/claudectl/releases)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Know which agent is blocked, burning budget, waiting for approval, or stalled - 
 </p>
 
 <div class="proof-strip">
-  <span>~1 MB binary</span>
+  <span>~6 MB binary (full features)</span>
   <span>Sub-50ms startup</span>
   <span>Zero config</span>
   <span>macOS &amp; Linux</span>

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -436,6 +436,6 @@ claudectl was the first tool to combine local LLM supervision with multi-session
 | File conflict detection across sessions | Yes | No | No |
 | Per-tool adaptive confidence thresholds | Yes | No | No |
 | Task decomposition into parallel DAGs | Yes | No | No |
-| Binary size | <1 MB | Varies | N/A |
+| Binary size | ~3.5 MB default / ~6 MB with all features | Varies | N/A |
 | Startup time | <50 ms | Varies | N/A |
 | Data stays on your machine | 100% | Usually | No |

--- a/docs/relay-and-hive.md
+++ b/docs/relay-and-hive.md
@@ -26,7 +26,7 @@ The coordination layer (see `coordination-layer.md`) solves multi-agent coordina
 - bootstrapping a new machine's brain with the team's accumulated wisdom
 - global cost tracking across distributed sessions
 
-These problems require a network layer. But claudectl's constraints (zero async runtime, 7 runtime crates, <1MB binary, local-first) mean we cannot bolt on a web framework or message broker. The relay is built entirely on `std::net`.
+These problems require a network layer. But claudectl's constraints (no async runtime in the relay path, lean runtime crate count, ~3.5 MB default binary, local-first) mean we cannot bolt on a web framework or message broker. The relay is built entirely on `std::net`. (The async-runtime exception lives only in the `bus` feature — see CLAUDE.md.)
 
 ## Design Principles
 


### PR DESCRIPTION
User asked \"are docs in sync\" after the DX overhaul release. Two classes of staleness found.

## Binary size claims

The \"~1 MB binary\" / \"<1 MB\" claims pre-date the hive feature (default), the bus feature stack (rmcp + tokio), and the Homebrew-bottle full-feature build from PR #321. Real numbers as of 0.57.0:

* `cargo build --release` (default = hive only) → **~3.5 MB**
* `cargo build --release --features \"bus,coord,relay,hive\"` → **~6.3 MB** (what the Homebrew bottle ships)

Updated:
| File | What changed |
|---|---|
| `README.md` | Tagline now says \"~6 MB binary (full features, Homebrew bottle)\" |
| `docs/index.md` | Proof strip same update |
| `docs/reference.md` | Comparison table row |
| `docs/relay-and-hive.md` | Design-constraints paragraph reframed to match current reality |
| `CLAUDE.md` + `AGENTS.md` | `cargo build` examples split into default vs full-feature |
| `AGENTS.md` | vs-similar-tools comparison table |

`docs/reddit-posts.md` left untouched — those snippets are historical (records of how we positioned the tool at past moments).

## Module list (CLAUDE.md)

The \"Binary modules\" section didn't mention two new files added in this release:

* `src/doctor.rs` (#326) — `claudectl doctor` unified install + runtime checklist
* `src/init/plugin_assets.rs` (#325) — embeds every `claude-plugin/` file via `include_str!`

Both added with one-paragraph descriptions explaining what they do and which issue they came from. Also tidied the `main.rs` subcommand-list order so `doctor` is where it actually fires in the dispatch chain.

## Test plan

- [x] Pure doc PR; no code changes
- [x] `cargo fmt --check`
- [x] Final sweep for `<1MB` / `~1 MB binary` claims returns nothing outside of historical reddit-posts.md

Companion to v0.57.0 (#333).