### PR TITLE
feat(init): add init --upgrade + plugin-version doctor row (closes #327)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ claudectl                     # Live dashboard — see all sessions at a glance
 claudectl --brain             # Enable local LLM auto-pilot
 ```
 
+After `brew upgrade claudectl`, run **`claudectl init --upgrade`** to re-sync hook entries, plugin files, and DB migrations to the new binary. `claudectl doctor`'s `plugin version` row will tell you when this is needed.
+
 The `init` wizard walks five phases — weekly budget, local-LLM brain detection, Claude Code hook install, agent-bus role, and curated skill suggestions. Plugin files (slash commands, supervisor agent, bus MCP server registration) are embedded in the binary and written to `~/.claude/plugins/claudectl/` automatically — no repo clone. Run `claudectl doctor` to verify every piece is wired up, or `claudectl init --check` for the drift report against the onboarding marker.
 
 ## Why claudectl

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -136,6 +136,18 @@ The `claude-plugin/` directory in the claudectl repo is a Claude Code plugin tha
 
 The plugin and `--init` hooks are complementary. Use `--init` for dashboard observability, the plugin for inline brain decisions.
 
+## Upgrading
+
+After `brew upgrade claudectl` (or `cargo install claudectl --force --locked`), the new binary is on disk but the hook entries, plugin files, and DB schema were written by the old binary. Refresh them with:
+
+```bash
+claudectl init --upgrade
+```
+
+The command walks four steps and reports each: (1) re-write Claude Code hook entries, (2) re-write embedded plugin files from the new binary, (3) run any pending bus / coord DB migrations, (4) bump the onboarding marker's recorded version. It's safe to run any time — files that haven't changed are reported "unchanged."
+
+`claudectl doctor` has a `plugin version` row that flags this scenario: it compares the binary's version against the on-disk `.claude-plugin/plugin.json` and surfaces an advisory with the upgrade command when they differ.
+
 ## Uninstall
 
 Roll back the onboarding wizard's installed artifacts:

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -62,6 +62,7 @@ pub fn run_all_checks() -> Vec<Check> {
         check_binary_on_path(),
         check_claude_code_hooks(),
         check_plugin_installed(),
+        check_plugin_version(),
         check_brain_endpoint(),
         check_bus_feature(),
         check_bus_db(),
@@ -267,6 +268,71 @@ fn walk_count(root: &std::path::Path) -> usize {
         }
     }
     count
+}
+
+/// Compare the on-disk plugin manifest version against the running
+/// binary's `CARGO_PKG_VERSION` (#327). When they differ the user is
+/// almost certainly running `brew upgrade` without `claudectl init
+/// upgrade` afterwards, so they're missing whatever new slash commands
+/// / hook scripts the latest binary ships.
+fn check_plugin_version() -> Check {
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        return Check {
+            name: "plugin version".into(),
+            status: CheckStatus::Skipped,
+            message: "HOME not set".into(),
+            fix_hint: None,
+        };
+    };
+    let manifest = home
+        .join(".claude")
+        .join("plugins")
+        .join("claudectl")
+        .join(".claude-plugin")
+        .join("plugin.json");
+    let raw = match std::fs::read_to_string(&manifest) {
+        Ok(s) => s,
+        Err(_) => {
+            return Check {
+                name: "plugin version".into(),
+                status: CheckStatus::Skipped,
+                message: "plugin not installed yet".into(),
+                fix_hint: None,
+            };
+        }
+    };
+    let binary = env!("CARGO_PKG_VERSION");
+    // Cheap parse — the manifest is small + stable, no point pulling
+    // serde_json::Value just for one field.
+    let on_disk = raw
+        .lines()
+        .find_map(|line| {
+            let trimmed = line.trim();
+            let prefix = "\"version\":";
+            let idx = trimmed.find(prefix)?;
+            let after = &trimmed[idx + prefix.len()..];
+            let v = after.trim().trim_start_matches('"');
+            let end = v.find('"')?;
+            Some(&v[..end])
+        })
+        .unwrap_or("unknown");
+    if on_disk == binary {
+        Check {
+            name: "plugin version".into(),
+            status: CheckStatus::Pass,
+            message: format!("{on_disk} matches binary"),
+            fix_hint: None,
+        }
+    } else {
+        Check {
+            name: "plugin version".into(),
+            status: CheckStatus::Advisory,
+            message: format!("plugin {on_disk}, binary {binary}"),
+            fix_hint: Some(
+                "Run `claudectl init upgrade` to re-sync hooks + plugin files + DB migrations to the current binary.".into(),
+            ),
+        }
+    }
 }
 
 fn check_brain_endpoint() -> Check {

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -205,6 +205,156 @@ pub fn run_reset() -> io::Result<()> {
     Ok(())
 }
 
+/// Re-sync everything the previous `init` wrote so it tracks the current
+/// binary (#327). Used after `brew upgrade claudectl` / `cargo install
+/// claudectl --force` — the new binary embeds newer plugin assets, may
+/// expect a different schema, and might have a fresher marker version,
+/// but the on-disk artifacts were written by the old binary.
+///
+/// Four refresh paths, in order — failures don't abort the rest so a
+/// half-broken install can still partially recover:
+///
+/// 1. Hook entries in `~/.claude/settings.json` — re-runs `init::hooks::run_init`
+///    which is idempotent.
+/// 2. Plugin files in `~/.claude/plugins/claudectl/` — re-writes from
+///    embedded `include_str!` contents. We checksum each file before
+///    writing so the report distinguishes "updated" from "no change".
+/// 3. DB migrations — opening the bus and coord stores runs any pending
+///    `ADD COLUMN` migrations as a side effect of `migrate(&conn)`.
+/// 4. Onboarding marker version bump — if the recorded version differs
+///    from the running binary's `CARGO_PKG_VERSION`, rewrite the version
+///    field (other phase records preserved).
+pub fn run_upgrade() -> io::Result<()> {
+    println!("claudectl init upgrade");
+    println!("=======================");
+    println!();
+
+    let mut had_error = false;
+
+    // 1. Hook entries. `hooks::run_init` prints its own report; we follow
+    // it with our progress line so the operator sees both the file path
+    // touched and the per-step ✓ summary.
+    println!("  [1/4] Claude Code hook entries");
+    match hooks::run_init(false, false) {
+        Ok(()) => println!("        \u{2713} refreshed"),
+        Err(e) => {
+            println!("        \u{2717} {e}");
+            had_error = true;
+        }
+    }
+
+    // 2. Plugin files (embedded → disk)
+    print!("  [2/4] Embedded plugin files ..................... ");
+    match upgrade_plugin_assets() {
+        Ok(Some((updated, unchanged))) => {
+            println!("\u{2713} {updated} updated, {unchanged} unchanged");
+        }
+        Ok(None) => println!("\u{2014} HOME not set, skipped"),
+        Err(e) => {
+            println!("\u{2717} {e}");
+            had_error = true;
+        }
+    }
+
+    // 3. DB migrations (opening the stores triggers `migrate()`)
+    print!("  [3/4] DB schema migrations ...................... ");
+    match upgrade_db_migrations() {
+        Ok(()) => println!("\u{2713} schema current"),
+        Err(e) => {
+            println!("\u{2717} {e}");
+            had_error = true;
+        }
+    }
+
+    // 4. Onboarding marker version stamp
+    print!("  [4/4] Onboarding marker version ................. ");
+    match upgrade_marker_version() {
+        Ok(Some((from, to))) => println!("\u{2713} {from} \u{2192} {to}"),
+        Ok(None) => println!("\u{2014} already current"),
+        Err(e) => {
+            println!("\u{2717} {e}");
+            had_error = true;
+        }
+    }
+
+    println!();
+    if had_error {
+        return Err(io::Error::other(
+            "one or more upgrade steps failed — run `claudectl doctor` for details",
+        ));
+    }
+    println!("Upgrade complete. Run `claudectl doctor` to verify.");
+    Ok(())
+}
+
+/// Re-write embedded plugin assets, returning `(updated, unchanged)` row
+/// counts. We compare against the on-disk contents before writing so the
+/// upgrade report can be honest about what actually changed.
+fn upgrade_plugin_assets() -> io::Result<Option<(usize, usize)>> {
+    let Some(dest) = plugin_assets::default_install_dir() else {
+        return Ok(None);
+    };
+    let mut updated = 0;
+    let mut unchanged = 0;
+    for asset in plugin_assets::ASSETS {
+        let target = dest.join(asset.rel_path);
+        let same = std::fs::read_to_string(&target)
+            .map(|on_disk| on_disk == asset.contents)
+            .unwrap_or(false);
+        if same {
+            unchanged += 1;
+            continue;
+        }
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&target, asset.contents)?;
+        #[cfg(unix)]
+        if asset.rel_path.ends_with(".sh") {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&target)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&target, perms)?;
+        }
+        updated += 1;
+    }
+    Ok(Some((updated, unchanged)))
+}
+
+/// Touch the bus + coord stores so their `migrate(&conn)` calls run any
+/// pending schema changes. Each open is independent — a failure to open
+/// one (feature flag off, or file missing) is not an error for the
+/// other.
+fn upgrade_db_migrations() -> io::Result<()> {
+    #[cfg(feature = "bus")]
+    {
+        let _ = crate::bus::store::open().map_err(io::Error::other)?;
+    }
+    #[cfg(feature = "coord")]
+    {
+        let _ = crate::coord::store::open().map_err(io::Error::other)?;
+    }
+    Ok(())
+}
+
+/// Bump the marker's `version` field to the running binary's
+/// `CARGO_PKG_VERSION` when they differ. Returns `Some((from, to))` on
+/// bump, `None` when already current or when no marker exists yet (a
+/// fresh install isn't an upgrade case).
+fn upgrade_marker_version() -> io::Result<Option<(String, String)>> {
+    let path = marker::default_path();
+    let Some(mut m) = marker::load(&path)? else {
+        return Ok(None);
+    };
+    let current = env!("CARGO_PKG_VERSION").to_string();
+    if m.version == current {
+        return Ok(None);
+    }
+    let from = std::mem::replace(&mut m.version, current.clone());
+    marker::save(&path, &m)?;
+    Ok(Some((from, current)))
+}
+
 /// Hard uninstall: `--remove` plus delete `~/.claudectl/` and
 /// `~/.config/claudectl/config.toml`. Used to start from a truly clean
 /// slate (e.g. for reinstall testing or recovering from corrupted state).
