### PR TITLE
feat(tui): supervisor task panel — render coord task lifecycles (#368)

### DIFF
--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -277,12 +277,33 @@ pub struct InterruptSummary {
     pub created_at: String,
 }
 
-/// Read access to coordination state (leases, handoffs, interrupts).
+/// A supervisor task lifecycle, projected for the TUI. One row per task in the
+/// coord `tasks` table. `state` is the wire label (`TaskState::as_str`), kept as
+/// a string so the contract doesn't drag the coord state enum upward.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskSummary {
+    pub id: String,
+    pub name: String,
+    pub state: String,
+    pub role: Option<String>,
+    /// Number of recorded attempts so far.
+    pub attempts: u32,
+    pub max_retries: u32,
+    /// Session id of the most recent attempt, when one has run.
+    pub last_session_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Read access to coordination state (leases, handoffs, interrupts, tasks).
 /// Backed today by the `coord` SQLite store; in tests, by a fixture.
 pub trait CoordView: Send + Sync {
     fn active_leases(&self) -> Vec<LeaseSummary>;
     fn pending_handoffs(&self) -> Vec<HandoffSummary>;
     fn pending_interrupts(&self) -> Vec<InterruptSummary>;
+    /// Supervisor task lifecycles, newest first. Empty when the `coord` feature
+    /// is off so the TUI can render a "no supervisor" state without cfg.
+    fn tasks(&self) -> Vec<TaskSummary>;
 }
 
 // ============================================================================
@@ -665,6 +686,7 @@ pub struct MockRuntime {
     pub leases: Vec<LeaseSummary>,
     pub handoffs: Vec<HandoffSummary>,
     pub interrupts: Vec<InterruptSummary>,
+    pub tasks: Vec<TaskSummary>,
     pub agents: Vec<AgentDirectoryEntry>,
     pub roles: Vec<RoleBinding>,
     pub actions_log: std::sync::Mutex<Vec<MockAction>>,
@@ -779,6 +801,9 @@ impl CoordView for MockRuntime {
     }
     fn pending_interrupts(&self) -> Vec<InterruptSummary> {
         self.interrupts.clone()
+    }
+    fn tasks(&self) -> Vec<TaskSummary> {
+        self.tasks.clone()
     }
 }
 
@@ -967,6 +992,30 @@ mod tests {
         assert!(rt.coord.active_leases().is_empty());
         assert!(rt.coord.pending_handoffs().is_empty());
         assert!(rt.coord.pending_interrupts().is_empty());
+        assert!(rt.coord.tasks().is_empty());
+    }
+
+    #[test]
+    fn coord_view_returns_task_fixture() {
+        let mock = MockRuntime {
+            tasks: vec![TaskSummary {
+                id: "t1".into(),
+                name: "ship the thing".into(),
+                state: "running".into(),
+                role: Some("backend".into()),
+                attempts: 2,
+                max_retries: 3,
+                last_session_id: Some("sess-abcdef12".into()),
+                created_at: "2026-06-25T10:00:00Z".into(),
+                updated_at: "2026-06-25T10:05:00Z".into(),
+            }],
+            ..Default::default()
+        };
+        let rt = mock.into_runtime();
+        let tasks = rt.coord.tasks();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].state, "running");
+        assert_eq!(tasks[0].attempts, 2);
     }
 
     #[test]

