### PR TITLE
docs: catch README + reference + AGENT_BUS up to the shipped supervisor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,11 +117,27 @@ Feature flags: `coord`, `relay`, `hive` mirror the binary's same-named features 
 
 **Bus** (`src/bus/`): Agent-bus MCP server, durable role directory, and mailbox (feature-gated behind `bus`; see `docs/AGENT_BUS.md`).
 - `mod.rs` — module surface
-- `store.rs` — SQLite (WAL) at `~/.claudectl/bus/bus.db`: roles + messages tables, drain-on-read semantics
+- `store.rs` — SQLite (WAL) at `~/.claudectl/bus/bus.db`: roles + messages tables (with `hop_count` column), drain + peek semantics
 - `roles.rs` — Role addressing, cwd-inference, ambiguity/unbound resolution. Caller may override with `CLAUDECTL_BUS_ROLE` or `--role`
-- `policy.rs` — Phase-4 guardrails: subject grammar, type allowlist, body cap, leading-`/` neutralization (§9)
-- `mcp.rs` — rmcp stdio server exposing `whoami`, `list_agents`, `publish`, `read_inbox`
-- `cli.rs` — `claudectl bus` subcommand (stdio, role bind/list, send, inbox, whoami)
+- `policy.rs` — Guardrails: subject grammar, type allowlist, body cap, leading-`/` neutralization (§9), hop cap (default 8), reserved-role guard (`supervisor`/`operator` cannot be bound)
+- `rate_limit.rs` — In-process token bucket per `sender_role`; default 60 messages/min, refills continuously without a background timer
+- `mcp.rs` — rmcp stdio server exposing `whoami`, `list_agents`, `publish` (with `parent_hop`), `read_inbox` (with `peek`), plus supervisor tools `submit_task` / `list_tasks` / `task_status`
+- `cli.rs` — `claudectl bus` subcommand (stdio, role bind/list, send, inbox + `--peek`, whoami, stop-hook driver, prune)
+
+**Supervisor** (`src/coord/{supervisor,actuator,verify,resume,tasks,session_policy,hook_events,events,exporter,supervisor_cli}.rs`, `src/ingest.rs`): Durable, verified task lifecycles on top of the bus (see `docs/AGENT_BUS.md#10-supervisor` and README §Supervisor).
+- `tasks.rs` — `tasks` / `task_attempts` / `task_verifications` / `task_transitions` CRUD + state machine. Every transition writes state + log in one transaction so the ledger invariant "every state has a cause" holds.
+- `supervisor.rs` — **pure** reconciler. Reads desired state from coord, observed state from `Sensors`, returns `Vec<Action>`. No I/O. Health-check → `HealthAction` mapping table. `Unknown` observed status is the no-actuation backstop (RFC §6).
+- `actuator.rs` — Carries out `Action`s. Three-step: insert attempt → perform side effect → log transition. Side-effect failure stops *before* the transition is recorded, so the next tick re-emits.
+- `verify.rs` — `Verifier` enum (Run/Brain/Agent) + `run_verifier` dispatch. Fail-closed on missing PASS/FAIL marker. `build_retry_prompt` composes original + failure output + "fix these issues" feedback.
+- `resume.rs` — Tree-state hash (git when available, mtime fallback) + recovery-prompt builder. Resume the *task*, not the session.
+- `session_policy.rs` — Atomic per-session policy file at `~/.claudectl/coord/session-policy/<session>.json`. Brain-gate hook reads it on every tool call; fail-open to `Inherit` keeps the manual-upgrade gap non-breaking.
+- `hook_events.rs` — `hook_events` table (latency-only signal path; JSONL tail stays authoritative).
+- `events.rs` — v1 NDJSON event schema (frozen). Three families: `task.transition`, `task.verification`, `task.escalated`.
+- `exporter.rs` — Hand-rolled HTTP `/metrics` server (no web framework dep). Worker thread per scrape so the tick loop never blocks. Exposes `claudectl_tasks_by_state`, `claudectl_fleet_cost_usd_total`, `claudectl_retries_total`, `claudectl_verifier_pass_rate`.
+- `supervisor_cli.rs` — `claudectl supervisor` subcommand (run / submit / status / logs / cancel / drain / undrain). Hand-rolled TOML reader for the `tasks.toml` subset.
+- `src/ingest.rs` — `claudectl ingest --hook <name>` subcommand. Bash hooks call `claudectl ingest --hook PostToolUse 2>/dev/null || true`. Best-effort by construction.
+
+Coord schema is gated on `PRAGMA user_version` (`EXPECTED_COORD_SCHEMA_VERSION = 3` today). A binary that meets a newer schema refuses to start with the exact `init --upgrade` remediation in the error.
 
 **Hive** (`src/hive/`): Gossip-based knowledge sharing across connected brains (feature-gated behind `relay`).
 - `mod.rs` — KnowledgeUnit, KnowledgeScope, KnowledgeContent types, semantic key, broadcast channel