@@ -413,6 +563,87 @@ mod drift_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Mirror of `upgrade_plugin_assets` but writing to an explicit dest
+    /// instead of `default_install_dir()`. Used by the upgrade tests so
+    /// we can drive them with a tempdir.
+    fn upgrade_plugin_assets_at(dest: &std::path::Path) -> io::Result<(usize, usize)> {
+        let mut updated = 0;
+        let mut unchanged = 0;
+        for asset in plugin_assets::ASSETS {
+            let target = dest.join(asset.rel_path);
+            let same = std::fs::read_to_string(&target)
+                .map(|on_disk| on_disk == asset.contents)
+                .unwrap_or(false);
+            if same {
+                unchanged += 1;
+                continue;
+            }
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&target, asset.contents)?;
+            updated += 1;
+        }
+        Ok((updated, unchanged))
+    }
+
+    #[test]
+    fn upgrade_first_pass_writes_every_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (updated, unchanged) = upgrade_plugin_assets_at(tmp.path()).unwrap();
+        assert_eq!(
+            unchanged, 0,
+            "tempdir was empty — nothing should be 'unchanged'"
+        );
+        assert_eq!(updated, plugin_assets::ASSETS.len());
+    }
+
+    #[test]
+    fn upgrade_second_pass_writes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        upgrade_plugin_assets_at(tmp.path()).unwrap();
+        let (updated, unchanged) = upgrade_plugin_assets_at(tmp.path()).unwrap();
+        assert_eq!(updated, 0, "second pass should be a no-op");
+        assert_eq!(unchanged, plugin_assets::ASSETS.len());
+    }
+
+    #[test]
+    fn upgrade_rewrites_a_locally_modified_file() {
+        // The realistic case for `init upgrade` after `brew upgrade`:
+        // some files match the embedded contents, others don't.
+        let tmp = tempfile::tempdir().unwrap();
+        upgrade_plugin_assets_at(tmp.path()).unwrap();
+        // Tamper with one file. role.md is a stable target — it always
+        // ships and isn't going to be renamed without intent.
+        let role_md = tmp.path().join("commands/role.md");
+        std::fs::write(&role_md, "wrong contents\n").unwrap();
+        let (updated, unchanged) = upgrade_plugin_assets_at(tmp.path()).unwrap();
+        assert_eq!(updated, 1);
+        assert_eq!(unchanged, plugin_assets::ASSETS.len() - 1);
+        // And the file should now match the embedded version.
+        let restored = std::fs::read_to_string(&role_md).unwrap();
+        assert!(restored.contains("name: role"));
+    }
+
+    #[test]
+    fn upgrade_marker_helper_bumps_a_stale_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("onboarding.json");
+        let m = marker::OnboardingMarker {
+            version: "0.0.1".into(),
+            completed_at: "2026-01-01T00:00:00Z".into(),
+            phases: Default::default(),
+        };
+        marker::save(&path, &m).unwrap();
+        // Re-read + bump
+        let mut loaded = marker::load(&path).unwrap().unwrap();
+        let from = std::mem::replace(&mut loaded.version, "0.99.0".into());
+        marker::save(&path, &loaded).unwrap();
+        let after = marker::load(&path).unwrap().unwrap();
+        assert_eq!(from, "0.0.1");
+        assert_eq!(after.version, "0.99.0");
+    }
 
     #[test]
     fn remove_helpers_treat_missing_paths_as_success() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,15 @@ pub(crate) enum Command {
             conflicts_with_all = ["check", "reset", "remove", "purge", "non_interactive"]
         )]
         plugin_only: bool,
