### PR TITLE
chore: bump to 0.57.3 — notification cooldown patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.57.3] - 2026-06-22
+
+### Fixed — notification cooldown + unified toggle (#364)
+- Desktop notifications now route through a single gate (`App::notify_user`) that honors the master `notify` toggle **and** a per-event cooldown. Previously only the "needs input" notification was gated by `notify`; budget, context, and conflict pings fired regardless, so `notify = false` did not actually silence everything.
+- **Anti-flap cooldown** — a session oscillating `NeedsInput ↔ Running` no longer re-pings on every transition. Per-event keys (`needs-input:<pid>`, `budget-warn:<pid>`, `conflict:<wt>`, …) scope the cooldown so each event fires at most once per window.
+- New **`notify_cooldown_secs`** config knob (default **30s**), wired through all three layers: CLI `--notify-cooldown <SECS>`, `[defaults]` TOML, `config set`/`config show`, and known-keys validation.
+- `fire_notification` no longer hardcodes `" needs input"` onto every message — budget/conflict notifications read correctly instead of e.g. "x budget needs input".
+- New pure `should_notify` helper with unit tests for the never-fired / within-cooldown / after-cooldown cases.
+
+Workspace crates bumped: `claudectl-core` and `claudectl-tui` → 0.52.2 (both touched by the fix).
+
 ## [0.57.2] - 2026-06-07
 
 ### Added — `claudectl init --upgrade` + plugin-version doctor row (closes #327)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.57.2"
+version = "0.57.3"
 edition = "2024"
 # MSRV — bumped to 1.88 in #328 so cargo-install on older toolchains
 # emits a clean "rustc too old" error instead of opaque transitive-dep
@@ -50,8 +50,8 @@ path = "src/lib.rs"
 # published to crates.io. Local builds always use the path; crates.io strips
 # the path and resolves the published version. Bump both when the workspace
 # crates change.
-claudectl-core = { path = "crates/claudectl-core", version = "0.52.1" }
-claudectl-tui = { path = "crates/claudectl-tui", version = "0.52.1" }
+claudectl-core = { path = "crates/claudectl-core", version = "0.52.2" }
+claudectl-tui = { path = "crates/claudectl-tui", version = "0.52.2" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }

--- a/crates/claudectl-core/Cargo.toml
+++ b/crates/claudectl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-core"
-version = "0.52.1"
+version = "0.52.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Foundational types and IO primitives for claudectl. Shared across the TUI, the binary, and future crates."

--- a/crates/claudectl-tui/Cargo.toml
+++ b/crates/claudectl-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-tui"
-version = "0.52.1"
+version = "0.52.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Terminal UI, dashboard recording, and demo-mode fixtures for claudectl. Splits out of the binary so the TUI can evolve independently of the brain/coord/bus subsystems."
@@ -23,7 +23,7 @@ relay = []
 hive = []
 
 [dependencies]
-claudectl-core = { path = "../claudectl-core", version = "0.52.1" }
+claudectl-core = { path = "../claudectl-core", version = "0.52.2" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde_json = "1"


### PR DESCRIPTION
Releases the notification cooldown + unified-toggle fix (#364, already merged to `main`).

## Why a bump is needed
`v0.57.2` is already tagged and on crates.io, so the fix on `main` is **not yet released** anywhere. The release pipeline (`release.yml`) is tag-driven and publishes each workspace crate to crates.io independently. Because the fix touched all three crates, all three must bump — otherwise the `cargo install` path would pull a `claudectl` that depends on the **stale** `claudectl-core`/`claudectl-tui` 0.52.1 (which lack the `fire_notification` and `notify_user` changes). The Homebrew bottle builds from source at the tag, so it'd be fine either way, but crates.io would not.

## Bumps
| crate | from | to | reason |
|---|---|---|---|
| `claudectl` | 0.57.2 | **0.57.3** | `src/*` (config, CLI, wiring) |
| `claudectl-core` | 0.52.1 | **0.52.2** | `helpers.rs` (`fire_notification`) |
| `claudectl-tui` | 0.52.1 | **0.52.2** | `app.rs` (`notify_user`, cooldown) |

Inter-crate version requirements updated to match; `CHANGELOG.md` entry added. (`Cargo.lock` is gitignored in this repo and regenerated by CI.)

## Releasing
Patch level (bug fix only). After merge, push the `v0.57.3` tag on `main` to trigger `release.yml` → tarballs + crates.io publish (core → tui → claudectl) + Homebrew tap formula update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
