### PR TITLE
feat(bus): retention + prune verb + doctor row (closes #337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to claudectl are documented here.
 
+## [Unreleased]
+
+### Added — bus retention + `prune` (closes #337)
+- **`bus::store::prune(retention_days)`** — deletes `delivered` messages older than the cutoff (default 30 days, matches `coord::store::prune`). Pending and acked rows untouched. Returns the count deleted.
+- **`claudectl bus prune [--days N] [--dry-run]`** — manual prune verb. Without `--days`, uses the 30-day default.
+- **`claudectl doctor`** gains a `bus retention` row: Pass while the table is under 5000 messages; Advisory above, with a `claudectl bus prune` fix hint.
+- New helpers `bus::store::message_count` and `bus::store::prune_dry_run` for the doctor advisory + dry-run.
+- 5 new bus store tests cover prune semantics, dry-run, the zero-day edge case, the empty-table noop, and total-count accounting.
+
+`docs/agent-bus.md` picks up a "Retention" section explaining the prune cadence and what stays vs goes.
+
+Closes the "no retention path — `bus.db` grows forever" gap surfaced after the 0.57.0 release.
+
 ## [0.57.0] - 2026-06-07
 
 The **DX overhaul release**. Closes #322, #324, #328, #325, #321, #326 — six issues from epic #320. A fresh Homebrew install now activates in three commands:

--- a/docs/agent-bus.md
+++ b/docs/agent-bus.md
@@ -109,6 +109,18 @@ claudectl bus inbox --json                 # machine-readable form
 
 Messages are drained on read — once delivered, they're marked acked and won't appear again.
 
+## Retention
+
+Delivered messages don't disappear on their own — they stay in `bus.db` so the audit trail survives a restart. To keep the table from growing forever:
+
+```bash
+claudectl bus prune                 # delete delivered messages older than 30 days
+claudectl bus prune --days 7        # tighter window
+claudectl bus prune --dry-run       # count what would go without writing
+```
+
+Pending and acked rows are always preserved — `prune` only touches the `delivered` tail. `claudectl doctor` flags the table once it crosses 5000 rows, with a pointer at this command.
+
 ## Where state lives
 
 | Path | What |

--- a/src/bus/cli.rs
+++ b/src/bus/cli.rs
@@ -74,6 +74,16 @@ pub enum BusCommand {
     /// agent picks the work up in-turn. Silent + exit 0 in every other case
     /// so a missing role / empty inbox / unbound cwd never blocks a session.
     StopHook,
+    /// Prune delivered messages older than the retention window (#337).
+    /// Defaults to 30 days. Pending and acked rows are untouched.
+    Prune {
+        /// Retention window in days. Older delivered messages get deleted.
+        #[arg(long, default_value_t = 30)]
+        days: u64,
+        /// Count what would be deleted without writing.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -137,6 +147,7 @@ pub fn dispatch(cmd: &BusCommand) -> Result<(), String> {
         BusCommand::Inbox { role, json } => dispatch_inbox(role.as_deref(), *json),
         BusCommand::Whoami { role, json } => dispatch_whoami(role.as_deref(), *json),
         BusCommand::StopHook => dispatch_stop_hook(),
+        BusCommand::Prune { days, dry_run } => dispatch_prune(*days, *dry_run),
     }
 }
 
@@ -409,6 +420,29 @@ struct WhoamiJson {
     /// PID this role is bound to (#307). `None` for cwd-only bindings.
     pid: Option<u32>,
     note: Option<String>,
+}
+
+// ---------------- Prune -----------------------------------------------------
+
+/// Delete delivered messages older than `days`. Dry-run shows what
+/// would go without writing. Mirrors `coord prune`'s shape (#337).
+fn dispatch_prune(days: u64, dry_run: bool) -> Result<(), String> {
+    let conn = store::open()?;
+    let total = store::message_count(&conn)?;
+    if dry_run {
+        let would_delete = store::prune_dry_run(&conn, Some(days))?;
+        println!(
+            "dry-run: {would_delete} delivered message(s) older than {days} day(s) would be \
+             deleted; {total} total in table"
+        );
+        return Ok(());
+    }
+    let deleted = store::prune(&conn, Some(days))?;
+    let remaining = total.saturating_sub(deleted);
+    println!(
+        "pruned {deleted} delivered message(s) older than {days} day(s); {remaining} remain in table"
+    );
+    Ok(())
 }
 
 // ---------------- Stop hook -------------------------------------------------

--- a/src/bus/store.rs
+++ b/src/bus/store.rs
@@ -334,6 +334,67 @@ pub fn drain_inbox(
     Ok(rows)
 }
 
+// ---------------- Retention ------------------------------------------------
+
+/// Default retention: 30 days of delivered messages. Matches the coord
+/// store's `DEFAULT_RETENTION_DAYS` so operators only need to learn one
+/// number.
+pub const DEFAULT_RETENTION_DAYS: u64 = 30;
+
+/// Delete delivered messages older than `retention_days`. Pending and
+/// acked rows are untouched — we never lose in-flight work or the
+/// audit trail of explicit acks. Returns the count deleted (#337).
+///
+/// Cutoff math mirrors `coord::store::prune` so the two prune paths
+/// agree on what "30 days ago" means.
+pub fn prune(conn: &Connection, retention_days: Option<u64>) -> Result<u64, String> {
+    let days = retention_days.unwrap_or(DEFAULT_RETENTION_DAYS);
+    let cutoff = prune_cutoff(days);
+    let n = conn
+        .execute(
+            "DELETE FROM messages WHERE status = 'delivered' AND delivered_at IS NOT NULL AND delivered_at < ?1",
+            params![cutoff],
+        )
+        .map_err(|e| format!("prune messages: {e}"))?;
+    Ok(n as u64)
+}
+
+/// How many rows `prune` would delete without writing. Used by
+/// `bus prune --dry-run` and by `claudectl doctor` when it wants to
+/// surface "X stale messages waiting to be pruned" advisories.
+pub fn prune_dry_run(conn: &Connection, retention_days: Option<u64>) -> Result<u64, String> {
+    let days = retention_days.unwrap_or(DEFAULT_RETENTION_DAYS);
+    let cutoff = prune_cutoff(days);
+    let n: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM messages WHERE status = 'delivered' AND delivered_at IS NOT NULL AND delivered_at < ?1",
+            params![cutoff],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("prune dry-run count: {e}"))?;
+    Ok(n as u64)
+}
+
+/// Total messages currently in the table. Used by `claudectl doctor`
+/// to flag a growing mailbox before it becomes a problem.
+pub fn message_count(conn: &Connection) -> Result<u64, String> {
+    let n: i64 = conn
+        .query_row("SELECT COUNT(*) FROM messages", [], |row| row.get(0))
+        .map_err(|e| format!("count messages: {e}"))?;
+    Ok(n as u64)
+}
+
+fn prune_cutoff(days: u64) -> String {
+    let epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        .saturating_sub(days * 86400);
+    let d = epoch / 86400;
+    let (year, month, day) = crate::logger::days_to_date(d);
+    format!("{year:04}-{month:02}-{day:02}T00:00:00Z")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -396,5 +457,96 @@ mod tests {
         // Second drain returns nothing — rows are now 'delivered'.
         let drained2 = drain_inbox(&mut conn, "impl", None).unwrap();
         assert!(drained2.is_empty());
+    }
+
+    /// Helper: insert a message with an explicit `delivered_at` so tests can
+    /// fabricate "this was delivered N days ago" rows without sleeping.
+    fn insert_delivered_at(conn: &Connection, id: &str, delivered_at: &str) {
+        conn.execute(
+            "INSERT INTO messages(id, subject, msg_type, sender_role, addressed_to,
+                                  body, priority, status, created_at, delivered_at)
+             VALUES (?1, 'task.created', 'task', 'spec', 'impl',
+                     'body', 'normal', 'delivered', ?2, ?2)",
+            params![id, delivered_at],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn prune_deletes_old_delivered_messages_only() {
+        let conn = open_memory();
+        // 60 days ago — should go.
+        insert_delivered_at(&conn, "old", "2026-04-08T00:00:00Z");
+        // 5 days ago — should stay.
+        insert_delivered_at(&conn, "fresh", "2026-06-02T00:00:00Z");
+        // Pending row from any era — should always stay.
+        insert_message(
+            &conn,
+            "task.created",
+            "task",
+            Some("spec"),
+            Some("impl"),
+            None,
+            "pending body",
+            "normal",
+        )
+        .unwrap();
+        assert_eq!(message_count(&conn).unwrap(), 3);
+        let deleted = prune(&conn, Some(30)).unwrap();
+        assert_eq!(deleted, 1, "only the 60-day-old delivered row should go");
+        assert_eq!(message_count(&conn).unwrap(), 2);
+    }
+
+    #[test]
+    fn prune_dry_run_counts_without_deleting() {
+        let conn = open_memory();
+        insert_delivered_at(&conn, "a", "2026-01-01T00:00:00Z");
+        insert_delivered_at(&conn, "b", "2026-01-02T00:00:00Z");
+        assert_eq!(prune_dry_run(&conn, Some(30)).unwrap(), 2);
+        assert_eq!(
+            message_count(&conn).unwrap(),
+            2,
+            "dry-run must not delete rows"
+        );
+    }
+
+    #[test]
+    fn prune_with_zero_days_drops_yesterday_and_older() {
+        // 0-day retention means the cutoff is today at 00:00:00. Rows
+        // with `delivered_at` strictly before that cutoff drop; rows
+        // dated exactly today (or in the future) survive. This matches
+        // the `<` in the DELETE WHERE clause.
+        let conn = open_memory();
+        insert_delivered_at(&conn, "yday", "2026-06-06T00:00:00Z"); // strictly before today → drops
+        insert_delivered_at(&conn, "older", "2025-12-31T00:00:00Z"); // way before → drops
+        let deleted = prune(&conn, Some(0)).unwrap();
+        assert_eq!(deleted, 2);
+    }
+
+    #[test]
+    fn prune_on_empty_table_is_a_noop() {
+        let conn = open_memory();
+        let deleted = prune(&conn, Some(30)).unwrap();
+        assert_eq!(deleted, 0);
+        assert_eq!(message_count(&conn).unwrap(), 0);
+        assert_eq!(prune_dry_run(&conn, Some(30)).unwrap(), 0);
+    }
+
+    #[test]
+    fn message_count_reflects_total_rows() {
+        let conn = open_memory();
+        assert_eq!(message_count(&conn).unwrap(), 0);
+        insert_message(
+            &conn,
+            "task.created",
+            "task",
+            Some("a"),
+            Some("b"),
+            None,
+            "body",
+            "normal",
+        )
+        .unwrap();
+        assert_eq!(message_count(&conn).unwrap(), 1);
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -65,6 +65,7 @@ pub fn run_all_checks() -> Vec<Check> {
         check_brain_endpoint(),
         check_bus_feature(),
         check_bus_db(),
+        check_bus_retention(),
         check_session_discovery(),
         check_terminal_integration(),
     ]
@@ -360,6 +361,55 @@ fn check_bus_db() -> Check {
                     "Check that ~/.claudectl/bus/ is writable. `claudectl init --purge --yes` resets everything.".into(),
                 ),
             },
+        }
+    }
+}
+
+/// Surface a growing mailbox before it becomes a problem (#337). Pass
+/// while total rows are reasonable; Advisory once the table is in the
+/// thousands AND a meaningful chunk is older than the default 30-day
+/// retention window. The fix hint always points at `bus prune`.
+fn check_bus_retention() -> Check {
+    #[cfg(not(feature = "bus"))]
+    {
+        Check {
+            name: "bus retention".into(),
+            status: CheckStatus::Skipped,
+            message: "bus feature not compiled in".into(),
+            fix_hint: None,
+        }
+    }
+    #[cfg(feature = "bus")]
+    {
+        let Ok(conn) = crate::bus::store::open() else {
+            // bus DB check already reports the open error; don't duplicate.
+            return Check {
+                name: "bus retention".into(),
+                status: CheckStatus::Skipped,
+                message: "bus DB not open".into(),
+                fix_hint: None,
+            };
+        };
+        let total = crate::bus::store::message_count(&conn).unwrap_or(0);
+        let stale = crate::bus::store::prune_dry_run(&conn, None).unwrap_or(0);
+        // Threshold matches the issue spec: < 5000 rows total is fine.
+        if total < 5_000 {
+            return Check {
+                name: "bus retention".into(),
+                status: CheckStatus::Pass,
+                message: format!("{total} messages in table"),
+                fix_hint: None,
+            };
+        }
+        Check {
+            name: "bus retention".into(),
+            status: CheckStatus::Advisory,
+            message: format!(
+                "{total} messages in table ({stale} older than 30 days, prunable)"
+            ),
+            fix_hint: Some(
+                "Run `claudectl bus prune` to delete delivered messages older than 30 days. Add `--days N` to override.".into(),
+            ),
         }
     }
 }