--- a/README.md
+++ b/README.md
@@ -230,7 +230,70 @@ Mailboxes live in `~/.claudectl/bus/bus.db` (SQLite WAL). Message bodies are san
 
 **Full guide:** [Agent Bus](docs/agent-bus.md) — wire-up, role binding, sending and receiving messages, worked planner→implementer example, where state lives, uninstall.
 
-Not yet built: pub/sub subscribe + claim protocol, flow guards, and the supervisor for long-horizon role persistence. See [AGENT_BUS.md](docs/AGENT_BUS.md#implementation-status) for the per-phase status table.
+Flow guards (hop limit, per-role rate limit, reserved-role ACL) and the supervisor for long-horizon role persistence are shipped. Pub/sub `subscribe` + claim protocol and the TUI bus view are still in flight. See [AGENT_BUS.md](docs/AGENT_BUS.md#implementation-status) for the per-phase status table.
+
+## Supervisor
+
+Durable, verified task lifecycles on top of the bus. Where the agent bus answers "how do I talk to the swarm?", the supervisor answers "how do I trust the swarm to run unattended overnight?" Submit a task, it lands in a SQLite ledger; the reconciler assigns it via mailbox (or spawns a session if no role is set); declared verifiers (`run` / `brain` / `agent`) gate the move to DONE; a dead session triggers Resume with a recovery prompt that carries autopsy findings forward; health-check signals (stalled, retry loop) become first-class transitions instead of dashboard warnings.
+
+```bash
+# One-shot inline submission
+claudectl supervisor submit \
+  --name "auth-middleware" \
+  --cwd ~/work/services \
+  --prompt "Add JWT middleware to all API routes" \
+  --role backend --budget-usd 3.00
+
+# Batch submission from a TOML file
+claudectl supervisor run tasks.toml --dry-run    # preview
+claudectl supervisor run tasks.toml              # commit
+
+# Inspect fleet state
+claudectl supervisor status
+claudectl supervisor status --state RUNNING
+claudectl supervisor logs <task_id>              # full transition log + verifier history
+
+# Lifecycle controls
+claudectl supervisor cancel <task_id>            # idempotent move to CANCELLED
+claudectl supervisor drain                       # stop issuing new assignments
+claudectl supervisor undrain                     # resume
+```
+
+A `tasks.toml` block carrying every supported field — including the three verifier kinds:
+
+```toml
+[[task]]
+name        = "auth-middleware"
+role        = "backend"
+cwd         = "./services"
+prompt      = "Add JWT auth middleware to all API routes"
+model       = "sonnet"
+budget_usd  = 3.00
+max_retries = 2
+timeout_min = 45
+
+  [[task.verify]]
+  run  = "cargo test --all-targets"            # exit code is the verdict
+
+  [[task.verify]]
+  brain = "Review the diff for auth-coverage gaps. PASS or FAIL with reasons."
+                                                # routed to the local brain — free
+
+  [[task.verify]]
+  agent = "Adversarial review: find a request that bypasses the middleware."
+  model = "haiku"                               # headless claude -p, own budget
+  budget_usd = 0.25
+```
+
+Tasks are submittable three ways: this CLI, a `task.created` bus message addressed to the `supervisor` role, or the `submit_task` MCP tool from inside a Claude Code session. All three land as the same SQLite row.
+
+Three load-bearing properties from the design spec:
+
+- **Cattle vs. pets** — a task survives the death of the session executing it; the next attempt is a fresh session that reads the recovery context (original prompt + autopsy + prior verifier failures + tree-state drift warning).
+- **Crash-safe by construction** — kill the headless daemon mid-tick, restart, and observed state re-converges from `~/.claudectl/coord/coord.db`. The ledger is the source of truth.
+- **Fail-closed verifiers** — a brain/agent verifier whose reply lacks the leading `PASS` / `FAIL:` marker is treated as FAIL. RFC §5 calls this the verifier-is-the-gradient principle: every FAIL output becomes the retry prompt the next attempt sees.
+
+Metrics: `claudectl supervisor` exposes a Prometheus exporter shape (`claudectl_tasks_by_state`, `claudectl_fleet_cost_usd_total`, `claudectl_retries_total`, `claudectl_verifier_pass_rate`). The headless flag that binds the listener is on the follow-up roadmap; the metrics surface itself is testable today via the `coord::exporter` API.
 
 ## Hive Mind & Relay
 

--- a/docs/AGENT_BUS.md
+++ b/docs/AGENT_BUS.md
@@ -12,11 +12,11 @@
 | 3. Provisioning (role binding + plugin install + hook capability probe) | **Shipped via `claudectl init`** (PR #283) — five-phase wizard owns bus role binding alongside budget, brain, hooks, and skill suggestions. Lifecycle verbs: `init`, `init --non-interactive`, `init --check`, `init --remove`, `init --reset`. Tracking: [#257](https://github.com/mercurialsolo/claudectl/issues/257). | `src/init/` |
 | 4. Mailbox + directed `publish` / `read_inbox` | **Shipped** | `src/bus/store.rs`, `src/bus/mcp.rs` |
 | 5. `Stop` hook → `read_inbox` (Trigger A) + `/inbox` fallback (Trigger B) | **Shipped (Trigger A continue-in-turn + Trigger B)** | `src/bus/stop_hook.rs`, `claude-plugin/hooks/scripts/inbox-drain.sh`, `claude-plugin/commands/inbox.md` |
-| 6. Command sanitization + content validation | **Shipped (subset)** — leading-`/` neutralized, body cap, subject grammar, type allowlist. Hop/rate/echo guards not yet. | `src/bus/policy.rs` |
+| 6. Command sanitization + content validation | **Shipped** — leading-`/` neutralized, body cap, subject grammar, type allowlist, hop cap (default 8), per-sender-role rate limit (60/min token bucket), reserved-role guard (`supervisor`/`operator` cannot be bound). | `src/bus/policy.rs`, `src/bus/rate_limit.rs` |
 | 7. Subjects + `subscribe` + claim protocol | **Not started** | — |
-| 8. Flow guards (rate/hop/loop/cost) + ACLs | **Not started** | — |
-| 9. Managed-artifact lifecycle (update/migrate/drift) | **Not started** | — |
-| 10. Supervisor + long-horizon persistence | **Not started** | — |
+| 8. Flow guards (rate/hop/loop/cost) + ACLs | **Shipped (hop + rate + reserved-role ACL)** via PR #351 / #344. Loop detection and cost-based throttling are deferred. | `src/bus/policy.rs`, `src/bus/rate_limit.rs` |
+| 9. Managed-artifact lifecycle (update/migrate/drift) | **Partial** — `init --upgrade` re-syncs hooks + plugin files + DB migrations (#327); drift surfaces in `claudectl doctor` via the `plugin version` row. | `src/init/`, `src/doctor.rs` |
+| 10. Supervisor + long-horizon persistence | **Shipped** via PRs #352–#356 — coord task tables, pure reconciler + actuator, bus-native assignment, verifier gates (`run`/`brain`/`agent`), resume protocol with tree-state drift detection, health-check transition triggers, `claudectl supervisor` CLI tree, v1 NDJSON event schema, Prometheus exporter. See [supervisor section](#10-supervisor--long-horizon-persistence) below. | `src/coord/{supervisor,actuator,verify,resume,events,exporter,supervisor_cli,tasks,session_policy,hook_events}.rs`, `src/ingest.rs` |
 | 11. TUI bus view | **Not started** | — |
 
 **Build / run:** `cargo build --release --features bus`. End-to-end smoke covered: role bind → cwd inference (macOS symlink resolution) → directed send → priority-ordered drain → leading-`/` neutralization → policy rejections. MCP handshake (`initialize` + `notifications/initialized` + `tools/list`) verified end-to-end. **Not yet exercised:** the plugin loaded inside Claude Code driving real cross-session traffic.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -96,6 +96,27 @@ Runs with fake sessions so you can explore the dashboard, keybindings, and featu
 | `n` | Launch a new session |
 | `?` | Show all keybindings |
 
+## Optional: submit a task to the supervisor
+
+The supervisor turns the durable coord ledger into a task runner: submit work, declare verifiers, let the reconciler hand it to a role's mailbox (or spawn a fresh session). It survives daemon restarts.
+
+```bash
+# Inline submission — useful for one-shot scripts
+claudectl supervisor submit \
+  --name "rename-utils" \
+  --cwd "$PWD" \
+  --prompt "Rename utils.rs → helpers.rs and update every import" \
+  --role backend
+
+# Inspect what's running
+claudectl supervisor status            # compact table
+claudectl supervisor logs <task_id>    # transitions + verifier history
+```
+
+Batch from a `tasks.toml` file (RFC §4 shape) with `claudectl supervisor run tasks.toml --dry-run` to preview, then without `--dry-run` to commit. See the [README's Supervisor section](../README.md#supervisor) for the verifier syntax (`run` / `brain` / `agent`) and the full design overview.
+
+`claudectl supervisor drain` halts new assignments without killing running tasks; the `supervisor drain` row in `claudectl doctor` surfaces the state.
+
 ## Optional: project-scoped hooks
 
 If you only want claudectl hooks in specific projects (not globally), the `--init` legacy flag still works for hook-only installs:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -169,7 +169,7 @@ Press `R` on any session to record a per-session highlight reel (edits, commands
 
 ### Coordination (--features coord)
 
-Inspect multi-session coordination state. Requires `cargo install claudectl --features coord`.
+Inspect multi-session coordination state. Enabled by default since the supervisor RFC (#342).
 
 | Command | Description |
 |---------|-------------|
@@ -182,6 +182,28 @@ Inspect multi-session coordination state. Requires `cargo install claudectl --fe
 | `coord memory search <q>` | Full-text search coordination memory |
 | `coord promote --project <name>` | Promote brain patterns to coordination memory |
 | `coord prune [--days N]` | Delete old events, resolved blockers, expired leases (default: 30 days) |
+
+### Supervisor
+
+Durable task lifecycles on top of the bus. See the [README's Supervisor section](../README.md#supervisor) for the design overview and `tasks.toml` shape.
+
+| Command | Description |
+|---------|-------------|
+| `supervisor run <tasks.toml> [--dry-run]` | Batch-submit one or more tasks from a TOML file (RFC §4 shape) |
+| `supervisor submit --name --cwd --prompt [--role ...]` | One-shot inline submission |
+| `supervisor status [--state STATE]` | Compact task table; optional state filter (`PENDING` / `RUNNING` / `DONE` / `NEEDS_HUMAN` / …) |
+| `supervisor logs <task_id>` | Task detail + full transition log |
+| `supervisor cancel <task_id>` | Idempotent move to CANCELLED |
+| `supervisor drain` | Set sentinel file at `~/.claudectl/coord/drain`; reconciler stops issuing new assignments |
+| `supervisor undrain` | Clear the drain marker |
+
+Coord schema is gated on `PRAGMA user_version`. A binary that meets a newer schema (e.g. after `brew upgrade` without a follow-up `init --upgrade`) refuses to start with the exact remediation in the error.
+
+### Ingest
+
+| Command | Description |
+|---------|-------------|
+| `ingest --hook <PreToolUse\|PostToolUse\|Stop\|SessionStart\|Notification\|UserPromptSubmit>` | Append the hook's stdin payload to coord `hook_events`. Best-effort by construction — meant to be called from a bash hook with `2>/dev/null \|\| true`. JSONL tail + `ps` stay authoritative; this is a latency optimization for the supervisor's reconciler. |
 
 ### Relay (--features relay)
 


### PR DESCRIPTION
Honest follow-up: PRs #350–#356 shipped the supervisor end-to-end but didn't update user-facing docs. A reader of \`README.md\` today still sees "the supervisor for long-horizon role persistence" listed under "not yet built", which is exactly backwards.

## What this PR does

- **\`README.md\`** — Fix the stale "not yet built" claim. Add a new \`## Supervisor\` section between Agent Bus and Hive Mind. Covers the design argument, CLI surface (inline + TOML), the three-verifier \`tasks.toml\` shape, the three load-bearing properties (cattle vs. pets / crash-safe from coord.db / fail-closed verifiers), and the Prometheus metric names.
- **\`docs/AGENT_BUS.md\`** — Implementation status table. Phase 6 (content validation), Phase 8 (flow guards), and Phase 10 (Supervisor) all marked Shipped with PR references and the module list. Phase 9 (managed-artifact lifecycle) corrected to Partial.
- **\`docs/reference.md\`** — New Supervisor command table, new Ingest row, schema-version-gate behavior noted.
- **\`docs/quickstart.md\`** — Optional "Submit a task to the supervisor" section.
- **\`CLAUDE.md\`** — Architecture section gets a Supervisor block listing every \`src/coord/*.rs\` file + \`src/ingest.rs\`. Schema-version gate documented.

## Deliberately out of scope

- \`docs/configuration.md\` doesn't get a supervisor section yet — \`~/.claudectl/coord/policy.toml\` isn't being loaded by the reconciler (defaults are baked in). When config loading lands, the TOML schema lands with it.
- \`docs/AGENT_BUS.md\` §13 narrative wasn't reworked. The status table at the top is what readers check for "is this real yet" and that's now accurate.

No code changes. Existing tests still pass; \`cargo fmt --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)