### PR TITLE
chore: bump to 0.57.1 — bus prune patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to claudectl are documented here.
 
-## [Unreleased]
+## [0.57.1] - 2026-06-07
 
 ### Added — bus retention + `prune` (closes #337)
 - **`bus::store::prune(retention_days)`** — deletes `delivered` messages older than the cutoff (default 30 days, matches `coord::store::prune`). Pending and acked rows untouched. Returns the count deleted.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.57.0"
+version = "0.57.1"
 edition = "2024"
 # MSRV — bumped to 1.88 in #328 so cargo-install on older toolchains
 # emits a clean "rustc too old" error instead of opaque transitive-dep


### PR DESCRIPTION
Patch release wrapping PR #338 (bus retention + prune verb + doctor row, #337) for current 0.57.0 users hitting the "messages table grows forever" gap.

## Version bumps

* **`claudectl` 0.57.0 → 0.57.1** — binary only.
* **`claudectl-core` 0.52.1 → 0.52.1** (unchanged) — no trait surface or DTO changes.
* **`claudectl-tui` 0.52.1 → 0.52.1** (unchanged).

The musl release pipeline fixes from #334 + #335 are already in 0.57.0 and don't need to re-ship.

`CHANGELOG.md` `[Unreleased]` → `[0.57.1] - 2026-06-07`.

## Test plan

- [x] `cargo build`
- [x] Confirmed core/tui versions unchanged

After merge, I'll tag `v0.57.1`. The release workflow's per-crate publish path is idempotent (existing `claudectl-core 0.52.1` and `claudectl-tui 0.52.1` skips will short-circuit via the crates.io API check); only `claudectl 0.57.1` is a new publish.