### PR DESCRIPTION
The bus mailbox had no retention path — `messages` grew forever. A long-running install accumulating a few directed messages per session per day hits hundreds of thousands of rows over weeks. Mirrors the `coord::store::prune` shape so operators only learn one retention story.

## What's new

**`bus::store`**

| Symbol | What |
|---|---|
| `DEFAULT_RETENTION_DAYS = 30` | Same default as coord |
| `prune(conn, retention_days)` | Deletes `delivered` rows where `delivered_at < cutoff`. Returns count. Pending and acked rows always preserved. |
| `prune_dry_run(conn, retention_days)` | `COUNT(*)` form of the same query — used by `--dry-run` and the doctor advisory |
| `message_count(conn)` | Total rows; doctor uses this to detect growth |

**CLI**

```bash
claudectl bus prune                 # 30-day default
claudectl bus prune --days 7        # tighter window
claudectl bus prune --dry-run       # count without writing
```

**`claudectl doctor`**

New row: `bus retention`. Pass while `message_count < 5000`; Advisory above, with the prune command as the fix hint.

## Live smoke

```
$ claudectl bus prune --dry-run
dry-run: 0 delivered message(s) older than 30 day(s) would be deleted; 0 total in table

$ claudectl bus prune --days 365
pruned 0 delivered message(s) older than 365 day(s); 0 remain in table

$ claudectl doctor | grep retention
  ✓ bus retention         0 messages in table
```

## Tests

5 new tests in `bus::store::tests`:

* `prune_deletes_old_delivered_messages_only`
* `prune_dry_run_counts_without_deleting`
* `prune_with_zero_days_drops_yesterday_and_older` (cutoff edge case)
* `prune_on_empty_table_is_a_noop`
* `message_count_reflects_total_rows`

Full suite: 1322+ tests passing.

## Docs

`docs/agent-bus.md` picks up a \"Retention\" subsection before \"Where state lives\". Three example commands, the \"pending and acked are preserved\" guarantee, the doctor advisory pointer.

## Out of scope

* Auto-prune on a schedule (decide once we see real-world growth rates from operators)
* `VACUUM` to reclaim pages
* Per-role retention overrides

Closes #337.