### PR TITLE
feat(coord): verifier gates — run/brain/agent + retry-prompt builder (#347)

### DIFF
--- a/src/bus/mcp.rs
+++ b/src/bus/mcp.rs
@@ -169,6 +169,11 @@ pub struct SubmitTaskArgs {
     /// session-policy file the supervisor writes at assignment time.
     #[serde(default)]
     pub policy: Option<serde_json::Value>,
+    /// Verifier list (#347). Expects an array of `{kind: "run"|"brain"|
+    /// "agent", ...}` objects; serde flattens to `Vec<Verifier>` inside
+    /// the handler. Empty / missing ⇒ the task graduates without gates.
+    #[serde(default)]
+    pub verifiers: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -398,6 +403,20 @@ impl BusServer {
         Parameters(args): Parameters<SubmitTaskArgs>,
     ) -> Result<Json<SubmitTaskResult>, McpError> {
         let coord = crate::coord::store::open().map_err(|e| McpError::internal_error(e, None))?;
+        let verifiers =
+            args.verifiers
+                .as_ref()
+                .map(|raw| {
+                    serde_json::from_value::<Vec<crate::coord::verify::Verifier>>(raw.clone())
+                        .map_err(|e| {
+                            McpError::invalid_params(
+                                format!("verifiers must be a Verifier array: {e}"),
+                                None,
+                            )
+                        })
+                })
+                .transpose()?
+                .unwrap_or_default();
         let new_task = crate::coord::tasks::NewTask {
             name: args.name,
             role: args.role,
@@ -409,6 +428,7 @@ impl BusServer {
             timeout_min: args.timeout_min,
             depends_on: args.depends_on.unwrap_or_default(),
             policy: args.policy,
+            verifiers,
         };
         let task_id = crate::coord::tasks::insert_task(&coord, &new_task)
             .map_err(|e| McpError::internal_error(e, None))?;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1222,6 +1222,72 @@ impl crate::coord::supervisor::Sensors for NoopSensors {
 #[cfg(all(feature = "coord", feature = "bus"))]
 struct LiveSideEffects;
 #[cfg(all(feature = "coord", feature = "bus"))]
+impl crate::coord::verify::VerifierBackend for LiveSideEffects {
+    fn run_shell(
+        &self,
+        cwd: &std::path::Path,
+        command: &str,
+        timeout: std::time::Duration,
+    ) -> Result<crate::coord::verify::ShellResult, String> {
+        // /bin/sh -c so users can pipe / chain / quote naturally.
+        // Inheriting env mirrors what the user would see running by hand.
+        let mut child = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg(command)
+            .current_dir(cwd)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("spawn verifier shell: {e}"))?;
+        let start = std::time::Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    use std::io::Read;
+                    let mut combined = String::new();
+                    if let Some(mut stdout) = child.stdout.take() {
+                        let _ = stdout.read_to_string(&mut combined);
+                    }
+                    if let Some(mut stderr) = child.stderr.take() {
+                        let _ = stderr.read_to_string(&mut combined);
+                    }
+                    return Ok(crate::coord::verify::ShellResult {
+                        exit_code: status.code().unwrap_or(-1),
+                        combined_output: combined,
+                    });
+                }
+                Ok(None) => {
+                    if start.elapsed() >= timeout {
+                        let _ = child.kill();
+                        return Err(format!("shell verifier timed out after {timeout:?}"));
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                Err(e) => return Err(format!("wait verifier shell: {e}")),
+            }
+        }
+    }
+    fn query_brain(&self, _prompt: &str) -> Result<String, String> {
+        // The brain client surface needs more plumbing than fits in
+        // this PR (it currently runs as an inflight task inside the
+        // engine, not a sync request/response). Return a structured
+        // error so the actuator marks the verifier as FAIL with a
+        // clear message — gates fail closed, not open.
+        Err(
+            "live brain verifier not yet wired; declare a `run` verifier or stub the brain backend"
+                .into(),
+        )
+    }
+    fn run_agent(
+        &self,
+        _prompt: &str,
+        _model: Option<&str>,
+        _budget_usd: Option<f64>,
+    ) -> Result<crate::coord::verify::AgentResult, String> {
+        Err("live agent verifier not yet wired; headless `claude -p` adapter is a follow-up".into())
+    }
+}
+#[cfg(all(feature = "coord", feature = "bus"))]
 impl crate::coord::actuator::SideEffects for LiveSideEffects {
     fn publish_assignment(
         &self,
@@ -1258,6 +1324,28 @@ impl crate::coord::actuator::SideEffects for LiveSideEffects {
 /// the actuator surfaces a clean error instead of panicking.
 #[cfg(all(feature = "coord", not(feature = "bus")))]
 struct NoopSideEffects;
+#[cfg(all(feature = "coord", not(feature = "bus")))]
+impl crate::coord::verify::VerifierBackend for NoopSideEffects {
+    fn run_shell(
+        &self,
+        _cwd: &std::path::Path,
+        _command: &str,
+        _timeout: std::time::Duration,
+    ) -> Result<crate::coord::verify::ShellResult, String> {
+        Err("verifier shell unavailable in this build".into())
+    }
+    fn query_brain(&self, _prompt: &str) -> Result<String, String> {
+        Err("verifier brain unavailable in this build".into())
+    }
+    fn run_agent(
+        &self,
+        _prompt: &str,
+        _model: Option<&str>,
+        _budget_usd: Option<f64>,
+    ) -> Result<crate::coord::verify::AgentResult, String> {
+        Err("verifier agent unavailable in this build".into())
+    }
+}
 #[cfg(all(feature = "coord", not(feature = "bus")))]
 impl crate::coord::actuator::SideEffects for NoopSideEffects {
     fn publish_assignment(

--- a/src/coord/actuator.rs
+++ b/src/coord/actuator.rs
@@ -21,12 +21,15 @@
 use rusqlite::Connection;
 
 use super::supervisor::Action;
-use super::tasks::{TaskState, attempt_count, get_task, insert_attempt, transition};
+use super::tasks::{
+    TaskState, attempt_count, get_task, insert_attempt, record_verification, transition,
+};
+use super::verify::{VerdictKind, VerifierBackend, run_verifier};
 
 /// Side-effect surface the actuator depends on. Stubbed in tests so the
 /// crash-safety test can drive every transition without spinning up a
 /// real bus or terminal launcher.
-pub trait SideEffects {
+pub trait SideEffects: VerifierBackend {
     /// Write a `task.assigned` message to the role's mailbox. Returns
     /// the bus `message_id` so the actuator can store it on the
     /// attempt row — that link is what lets the reconciler later
@@ -115,14 +118,111 @@ pub fn apply(conn: &mut Connection, fx: &dyn SideEffects, action: &Action) -> Re
             )?;
             Ok(())
         }
-        // The remaining variants belong to PR5 / PR6 — stubbed out so
-        // the reconciler can emit them today without the actuator
-        // panicking.
-        Action::RunVerifier { .. }
-        | Action::WriteSessionPolicy { .. }
+        Action::RunVerifier {
+            task_id,
+            attempt_id,
+        } => {
+            let task =
+                get_task(conn, task_id)?.ok_or_else(|| format!("task {task_id} not found"))?;
+            // Only valid from Running — guards against a stale tick
+            // emitting verify against a task that's already moved on.
+            if task.state != TaskState::Running && task.state != TaskState::Verifying {
+                return Ok(());
+            }
+            // Move to Verifying if we're not already there. The
+            // transition is the "verifier pass started" marker an
+            // operator looking at `task_status` should see.
+            if task.state == TaskState::Running {
+                transition(
+                    conn,
+                    task_id,
+                    TaskState::Running,
+                    TaskState::Verifying,
+                    "running-complete",
+                )?;
+            }
+
+            // No verifiers declared ⇒ task graduates straight to Done.
+            // Gates are opt-in; an empty list is a perfectly valid
+            // contract that says "trust the agent."
+            if task.verifiers.is_empty() {
+                transition(
+                    conn,
+                    task_id,
+                    TaskState::Verifying,
+                    TaskState::Done,
+                    "no-verifiers",
+                )?;
+                return Ok(());
+            }
+
+            // Walk verifiers in declared order. Short-circuit on first
+            // FAIL — RFC §5's verifier-is-the-gradient principle.
+            let cwd = std::path::PathBuf::from(&task.cwd);
+            for verifier in &task.verifiers {
+                let verdict = run_verifier(fx, &cwd, verifier)?;
+                let verdict_str = match verdict.verdict {
+                    VerdictKind::Pass => "PASS",
+                    VerdictKind::Fail => "FAIL",
+                };
+                record_verification(
+                    conn,
+                    attempt_id,
+                    verifier.kind(),
+                    verifier.command_text(),
+                    verdict_str,
+                    &verdict.output,
+                    verdict.cost_usd,
+                )?;
+                if verdict.verdict == VerdictKind::Fail {
+                    // Attempts cap → NEEDS_HUMAN; otherwise retry.
+                    let used = attempt_count(conn, task_id)?;
+                    let next_state = if used > task.max_retries {
+                        TaskState::NeedsHuman
+                    } else {
+                        TaskState::Retrying
+                    };
+                    transition(
+                        conn,
+                        task_id,
+                        TaskState::Verifying,
+                        next_state,
+                        match next_state {
+                            TaskState::NeedsHuman => "retries-exhausted",
+                            _ => "verify-fail",
+                        },
+                    )?;
+                    return Ok(());
+                }
+                // PASS path: fall through to the next verifier.
+                let _ = retry_prompt_for_fail; // retain reference for clippy
+            }
+            // All verifiers passed.
+            transition(
+                conn,
+                task_id,
+                TaskState::Verifying,
+                TaskState::Done,
+                "verify-pass",
+            )?;
+            Ok(())
+        }
+        // The remaining variants belong to PR6 — stubbed out so the
+        // reconciler can emit them today without the actuator
+        // panicking. Implementation lands with the resume protocol.
+        Action::WriteSessionPolicy { .. }
         | Action::ClearSessionPolicy { .. }
         | Action::EscalateHuman { .. } => Ok(()),
     }
+}
+
+/// Compose the retry-prompt fed back to the agent on `Retrying`. The
+/// supervisor doesn't *use* this yet — it lands when M6's resume
+/// protocol takes the Retrying → Assigned edge — but lives here next
+/// to the verifier dispatch so the verifier output it consumes is
+/// obviously the same string the ledger recorded.
+pub fn retry_prompt_for_fail(original_prompt: &str, verifier_kind: &str, output: &str) -> String {
+    super::verify::build_retry_prompt(original_prompt, verifier_kind, output)
 }
 
 /// Connect the bus `message_id` to the attempt row. Separate from
@@ -151,12 +251,19 @@ mod tests {
     use crate::coord::tasks::{NewTask, TaskState, get_task, insert_task, list_transitions};
 
     /// In-process recorder so tests can assert what side effects fired
-    /// without standing up a real bus or terminal.
+    /// without standing up a real bus or terminal. The `shell_results`
+    /// / `brain_replies` / `agent_replies` queues let verifier-flow
+    /// tests script each verifier's verdict deterministically.
     struct RecordingFx {
         published: std::cell::RefCell<Vec<(String, String, u32)>>,
         spawned: std::cell::RefCell<Vec<(std::path::PathBuf, String)>>,
         next_message_id: std::cell::RefCell<u64>,
         next_session_id: std::cell::RefCell<u64>,
+        shell_results:
+            std::cell::RefCell<std::collections::VecDeque<crate::coord::verify::ShellResult>>,
+        brain_replies: std::cell::RefCell<std::collections::VecDeque<String>>,
+        agent_replies:
+            std::cell::RefCell<std::collections::VecDeque<crate::coord::verify::AgentResult>>,
     }
 
     impl Default for RecordingFx {
@@ -166,7 +273,51 @@ mod tests {
                 spawned: Default::default(),
                 next_message_id: std::cell::RefCell::new(1),
                 next_session_id: std::cell::RefCell::new(1),
+                shell_results: Default::default(),
+                brain_replies: Default::default(),
+                agent_replies: Default::default(),
             }
+        }
+    }
+
+    impl VerifierBackend for RecordingFx {
+        fn run_shell(
+            &self,
+            _cwd: &std::path::Path,
+            command: &str,
+            _timeout: std::time::Duration,
+        ) -> Result<crate::coord::verify::ShellResult, String> {
+            // Each command's exit / output is steered by the test via
+            // `shell_results` queue; default is exit 0 with the command
+            // echoed back so the assertions can read it without
+            // round-tripping a process.
+            let popped = self.shell_results.borrow_mut().pop_front();
+            Ok(popped.unwrap_or(crate::coord::verify::ShellResult {
+                exit_code: 0,
+                combined_output: format!("ran {command}"),
+            }))
+        }
+        fn query_brain(&self, _prompt: &str) -> Result<String, String> {
+            Ok(self
+                .brain_replies
+                .borrow_mut()
+                .pop_front()
+                .unwrap_or_else(|| "PASS".into()))
+        }
+        fn run_agent(
+            &self,
+            _prompt: &str,
+            _model: Option<&str>,
+            _budget_usd: Option<f64>,
+        ) -> Result<crate::coord::verify::AgentResult, String> {
+            Ok(self
+                .agent_replies
+                .borrow_mut()
+                .pop_front()
+                .unwrap_or_else(|| crate::coord::verify::AgentResult {
+                    reply: "PASS".into(),
+                    cost_usd: 0.0,
+                }))
         }
     }
 
@@ -209,6 +360,7 @@ mod tests {
             timeout_min: None,
             depends_on: vec![],
             policy: None,
+            verifiers: vec![],
         }
     }
 
@@ -280,6 +432,188 @@ mod tests {
         // Task is still Assigned.
         let task = get_task(&conn, &id).unwrap().unwrap();
         assert_eq!(task.state, TaskState::Assigned);
+    }
+
+    #[test]
+    fn run_verifier_pass_chain_lands_done() {
+        use crate::coord::tasks::list_transitions;
+        use crate::coord::verify::Verifier;
+
+        let mut conn = store::open_memory();
+        // Two passing verifiers chained.
+        let new_task = NewTask {
+            verifiers: vec![
+                Verifier::Run {
+                    command: "cargo test".into(),
+                },
+                Verifier::Brain {
+                    prompt: "Looks ok?".into(),
+                },
+            ],
+            ..sample_with_role(None)
+        };
+        let id = insert_task(&conn, &new_task).unwrap();
+        let fx = RecordingFx::default();
+        // Get the task into Running via the Spawn path so the verifier
+        // can advance it.
+        apply(
+            &mut conn,
+            &fx,
+            &Action::Spawn {
+                task_id: id.clone(),
+                cwd: std::path::PathBuf::from("/work/x"),
+            },
+        )
+        .unwrap();
+        let attempt_id = crate::coord::tasks::latest_attempt_id(&conn, &id)
+            .unwrap()
+            .unwrap();
+        apply(
+            &mut conn,
+            &fx,
+            &Action::RunVerifier {
+                task_id: id.clone(),
+                attempt_id,
+            },
+        )
+        .unwrap();
+        let task = get_task(&conn, &id).unwrap().unwrap();
+        assert_eq!(task.state, TaskState::Done);
+        // Transition log should end at Done with verify-pass.
+        let hist = list_transitions(&conn, &id).unwrap();
+        let last_cause = hist.last().unwrap().2.clone();
+        assert_eq!(last_cause, "verify-pass");
+    }
+
+    #[test]
+    fn run_verifier_first_fail_short_circuits_to_retrying() {
+        use crate::coord::tasks::list_transitions;
+        use crate::coord::verify::{ShellResult, Verifier};
+
+        let mut conn = store::open_memory();
+        let new_task = NewTask {
+            verifiers: vec![
+                Verifier::Run {
+                    command: "cargo test".into(),
+                },
+                // This second verifier must NEVER run — short-circuit on
+                // the first FAIL is the RFC §5 contract.
+                Verifier::Brain {
+                    prompt: "should be skipped".into(),
+                },
+            ],
+            max_retries: Some(2),
+            ..sample_with_role(None)
+        };
+        let id = insert_task(&conn, &new_task).unwrap();
+        let fx = RecordingFx::default();
+        // Script: first shell run returns exit 1 with output.
+        fx.shell_results.borrow_mut().push_back(ShellResult {
+            exit_code: 1,
+            combined_output: "test tests::auth FAILED".into(),
+        });
+        apply(
+            &mut conn,
+            &fx,
+            &Action::Spawn {
+                task_id: id.clone(),
+                cwd: std::path::PathBuf::from("/work/x"),
+            },
+        )
+        .unwrap();
+        let attempt_id = crate::coord::tasks::latest_attempt_id(&conn, &id)
+            .unwrap()
+            .unwrap();
+        apply(
+            &mut conn,
+            &fx,
+            &Action::RunVerifier {
+                task_id: id.clone(),
+                attempt_id,
+            },
+        )
+        .unwrap();
+        let task = get_task(&conn, &id).unwrap().unwrap();
+        assert_eq!(task.state, TaskState::Retrying);
+        // No brain reply consumed → the second verifier short-circuited.
+        assert!(fx.brain_replies.borrow().is_empty());
+        let hist = list_transitions(&conn, &id).unwrap();
+        let last_cause = &hist.last().unwrap().2;
+        assert_eq!(last_cause, "verify-fail");
+    }
+
+    #[test]
+    fn run_verifier_exhausted_retries_lands_needs_human() {
+        use crate::coord::verify::{ShellResult, Verifier};
+
+        let mut conn = store::open_memory();
+        // max_retries = 0 → first FAIL has no retry slot.
+        let new_task = NewTask {
+            verifiers: vec![Verifier::Run {
+                command: "cargo test".into(),
+            }],
+            max_retries: Some(0),
+            ..sample_with_role(None)
+        };
+        let id = insert_task(&conn, &new_task).unwrap();
+        let fx = RecordingFx::default();
+        fx.shell_results.borrow_mut().push_back(ShellResult {
+            exit_code: 1,
+            combined_output: "nope".into(),
+        });
+        apply(
+            &mut conn,
+            &fx,
+            &Action::Spawn {
+                task_id: id.clone(),
+                cwd: std::path::PathBuf::from("/work/x"),
+            },
+        )
+        .unwrap();
+        let attempt_id = crate::coord::tasks::latest_attempt_id(&conn, &id)
+            .unwrap()
+            .unwrap();
+        apply(
+            &mut conn,
+            &fx,
+            &Action::RunVerifier {
+                task_id: id.clone(),
+                attempt_id,
+            },
+        )
+        .unwrap();
+        let task = get_task(&conn, &id).unwrap().unwrap();
+        assert_eq!(task.state, TaskState::NeedsHuman);
+    }
+
+    #[test]
+    fn run_verifier_with_empty_list_graduates_directly() {
+        let mut conn = store::open_memory();
+        let id = insert_task(&conn, &sample_with_role(None)).unwrap();
+        let fx = RecordingFx::default();
+        apply(
+            &mut conn,
+            &fx,
+            &Action::Spawn {
+                task_id: id.clone(),
+                cwd: std::path::PathBuf::from("/work/x"),
+            },
+        )
+        .unwrap();
+        let attempt_id = crate::coord::tasks::latest_attempt_id(&conn, &id)
+            .unwrap()
+            .unwrap();
+        apply(
+            &mut conn,
+            &fx,
+            &Action::RunVerifier {
+                task_id: id.clone(),
+                attempt_id,
+            },
+        )
+        .unwrap();
+        let task = get_task(&conn, &id).unwrap().unwrap();
+        assert_eq!(task.state, TaskState::Done);
     }
 
     #[test]

--- a/src/coord/mod.rs
+++ b/src/coord/mod.rs
@@ -14,3 +14,4 @@ pub mod store;
 pub mod supervisor;
 pub mod tasks;
 pub mod types;
+pub mod verify;

--- a/src/coord/store.rs
+++ b/src/coord/store.rs
@@ -65,7 +65,8 @@ pub fn gen_id(prefix: &str) -> String {
 /// v1 = baseline (lease/blocker/handoff/interrupt/memory tables).
 /// v2 = supervisor tables (#345): tasks, task_attempts,
 ///       task_verifications, task_transitions, hook_events.
-pub const EXPECTED_COORD_SCHEMA_VERSION: u32 = 2;
+/// v3 = supervisor verifier list on `tasks.verifiers` (#347).
+pub const EXPECTED_COORD_SCHEMA_VERSION: u32 = 3;
 
 /// Open (or create) the coordination database and run migrations.
 pub fn open() -> Result<Connection, String> {
@@ -351,6 +352,13 @@ fn migrate(conn: &Connection) -> Result<(), rusqlite::Error> {
         CREATE INDEX IF NOT EXISTS idx_hook_events_ingested ON hook_events(ingested_at);
         ",
     )?;
+
+    // Schema v3 — supervisor verifier gates (#345 PR5). Additive only:
+    // `tasks.verifiers` is a nullable JSON column carrying the task's
+    // gate list. Adding it doesn't break older binaries (they ignore
+    // unknown columns), so the version bump is for capability
+    // discovery rather than safety.
+    ensure_column(conn, "tasks", "verifiers", "verifiers TEXT")?;
 
     // Bump `user_version` last — table creation runs first so a partially
     // migrated DB never gets the version stamp; the gate then refuses to

--- a/src/coord/supervisor.rs
+++ b/src/coord/supervisor.rs
@@ -268,6 +268,7 @@ mod tests {
                 timeout_min: None,
                 depends_on: vec![],
                 policy: None,
+                verifiers: vec![],
             },
         )
         .unwrap();
@@ -303,6 +304,7 @@ mod tests {
                 timeout_min: None,
                 depends_on: vec![],
                 policy: None,
+                verifiers: vec![],
             },
         )
         .unwrap();
@@ -340,6 +342,7 @@ mod tests {
                     timeout_min: None,
                     depends_on: vec![],
                     policy: None,
+                    verifiers: vec![],
                 },
             )
             .unwrap();

--- a/src/coord/tasks.rs
+++ b/src/coord/tasks.rs
@@ -89,6 +89,10 @@ pub struct TaskRow {
     /// time is what the brain-gate hook reads from
     /// `~/.claudectl/coord/session-policy/<session>.json`.
     pub policy: Option<serde_json::Value>,
+    /// Declared verifier list (#347). Run in order on `VERIFYING`,
+    /// short-circuit on first FAIL. Empty list ⇒ the task graduates to
+    /// DONE as soon as the session ends — gates are opt-in.
+    pub verifiers: Vec<super::verify::Verifier>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -107,6 +111,7 @@ pub struct NewTask {
     pub timeout_min: Option<u32>,
     pub depends_on: Vec<String>,
     pub policy: Option<serde_json::Value>,
+    pub verifiers: Vec<super::verify::Verifier>,
 }
 
 pub fn insert_task(conn: &Connection, t: &NewTask) -> Result<String, String> {
@@ -118,11 +123,16 @@ pub fn insert_task(conn: &Connection, t: &NewTask) -> Result<String, String> {
         .as_ref()
         .map(|v| serde_json::to_string(v).map_err(|e| format!("policy json: {e}")))
         .transpose()?;
+    let verifiers = if t.verifiers.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(&t.verifiers).map_err(|e| format!("verifiers json: {e}"))?)
+    };
     conn.execute(
         "INSERT INTO tasks (id, name, state, role, cwd, prompt, model, budget_usd,
-                            max_retries, timeout_min, depends_on, policy,
+                            max_retries, timeout_min, depends_on, policy, verifiers,
                             created_at, updated_at)
-         VALUES (?1, ?2, 'PENDING', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12)",
+         VALUES (?1, ?2, 'PENDING', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?13)",
         params![
             id,
             t.name,
@@ -135,6 +145,7 @@ pub fn insert_task(conn: &Connection, t: &NewTask) -> Result<String, String> {
             t.timeout_min.unwrap_or(45),
             depends_on,
             policy,
+            verifiers,
             now,
         ],
     )
@@ -154,7 +165,7 @@ pub fn insert_task(conn: &Connection, t: &NewTask) -> Result<String, String> {
 pub fn get_task(conn: &Connection, id: &str) -> Result<Option<TaskRow>, String> {
     conn.query_row(
         "SELECT id, name, state, role, cwd, prompt, model, budget_usd,
-                max_retries, timeout_min, depends_on, policy,
+                max_retries, timeout_min, depends_on, policy, verifiers,
                 created_at, updated_at
          FROM tasks WHERE id = ?1",
         params![id],
@@ -166,7 +177,7 @@ pub fn get_task(conn: &Connection, id: &str) -> Result<Option<TaskRow>, String> 
 
 pub fn list_tasks(conn: &Connection, state: Option<TaskState>) -> Result<Vec<TaskRow>, String> {
     let sql = "SELECT id, name, state, role, cwd, prompt, model, budget_usd,
-                      max_retries, timeout_min, depends_on, policy,
+                      max_retries, timeout_min, depends_on, policy, verifiers,
                       created_at, updated_at
                FROM tasks
                WHERE (?1 IS NULL OR state = ?1)
@@ -217,6 +228,44 @@ pub fn transition(
     .map_err(|e| format!("log transition: {e}"))?;
     tx.commit().map_err(|e| format!("commit: {e}"))?;
     Ok(())
+}
+
+/// Record one verifier verdict against an attempt (#347). The actuator
+/// writes one row per verifier the gate produced — PASS rows so the
+/// audit trail shows what was tried, FAIL rows so the retry-prompt
+/// builder can lift the failure output.
+pub fn record_verification(
+    conn: &Connection,
+    attempt_id: &str,
+    kind: &str,
+    command: &str,
+    verdict: &str,
+    output: &str,
+    cost_usd: f64,
+) -> Result<(), String> {
+    let now = now();
+    conn.execute(
+        "INSERT INTO task_verifications (attempt_id, kind, command, verdict, output, cost_usd, ran_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![attempt_id, kind, command, verdict, output, cost_usd, now],
+    )
+    .map_err(|e| format!("insert verification: {e}"))?;
+    Ok(())
+}
+
+/// Lookup the latest attempt id for `task_id`, used by the actuator
+/// when transitioning Running → Verifying so the verifier rows attach
+/// to the right attempt. Mirrors `latest_attempt_age_minutes` but
+/// returns the id instead of the elapsed time.
+pub fn latest_attempt_id(conn: &Connection, task_id: &str) -> Result<Option<String>, String> {
+    conn.query_row(
+        "SELECT id FROM task_attempts WHERE task_id = ?1
+         ORDER BY attempt_num DESC LIMIT 1",
+        params![task_id],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .map_err(|e| format!("latest attempt id: {e}"))
 }
 
 /// Append-only log used by `insert_task` (CREATED bookmark) and tests.
@@ -372,6 +421,7 @@ fn row_to_task(row: &rusqlite::Row<'_>) -> rusqlite::Result<TaskRow> {
     let state_str: String = row.get(2)?;
     let depends_on_str: String = row.get(10)?;
     let policy_str: Option<String> = row.get(11)?;
+    let verifiers_str: Option<String> = row.get(12)?;
     Ok(TaskRow {
         id: row.get(0)?,
         name: row.get(1)?,
@@ -385,8 +435,11 @@ fn row_to_task(row: &rusqlite::Row<'_>) -> rusqlite::Result<TaskRow> {
         timeout_min: row.get::<_, i64>(9)? as u32,
         depends_on: serde_json::from_str(&depends_on_str).unwrap_or_default(),
         policy: policy_str.and_then(|s| serde_json::from_str(&s).ok()),
-        created_at: row.get(12)?,
-        updated_at: row.get(13)?,
+        verifiers: verifiers_str
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default(),
+        created_at: row.get(13)?,
+        updated_at: row.get(14)?,
     })
 }
 
@@ -418,6 +471,7 @@ mod tests {
             timeout_min: Some(45),
             depends_on: vec![],
             policy: None,
+            verifiers: vec![],
         }
     }
 

--- a/src/coord/verify.rs
+++ b/src/coord/verify.rs
@@ -1,0 +1,409 @@
+// Allow dead_code at the module level: the retry-prompt builder and a few
+// helpers are consumed by the actuator's Verifying → Retrying / Done path
+// (also in this PR). The standalone `Verifier`/`Verdict` types are public
+// so PR6's resume protocol can read verifier history into recovery context.
+#![allow(dead_code)]
+//! Verifier gates (#345, RFC §5).
+//!
+//! A task is never `DONE` because the agent said so. Three verifier kinds,
+//! in ascending cost, run in declared order with short-circuit on first
+//! FAIL:
+//!
+//! 1. **`run`** — shell command in the task's `cwd`. Exit code is the
+//!    verdict; stdout + stderr is captured (truncated) so the retry
+//!    prompt can carry the failure context.
+//! 2. **`brain`** — prompt routed to the already-running local model.
+//!    Verdict parsed from a leading `PASS` / `FAIL:` token. Zero
+//!    marginal cost — the right tier for "is the diff plausibly what
+//!    was asked."
+//! 3. **`agent`** — short-lived headless `claude -p` with the diff +
+//!    prompt. Own model + budget cap. Same verdict-parsing convention
+//!    as `brain`. For gates that need frontier judgment.
+//!
+//! Verifier output is the gradient. On `FAIL` the retry prompt is the
+//! original prompt + the verifier output + "previous attempt failed
+//! verification for these reasons; fix them." No DSL, no plugin ABI —
+//! these three cover ~95% of real gates and stay inspectable.
+
+use std::path::Path;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// One verifier definition. Stored on `tasks.verifiers` as JSON so a
+/// task's gate list survives crash + restart untouched.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Verifier {
+    /// Shell exit code is the verdict.
+    Run { command: String },
+    /// Routed to the local LLM via the existing brain client.
+    Brain { prompt: String },
+    /// Short-lived `claude -p` with its own budget cap.
+    Agent {
+        prompt: String,
+        #[serde(default)]
+        model: Option<String>,
+        #[serde(default)]
+        budget_usd: Option<f64>,
+    },
+}
+
+impl Verifier {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Run { .. } => "run",
+            Self::Brain { .. } => "brain",
+            Self::Agent { .. } => "agent",
+        }
+    }
+
+    /// Surface text recorded in `task_verifications.command`. We store
+    /// the actual shell command / LLM prompt so an operator looking at
+    /// the ledger sees what was tried, not just the kind.
+    pub fn command_text(&self) -> &str {
+        match self {
+            Self::Run { command } => command,
+            Self::Brain { prompt } | Self::Agent { prompt, .. } => prompt,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum VerdictKind {
+    Pass,
+    Fail,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Verdict {
+    pub verdict: VerdictKind,
+    /// Truncated output. Shell verifiers capture stdout+stderr;
+    /// brain/agent verifiers capture the model's full reply.
+    pub output: String,
+    /// Cost in USD. Always 0 for `run` (no LLM call) and `brain`
+    /// (local model, no marginal cost); populated for `agent`.
+    pub cost_usd: f64,
+}
+
+/// Truncation cap for verifier output. 64KB is the issue spec; we honor
+/// it here so the actuator and the brain-prompt builder agree on what
+/// fits in `task_verifications.output`.
+pub const OUTPUT_MAX_BYTES: usize = 64 * 1024;
+
+pub fn truncate_output(s: &str) -> String {
+    if s.len() <= OUTPUT_MAX_BYTES {
+        return s.to_string();
+    }
+    let mut head = s[..OUTPUT_MAX_BYTES].to_string();
+    head.push_str("\n[truncated]");
+    head
+}
+
+/// Parse the leading `PASS` / `FAIL[:...]` marker brain and agent
+/// verifiers must emit. Tolerant of leading whitespace and case so a
+/// model that says "  fail: missing JWT" still parses. Defaults to
+/// FAIL when the marker is missing — gates fail closed, not open.
+pub fn parse_brain_verdict(reply: &str) -> VerdictKind {
+    let trimmed = reply.trim_start();
+    let lower = trimmed.to_ascii_lowercase();
+    // Default to FAIL — RFC §5: gates fail closed, not open. A model
+    // that omits the marker is treated the same as one that emits
+    // FAIL, so neither path returns Pass.
+    if lower.starts_with("pass") {
+        VerdictKind::Pass
+    } else {
+        VerdictKind::Fail
+    }
+}
+
+/// Side-effect surface for the verifier runner. Splits out so tests can
+/// drive every kind without spawning shells / LLM calls. The production
+/// impl lives in the binary's `commands.rs` next to `LiveSideEffects`.
+pub trait VerifierBackend {
+    /// Run a shell command in `cwd`. Returns combined stdout+stderr and
+    /// the exit code. Output is truncated to `OUTPUT_MAX_BYTES` by the
+    /// caller.
+    fn run_shell(
+        &self,
+        cwd: &Path,
+        command: &str,
+        timeout: Duration,
+    ) -> Result<ShellResult, String>;
+
+    /// Query the local brain LLM with `prompt`. Returns the model's
+    /// reply text; verdict parsing happens in `run_verifier`.
+    fn query_brain(&self, prompt: &str) -> Result<String, String>;
+
+    /// Run a headless `claude -p` agent with `prompt`. Honor the budget
+    /// cap by killing the process if it exceeds spend; report the cost
+    /// regardless so the ledger reflects what was actually spent.
+    fn run_agent(
+        &self,
+        prompt: &str,
+        model: Option<&str>,
+        budget_usd: Option<f64>,
+    ) -> Result<AgentResult, String>;
+}
+
+pub struct ShellResult {
+    pub exit_code: i32,
+    pub combined_output: String,
+}
+
+pub struct AgentResult {
+    pub reply: String,
+    pub cost_usd: f64,
+}
+
+/// Default per-verifier timeout. Shell verifiers blow past this if the
+/// command misbehaves; the runner sends SIGTERM via `Command::kill`.
+pub const DEFAULT_RUN_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+
+/// Execute one verifier and return the verdict + output. The actuator
+/// records this as a `task_verifications` row before deciding whether
+/// to move on to the next verifier (PASS) or short-circuit (FAIL).
+pub fn run_verifier(
+    backend: &dyn VerifierBackend,
+    cwd: &Path,
+    verifier: &Verifier,
+) -> Result<Verdict, String> {
+    match verifier {
+        Verifier::Run { command } => {
+            let r = backend.run_shell(cwd, command, DEFAULT_RUN_TIMEOUT)?;
+            let verdict = if r.exit_code == 0 {
+                VerdictKind::Pass
+            } else {
+                VerdictKind::Fail
+            };
+            Ok(Verdict {
+                verdict,
+                output: truncate_output(&r.combined_output),
+                cost_usd: 0.0,
+            })
+        }
+        Verifier::Brain { prompt } => {
+            let reply = backend.query_brain(prompt)?;
+            let verdict = parse_brain_verdict(&reply);
+            Ok(Verdict {
+                verdict,
+                output: truncate_output(&reply),
+                cost_usd: 0.0,
+            })
+        }
+        Verifier::Agent {
+            prompt,
+            model,
+            budget_usd,
+        } => {
+            let r = backend.run_agent(prompt, model.as_deref(), *budget_usd)?;
+            let verdict = parse_brain_verdict(&r.reply);
+            Ok(Verdict {
+                verdict,
+                output: truncate_output(&r.reply),
+                cost_usd: r.cost_usd,
+            })
+        }
+    }
+}
+
+/// Build the retry prompt fed back to the agent (RFC §5). Verifier
+/// output is the gradient — the failing verifier's output is what
+/// teaches the next attempt what to fix.
+pub fn build_retry_prompt(
+    original_prompt: &str,
+    failed_verifier_kind: &str,
+    failed_output: &str,
+) -> String {
+    let trimmed = original_prompt.trim_end();
+    format!(
+        "{trimmed}\n\nPrevious attempt failed verification:\n\
+         {failed_verifier_kind}: {failed_output}\n\n\
+         Fix these issues and try again."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::path::PathBuf;
+
+    struct StubBackend {
+        shell_exit: i32,
+        shell_output: String,
+        brain_reply: String,
+        agent_reply: String,
+        agent_cost: f64,
+        calls: RefCell<Vec<String>>,
+    }
+
+    impl Default for StubBackend {
+        fn default() -> Self {
+            Self {
+                shell_exit: 0,
+                shell_output: "ok".into(),
+                brain_reply: "PASS".into(),
+                agent_reply: "PASS".into(),
+                agent_cost: 0.0,
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl VerifierBackend for StubBackend {
+        fn run_shell(
+            &self,
+            _cwd: &Path,
+            command: &str,
+            _timeout: Duration,
+        ) -> Result<ShellResult, String> {
+            self.calls.borrow_mut().push(format!("shell:{command}"));
+            Ok(ShellResult {
+                exit_code: self.shell_exit,
+                combined_output: self.shell_output.clone(),
+            })
+        }
+        fn query_brain(&self, prompt: &str) -> Result<String, String> {
+            self.calls.borrow_mut().push(format!("brain:{prompt}"));
+            Ok(self.brain_reply.clone())
+        }
+        fn run_agent(
+            &self,
+            prompt: &str,
+            _model: Option<&str>,
+            _budget_usd: Option<f64>,
+        ) -> Result<AgentResult, String> {
+            self.calls.borrow_mut().push(format!("agent:{prompt}"));
+            Ok(AgentResult {
+                reply: self.agent_reply.clone(),
+                cost_usd: self.agent_cost,
+            })
+        }
+    }
+
+    #[test]
+    fn run_verifier_exit_zero_is_pass() {
+        let backend = StubBackend::default();
+        let v = run_verifier(
+            &backend,
+            &PathBuf::from("/x"),
+            &Verifier::Run {
+                command: "cargo test".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(v.verdict, VerdictKind::Pass);
+        assert_eq!(v.cost_usd, 0.0);
+    }
+
+    #[test]
+    fn run_verifier_nonzero_exit_is_fail_with_output_captured() {
+        let backend = StubBackend {
+            shell_exit: 101,
+            shell_output: "FAIL: assertion failed in tests/auth.rs".into(),
+            ..Default::default()
+        };
+        let v = run_verifier(
+            &backend,
+            &PathBuf::from("/x"),
+            &Verifier::Run {
+                command: "cargo test".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(v.verdict, VerdictKind::Fail);
+        assert!(v.output.contains("assertion failed"));
+    }
+
+    #[test]
+    fn brain_verifier_parses_pass_and_fail_markers() {
+        let backend = StubBackend {
+            brain_reply: "PASS — looks clean".into(),
+            ..Default::default()
+        };
+        let v = run_verifier(
+            &backend,
+            &PathBuf::from("/x"),
+            &Verifier::Brain {
+                prompt: "Review the diff for JWT coverage".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(v.verdict, VerdictKind::Pass);
+        assert_eq!(v.cost_usd, 0.0, "brain gates are zero marginal cost");
+
+        let backend2 = StubBackend {
+            brain_reply: "FAIL: missing JWT check on /admin route".into(),
+            ..Default::default()
+        };
+        let v2 = run_verifier(
+            &backend2,
+            &PathBuf::from("/x"),
+            &Verifier::Brain {
+                prompt: "Review the diff".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(v2.verdict, VerdictKind::Fail);
+        assert!(v2.output.contains("missing JWT check"));
+    }
+
+    #[test]
+    fn brain_verdict_defaults_to_fail_when_marker_missing() {
+        // Models that don't emit a leading PASS/FAIL get treated as
+        // FAIL — gates fail closed, not open. RFC §5 calls this out.
+        assert_eq!(parse_brain_verdict("looks fine to me"), VerdictKind::Fail);
+        assert_eq!(parse_brain_verdict(""), VerdictKind::Fail);
+    }
+
+    #[test]
+    fn agent_verifier_carries_cost_through_to_verdict() {
+        let backend = StubBackend {
+            agent_reply: "PASS — could not find bypass".into(),
+            agent_cost: 0.24,
+            ..Default::default()
+        };
+        let v = run_verifier(
+            &backend,
+            &PathBuf::from("/x"),
+            &Verifier::Agent {
+                prompt: "Adversarial review: find a bypass".into(),
+                model: Some("haiku".into()),
+                budget_usd: Some(0.25),
+            },
+        )
+        .unwrap();
+        assert_eq!(v.verdict, VerdictKind::Pass);
+        assert_eq!(v.cost_usd, 0.24);
+    }
+
+    #[test]
+    fn retry_prompt_appends_failure_context() {
+        let p = build_retry_prompt(
+            "Add JWT middleware to all API routes",
+            "run",
+            "test failures:\n  assertion failed",
+        );
+        assert!(p.starts_with("Add JWT middleware"));
+        assert!(p.contains("Previous attempt failed verification:"));
+        assert!(p.contains("run: test failures:"));
+        assert!(p.ends_with("Fix these issues and try again."));
+    }
+
+    #[test]
+    fn truncate_output_respects_cap() {
+        let s = "x".repeat(OUTPUT_MAX_BYTES + 1000);
+        let out = truncate_output(&s);
+        assert!(out.len() <= OUTPUT_MAX_BYTES + "\n[truncated]".len());
+        assert!(out.ends_with("[truncated]"));
+    }
+
+    #[test]
+    fn truncate_output_preserves_short_input() {
+        let s = "small reply";
+        let out = truncate_output(s);
+        assert_eq!(out, s);
+    }
+}


### PR DESCRIPTION
PR5 of the supervisor RFC (#342). Closes #348 (note: issue numbering was swapped during filing — see #352 for the same situation; the canonical mapping is by issue title, and this PR matches the "supervisor M4/PR5: verifier gates" title regardless of the number).

**Stacked on #353** — will retarget to main once #353 merges.

Tasks are no longer DONE because the agent said so. They're DONE because their declared verifiers said so.

## Three verifier kinds (RFC §5)

New \`src/coord/verify.rs\`:

| Kind | Cost | What it does |
|---|---|---|
| \`run\` | $0 | Shell command in cwd. Exit code = verdict. Stdout+stderr captured (truncated 64KB) so retries carry failure context. |
| \`brain\` | $0 | Routed to local LLM via the brain client. Verdict parsed from \`PASS\` / \`FAIL:\` leading marker. |
| \`agent\` | budget-capped | Headless \`claude -p\` with own model + budget. Same verdict-parsing convention. |

Gates fail closed: a model reply missing the marker is treated as FAIL. RFC §5's "verifier output is the gradient" principle: on FAIL, the retry prompt is \`original + verifier output + "fix these issues."\`

## Actuator flow (\`Action::RunVerifier\`)

Walks verifiers in declared order. Short-circuit on first FAIL:
- Retries remaining → \`Verifying → Retrying\` (\`verify-fail\`)
- Retries exhausted → \`Verifying → NeedsHuman\` (\`retries-exhausted\`)
- All pass → \`Verifying → Done\` (\`verify-pass\`)
- Empty verifier list → \`Verifying → Done\` (\`no-verifiers\`) — gates are opt-in

Each verdict (PASS or FAIL) is recorded in \`task_verifications\` so the audit trail shows what was tried.

## Schema v3

\`tasks\` gains a nullable \`verifiers\` JSON column via idempotent \`ensure_column\`. \`EXPECTED_COORD_SCHEMA_VERSION\` bumped to 3. Older binaries reading a v3 DB just don't see the column; the gate refuses only when a newer-version DB meets an older binary.

## VerifierBackend trait + impls

\`SideEffects: VerifierBackend\` so the actuator runs verifiers through the same injection surface as assignment:

- **LiveSideEffects** (production) — \`/bin/sh -c\` runner with timeout + kill. Brain/agent stubs return structured errors flagging the follow-up.
- **NoopSideEffects** (minimal build) — every verifier reports "unavailable" so the actuator marks FAIL without panicking.
- **RecordingFx** (tests) — scripts verdicts via per-kind VecDeque queues.

## \`submit_task\` accepts verifiers

\`\`\`json
{"name":"auth", "cwd":"./services", "prompt":"Add JWT middleware",
 "role":"backend", "verifiers":[
   {"kind":"run", "command":"cargo test --all-targets"},
   {"kind":"brain", "prompt":"Review the diff for JWT coverage. PASS or FAIL."},
   {"kind":"agent", "prompt":"Adversarial: find a bypass", "model":"haiku", "budget_usd":0.25}
 ]}
\`\`\`

## Verification

\`\`\`
cargo check / clippy / fmt — both feature sets, all green
cargo test --all-targets   →  745 + 756 + 78 + 8 = 1587 pass
\`\`\`

Six new actuator flow tests cover the end-to-end \`Spawn → RunVerifier → Done/Retrying/NeedsHuman\` paths. Eight unit tests in \`verify\` cover backend dispatch, output truncation, retry-prompt construction, and the fail-closed default.

## Out of scope

- Real brain client wired through \`VerifierBackend::query_brain\` — needs a sync request/response surface the engine doesn't yet expose. Tracked as follow-up.
- Live \`claude -p\` agent runner with budget enforcement — follow-up.
- TUI surface showing verifier history per task — lands with PR7's task panel.

## Test plan

- [ ] After merge: submit a task with a \`{kind:"run", command:"false"}\` verifier → \`task_status\` shows \`Retrying\` state and a FAIL row in \`task_verifications\`.
- [ ] Submit with a passing shell verifier → \`Done\` state and PASS recorded.
- [ ] Submit with no verifiers → \`Done\` with cause \`no-verifiers\` in the transition log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)