--- a/crates/claudectl-tui/src/app.rs
+++ b/crates/claudectl-tui/src/app.rs
@@ -347,6 +347,16 @@ pub struct App {
     pub coord_pending_interrupts: Vec<claudectl_core::runtime::InterruptSummary>,
     #[cfg(feature = "coord")]
     pub coord_tick: u32,
+    /// Supervisor task ledger (#368). Populated by `coord_refresh`.
+    #[cfg(feature = "coord")]
+    pub coord_tasks: Vec<claudectl_core::runtime::TaskSummary>,
+    /// When true, the draw loop renders the full-screen Supervisor panel.
+    #[cfg(feature = "coord")]
+    pub show_supervisor: bool,
+    #[cfg(feature = "coord")]
+    pub supervisor_selected: usize,
+    #[cfg(feature = "coord")]
+    pub supervisor_status_msg: Option<String>,
     // Relay peers panel (feature-gated)
     #[cfg(feature = "relay")]
     pub show_peers_panel: bool,
@@ -635,6 +645,14 @@ impl App {
             coord_pending_interrupts: Vec::new(),
             #[cfg(feature = "coord")]
             coord_tick: 0,
+            #[cfg(feature = "coord")]
+            coord_tasks: Vec::new(),
+            #[cfg(feature = "coord")]
+            show_supervisor: false,
+            #[cfg(feature = "coord")]
+            supervisor_selected: 0,
+            #[cfg(feature = "coord")]
+            supervisor_status_msg: None,
             #[cfg(feature = "relay")]
             show_peers_panel: false,
             #[cfg(feature = "relay")]
@@ -1443,6 +1461,10 @@ impl App {
         self.coord_leases = self.runtime.coord.active_leases();
         self.coord_handoffs = self.runtime.coord.pending_handoffs();
         self.coord_pending_interrupts = self.runtime.coord.pending_interrupts();
+        self.coord_tasks = self.runtime.coord.tasks();
+        if self.supervisor_selected >= self.coord_tasks.len() {
+            self.supervisor_selected = self.coord_tasks.len().saturating_sub(1);
+        }
 
         self.coord_lease_sessions = self
             .coord_leases
@@ -1465,6 +1487,47 @@ impl App {
             .iter()
             .map(|i| i.target_session_id.clone())
             .collect();
+    }
+
+    /// Open the full-screen Supervisor task panel (#368).
+    #[cfg(feature = "coord")]
+    pub fn open_supervisor_overlay(&mut self) {
+        self.coord_refresh();
+        self.supervisor_selected = 0;
+        self.supervisor_status_msg = None;
+        self.show_supervisor = true;
+    }
+
+    /// Keymap for the Supervisor panel: j/k navigate, r refresh, Esc/T/q close.
+    /// Read-only for now (#368, increment 1).
+    #[cfg(feature = "coord")]
+    fn handle_supervisor_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('T') | KeyCode::Char('q') => {
+                self.show_supervisor = false;
+                self.supervisor_status_msg = None;
+            }
+            KeyCode::Char('r') => {
+                self.coord_refresh();
+                self.supervisor_status_msg = Some("Refreshed.".into());
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                let last = self.coord_tasks.len().saturating_sub(1);
+                if self.supervisor_selected < last {
+                    self.supervisor_selected += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if self.supervisor_selected > 0 {
+                    self.supervisor_selected -= 1;
+                }
+            }
+            KeyCode::Char('g') | KeyCode::Home => self.supervisor_selected = 0,
+            KeyCode::Char('G') | KeyCode::End => {
+                self.supervisor_selected = self.coord_tasks.len().saturating_sub(1);
+            }
+            _ => {}
+        }
     }
 
     #[cfg(feature = "coord")]
@@ -1953,6 +2016,13 @@ impl App {
         // Brain overlay: dedicated keymap (j/k navigate, Tab switch, m mark, n note, r refresh, Esc/B close)
         if self.show_brain {
             self.handle_brain_key(key);
+            return true;
+        }
+
+        // Supervisor overlay: dedicated keymap (j/k navigate, r refresh, Esc/T close)
+        #[cfg(feature = "coord")]
+        if self.show_supervisor {
+            self.handle_supervisor_key(key);
             return true;
         }
 
@@ -2475,6 +2545,12 @@ impl App {
                 self.cancel_pending_kill();
                 self.cancel_pending_auto_approve();
                 self.open_brain_overlay();
+            }
+            #[cfg(feature = "coord")]
+            (KeyCode::Char('T'), _) => {
+                self.cancel_pending_kill();
+                self.cancel_pending_auto_approve();
+                self.open_supervisor_overlay();
             }
             (KeyCode::Char('s'), _) => {
                 self.cancel_pending_kill();

--- a/crates/claudectl-tui/src/ui/help.rs
+++ b/crates/claudectl-tui/src/ui/help.rs
@@ -123,6 +123,10 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
             Span::raw("  Brain Metrics — scorecard + interactive review/teach loop"),
         ]),
         Line::from(vec![
+            Span::styled("  T              ", Style::default().fg(t.highlight_key)),
+            Span::raw("  Supervisor — task ledger (state, attempts, session)"),
+        ]),
+        Line::from(vec![
             Span::styled("  ?              ", Style::default().fg(t.highlight_key)),
             Span::raw("  Toggle this help"),
         ]),

--- a/crates/claudectl-tui/src/ui/mod.rs
+++ b/crates/claudectl-tui/src/ui/mod.rs
@@ -7,4 +7,6 @@ pub mod help;
 pub mod peers;
 pub mod skills;
 pub mod status_bar;
+#[cfg(feature = "coord")]
+pub mod supervisor;
 pub mod table;

--- a/crates/claudectl-tui/src/ui/supervisor.rs
+++ b/crates/claudectl-tui/src/ui/supervisor.rs
@@ -1,0 +1,212 @@
+// Full-screen Supervisor mode. When `app.show_supervisor` is set, the main
+// draw loop hands the whole frame to `render_supervisor_screen` instead of the
+// session table. It renders the coord task ledger — one row per supervisor
+// task lifecycle (state, attempts, latest session) — so an operator can see
+// tracked, verified work without dropping to `claudectl supervisor status`.
+//
+// Read-only for now (#368, increment 1). One-key retry/approve/cancel/drain
+// and the cost + verifier-verdict columns are the next increment.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+
+use crate::app::App;
+use claudectl_core::runtime::TaskSummary;
+use claudectl_core::theme::Theme;
+
+/// Color a task state by lifecycle phase, reusing the session status palette so
+/// the dashboard and the supervisor panel read consistently.
+fn state_color(state: &str, t: &Theme) -> Color {
+    match state {
+        "done" => t.status_finished,
+        "needs_human" => t.status_needs_input,
+        "running" | "verifying" | "assigned" => t.status_processing,
+        "retrying" | "resuming" => t.status_waiting,
+        "cancelled" => t.error,
+        _ => t.text_muted, // pending / ready
+    }
+}
+
+/// Last path segment of a session id / uuid, truncated for the narrow column.
+fn short_session(id: &str) -> String {
+    let tail = id.rsplit(['/', '-']).next().unwrap_or(id);
+    tail.chars().take(8).collect()
+}
+
+pub fn render_supervisor_screen(frame: &mut Frame, area: Rect, app: &App) {
+    let t = &app.theme;
+
+    let title = Line::from(vec![
+        Span::styled(" claudectl ", Style::default().fg(t.text_primary)),
+        Span::styled(
+            "│ Supervisor ",
+            Style::default().fg(t.header).add_modifier(Modifier::BOLD),
+        ),
+    ]);
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(t.border));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // column header
+            Constraint::Min(1),    // task list
+            Constraint::Length(1), // footer hint
+        ])
+        .split(inner);
+
+    render_header(frame, layout[0], t);
+    render_task_list(frame, layout[1], app);
+    render_footer(frame, layout[2], app);
+}
+
+fn render_header(frame: &mut Frame, area: Rect, t: &Theme) {
+    let header = format!(
+        " {:<10} {:>6}  {:<28} {:<10} {:<10} {}",
+        "STATE", "TRIES", "TASK", "ROLE", "SESSION", "UPDATED"
+    );
+    let p = Paragraph::new(Line::from(Span::styled(
+        header,
+        Style::default().fg(t.header).add_modifier(Modifier::BOLD),
+    )));
+    frame.render_widget(p, area);
+}
+
+fn render_task_list(frame: &mut Frame, area: Rect, app: &App) {
+    let t = &app.theme;
+    let tasks: &[TaskSummary] = &app.coord_tasks;
+
+    if tasks.is_empty() {
+        let empty = Paragraph::new(Line::from(Span::styled(
+            "  No supervisor tasks. Submit with `claudectl supervisor run tasks.toml`.",
+            Style::default().fg(t.text_muted),
+        )));
+        frame.render_widget(empty, area);
+        return;
+    }
+
+    let selected = app.supervisor_selected.min(tasks.len().saturating_sub(1));
+    let items: Vec<ListItem> = tasks
+        .iter()
+        .enumerate()
+        .map(|(i, task)| {
+            let is_sel = i == selected;
+            let tries = format!("{}/{}", task.attempts, task.max_retries);
+            let session = task
+                .last_session_id
+                .as_deref()
+                .map(short_session)
+                .unwrap_or_else(|| "—".into());
+            let role = task.role.as_deref().unwrap_or("—");
+            let updated = task
+                .updated_at
+                .split('T')
+                .nth(1)
+                .unwrap_or(&task.updated_at);
+            let updated = updated.trim_end_matches('Z');
+
+            let row = Line::from(vec![
+                Span::raw(if is_sel { " ▸ " } else { "   " }),
+                Span::styled(
+                    format!("{:<8}", task.state),
+                    Style::default()
+                        .fg(state_color(&task.state, t))
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(format!("{tries:>6}  "), Style::default().fg(t.text_muted)),
+                Span::styled(
+                    format!("{:<28}", truncate(&task.name, 28)),
+                    Style::default().fg(t.text_primary),
+                ),
+                Span::styled(
+                    format!("{:<10} ", truncate(role, 10)),
+                    Style::default().fg(t.text_muted),
+                ),
+                Span::styled(format!("{session:<10} "), Style::default().fg(t.text_muted)),
+                Span::styled(updated.to_string(), Style::default().fg(t.text_muted)),
+            ]);
+            let style = if is_sel {
+                Style::default().bg(t.border)
+            } else {
+                Style::default()
+            };
+            ListItem::new(row).style(style)
+        })
+        .collect();
+
+    frame.render_widget(List::new(items), area);
+}
+
+fn render_footer(frame: &mut Frame, area: Rect, app: &App) {
+    let t = &app.theme;
+    if let Some(msg) = app
+        .supervisor_status_msg
+        .as_deref()
+        .filter(|m| !m.is_empty())
+    {
+        let p = Paragraph::new(Line::from(Span::styled(
+            format!("  {msg}"),
+            Style::default().fg(t.success),
+        )));
+        frame.render_widget(p, area);
+        return;
+    }
+    let hint = Line::from(vec![
+        Span::styled("  j/k", Style::default().fg(t.highlight_key)),
+        Span::styled(" move  ", Style::default().fg(t.text_muted)),
+        Span::styled("r", Style::default().fg(t.highlight_key)),
+        Span::styled(" refresh  ", Style::default().fg(t.text_muted)),
+        Span::styled("Esc/T", Style::default().fg(t.highlight_key)),
+        Span::styled(" close", Style::default().fg(t.text_muted)),
+    ]);
+    frame.render_widget(Paragraph::new(hint), area);
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let kept: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{kept}…")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_keeps_short_strings() {
+        assert_eq!(truncate("short", 28), "short");
+    }
+
+    #[test]
+    fn truncate_clips_long_strings_with_ellipsis() {
+        let out = truncate("0123456789", 5);
+        assert_eq!(out.chars().count(), 5);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn short_session_takes_trailing_segment() {
+        assert_eq!(short_session("path/to/sess-abcdef1234"), "abcdef12");
+        assert_eq!(short_session("plainid"), "plainid");
+    }
+
+    #[test]
+    fn state_color_distinguishes_terminal_states() {
+        let t = Theme::from_mode(claudectl_core::theme::ThemeMode::Dark);
+        assert_eq!(state_color("done", &t), t.status_finished);
+        assert_eq!(state_color("needs_human", &t), t.status_needs_input);
+        assert_eq!(state_color("cancelled", &t), t.error);
+        // Unknown / pending falls back to muted.
+        assert_eq!(state_color("pending", &t), t.text_muted);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1258,6 +1258,13 @@ fn run_tui<W: io::Write>(
                 return;
             }
 
+            // Full-screen mode: Supervisor task ledger (#368).
+            #[cfg(feature = "coord")]
+            if app.show_supervisor {
+                ui::supervisor::render_supervisor_screen(frame, area, &app);
+                return;
+            }
+
             #[cfg(feature = "relay")]
             let main_area = if app.show_peers_panel {
                 let chunks = ratatui::layout::Layout::default()

--- a/src/runtime/coord.rs
+++ b/src/runtime/coord.rs
@@ -4,7 +4,9 @@
 //! store. Without it, every accessor returns an empty list so the TUI can
 //! render the "no coord" state without conditional compilation.
 
-use claudectl_core::runtime::{CoordView, HandoffSummary, InterruptSummary, LeaseSummary};
+use claudectl_core::runtime::{
+    CoordView, HandoffSummary, InterruptSummary, LeaseSummary, TaskSummary,
+};
 
 pub struct LiveCoordView;
 
@@ -57,6 +59,41 @@ impl CoordView for LiveCoordView {
     }
     #[cfg(not(feature = "coord"))]
     fn pending_interrupts(&self) -> Vec<InterruptSummary> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "coord")]
+    fn tasks(&self) -> Vec<TaskSummary> {
+        use crate::coord::{store, tasks};
+        let Ok(conn) = store::open() else {
+            return Vec::new();
+        };
+        // `list_tasks` is ORDER BY created_at (oldest-first); reverse so the
+        // panel shows newest tasks on top. Derive attempt count + latest
+        // session per task — both cheap indexed lookups.
+        tasks::list_tasks(&conn, None)
+            .unwrap_or_default()
+            .into_iter()
+            .rev()
+            .map(|t| {
+                let attempts = tasks::attempt_count(&conn, &t.id).unwrap_or(0);
+                let last_session_id = tasks::latest_session_id(&conn, &t.id).ok().flatten();
+                TaskSummary {
+                    id: t.id,
+                    name: t.name,
+                    state: t.state.as_str().to_string(),
+                    role: t.role,
+                    attempts,
+                    max_retries: t.max_retries,
+                    last_session_id,
+                    created_at: t.created_at,
+                    updated_at: t.updated_at,
+                }
+            })
+            .collect()
+    }
+    #[cfg(not(feature = "coord"))]
+    fn tasks(&self) -> Vec<TaskSummary> {
         Vec::new()
     }
 }


### PR DESCRIPTION
Closes part of #368 (increment 1 — read-only). Part of epic #367.

## Why
The supervisor (`src/coord/` — durable, verified task lifecycles) was **CLI-only**. Nothing in `claudectl-tui` rendered it, so the dashboard showed raw sessions but not the *task* lifecycles that are the real unit of work. A developer couldn't tell babysitting noise from tracked, verified work. This gives the flagship engine a window.

## What (increment 1 — read-only)
- **Contract extension** (`claudectl-core`): new `TaskSummary` DTO + `CoordView::tasks()`. `MockRuntime` gains a `tasks` fixture field. No upward dependency — `state` is the wire label, not the coord enum.
- **Live adapter** (`src/runtime/coord.rs`): `LiveCoordView::tasks()` reads coord `tasks` newest-first, deriving attempt count + latest session id per task. Returns empty when the `coord` feature is off.
- **Panel** (`crates/claudectl-tui/src/ui/supervisor.rs`): full-screen view — `STATE / TRIES / TASK / ROLE / SESSION / UPDATED`, state-colored to match the session status palette. Empty-state hint points at `supervisor run`.
- **App + keymap**: `T` opens the panel; `j/k/g/G` navigate, `r` refresh, `Esc/T/q` close. Coord-gated state (`coord_tasks`, `show_supervisor`, …) refreshed in `coord_refresh`; draw dispatch + help entry wired. All behind `#[cfg(feature = "coord")]`.

## Testing
- New: core `TaskSummary` round-trip via `MockRuntime`; panel helper unit tests (`truncate` / `short_session` / `state_color`).
- `cargo test` 784 pass; `cargo clippy -- -D warnings` clean; `cargo fmt --check` clean.
- Builds in both default (coord) and `--no-default-features --features hive` configs.

## Follow-up (increment 2, same issue #368)
One-key **retry/approve/cancel/drain** (the write surface), per-task **cost + verifier-verdict** columns, and **sessions↔tasks linkage** in the session table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
