### PR TITLE
chore: bump to 0.57.2 — init --upgrade patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.57.2] - 2026-06-07
+
+### Added — `claudectl init --upgrade` + plugin-version doctor row (closes #327)
+- **`claudectl init --upgrade`** — re-sync everything the previous `init` wrote to match the running binary. Used after `brew upgrade claudectl` (or `cargo install ... --force`). Four steps, each with a ✓ / — / ✗ report:
+  1. Claude Code hook entries (`~/.claude/settings.json`)
+  2. Embedded plugin files (`~/.claude/plugins/claudectl/`) — checksums on-disk vs embedded before writing, so the report distinguishes "updated" from "unchanged"
+  3. DB schema migrations (touching the bus + coord stores triggers `migrate(&conn)` as a side effect of `open()`)
+  4. Onboarding marker version bump — when the recorded version differs from the binary's
+- **`claudectl doctor` gains a `plugin version` row** — compares the on-disk `.claude-plugin/plugin.json` version against the binary's `CARGO_PKG_VERSION`. Pass when they match; Advisory when they differ, with `claudectl init upgrade` as the fix hint. This is how operators discover they need to upgrade in the first place.
+- README "Get started" section and `docs/quickstart.md` gain a new "Upgrading" callout pointing at the new verb.
+- 4 new init tests cover the upgrade helpers: first pass writes everything, second pass writes nothing, modified file gets rewritten, marker version bump round-trips.
+
+Closes the last open issue of DX epic #320. With this shipped, all 8 sub-issues of the DX overhaul are done — `brew install` → `claudectl init` → `claudectl doctor` is a complete activation, and `brew upgrade` → `claudectl init --upgrade` is the complete refresh.
+
 ## [0.57.1] - 2026-06-07
 
 ### Added — bus retention + `prune` (closes #337)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.57.1"
+version = "0.57.2"
 edition = "2024"
 # MSRV — bumped to 1.88 in #328 so cargo-install on older toolchains
 # emits a clean "rustc too old" error instead of opaque transitive-dep


### PR DESCRIPTION
Patch release wrapping PR #340 (init --upgrade + plugin-version doctor row, #327) for current 0.57.x users. **Closes the last sub-issue of the DX overhaul epic #320.**

## Version bumps

* **`claudectl` 0.57.1 → 0.57.2** — binary only.
* **`claudectl-core` 0.52.1 → 0.52.1** (unchanged).
* **`claudectl-tui` 0.52.1 → 0.52.1** (unchanged).

## Note

The CHANGELOG entry for #340 missed the `[Unreleased]` section in that merge — adding it now as `[0.57.2]` directly.

## Test plan

- [x] `cargo build`
- [x] Confirmed core/tui versions unchanged

After merge: tag `v0.57.2` → release workflow runs (core/tui publishes short-circuit via idempotent crates.io check; only `claudectl 0.57.2` is a new publish).