+        /// Re-sync everything the previous `init` wrote to match the
+        /// running binary (#327): hook entries, embedded plugin files,
+        /// DB schema migrations, and the onboarding marker version. Use
+        /// after `brew upgrade claudectl` / `cargo install ... --force`.
+        #[arg(
+            long,
+            conflicts_with_all = ["check", "reset", "remove", "purge", "plugin_only", "non_interactive"]
+        )]
+        upgrade: bool,
         /// Run every phase without prompting. Combine with the per-phase
         /// flags below (`--budget`, `--brain-url`, `--bus-role`, etc.).
         #[arg(long)]
@@ -789,6 +798,7 @@ fn run_main(cli: Cli) -> io::Result<()> {
                 purge,
                 yes,
                 plugin_only,
+                upgrade,
                 non_interactive,
                 budget,
                 skip_budget,
@@ -812,6 +822,12 @@ fn run_main(cli: Cli) -> io::Result<()> {
                 }
                 if *purge {
                     return init::run_purge(*yes);
+                }
+                if *upgrade {
+                    // #327 — re-sync after `brew upgrade`. Hooks +
+                    // plugin + DB migrations + marker version, with a
+                    // per-step report.
+                    return init::run_upgrade();
                 }
                 if *plugin_only {
                     // #325 — install just the embedded plugin + hook


### PR DESCRIPTION
**Last open issue of the DX overhaul epic #320.** After `brew upgrade claudectl` the new binary is on disk but the hook entries, plugin files, and DB schema are still whatever the old binary wrote. This PR closes that gap.

## CLI

`claudectl init --upgrade` walks four refresh steps in order, with ✓ / — / ✗ reporting on each:

1. **Claude Code hook entries** — re-runs `hooks::run_init` (idempotent).
2. **Embedded plugin files** — for each of the 17 embedded `claude-plugin/` assets (#325), checksums on-disk content against the embedded copy and writes only when they differ. Final report distinguishes \"updated\" from \"unchanged\" so the operator sees what actually changed.
3. **DB schema migrations** — opens `bus::store` and `coord::store`, which run any pending `ADD COLUMN` migrations via `migrate()` as a side effect of `open()`.
4. **Onboarding marker version** — when the recorded version differs from `CARGO_PKG_VERSION`, rewrites the marker's `version` field (phase records preserved).

Failures don't abort — a half-broken install can still partially recover. The flag conflicts with `--check`, `--reset`, `--remove`, `--purge`, `--plugin-only`, and `--non-interactive`.

## Doctor row

New `plugin version` check reads the on-disk `.claude-plugin/plugin.json` `version` field and compares against `CARGO_PKG_VERSION`. Pass when they match; Advisory when they differ:

```
⚠ plugin version        plugin 0.56.0, binary 0.58.0
    → Run `claudectl init upgrade` to re-sync hooks + plugin files + DB migrations to the current binary.
```

This is how operators discover they need to upgrade in the first place.

## Live smoke

```
$ HOME=$tmp claudectl init --upgrade
claudectl init upgrade
=======================

  [1/4] Claude Code hook entries
        ✓ refreshed
  [2/4] Embedded plugin files ..................... ✓ 0 updated, 17 unchanged
  [3/4] DB schema migrations ...................... ✓ schema current
  [4/4] Onboarding marker version ................. — already current

Upgrade complete. Run `claudectl doctor` to verify.
```

Tamper with one file → second run reports `✓ 1 updated, 16 unchanged`.

## Tests

4 new unit tests in `init::tests` cover first-pass writes, second-pass no-op, modified-file rewrite, and marker version round-trip. Full suite: 1330+ tests passing.

## Docs

* `README.md` Get Started — callout pointing at upgrade verb
* `docs/quickstart.md` — new \"Upgrading\" section between Try Demo and Uninstall
* `CHANGELOG.md` — `[Unreleased]` documents the verb + doctor row

## Test plan

- [x] `cargo build --features bus`
- [x] `cargo test --features bus` — 1330+ tests passing
- [x] `cargo clippy --features bus --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Live smoke against fake `$HOME` confirming all four steps + change detection

Closes #327. Closes epic #320 (all 8 sub-issues now done).