### PR TITLE
chore: bump to 0.58.0 — supervisor TUI panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to claudectl are documented here.
 
+## [0.58.0] - 2026-06-25
+
+### Added — Supervisor TUI panel (#368)
+- **Full-screen Supervisor panel** in the dashboard (press `T`). The durable, verified task engine (`src/coord/`) was CLI-only; this renders the task ledger — `STATE / TRIES / TASK / ROLE / SESSION / UPDATED`, state-colored to match the session palette — so an operator can see tracked, verified work without dropping to `claudectl supervisor status`.
+- Keymap: `T` opens; `j/k/g/G` navigate, `r` refresh, `Esc/T/q` close. Help overlay + draw dispatch wired. All behind the `coord` feature.
+- **Contract extension**: new `TaskSummary` DTO + `CoordView::tasks()` on the UI↔runtime trait. `LiveCoordView::tasks()` reads coord `tasks` newest-first, deriving attempt count + latest session per task.
+
+This is increment 1 (read-only). One-key retry/approve/cancel/drain, per-task cost + verifier-verdict columns, and sessions↔tasks linkage are the next increment of #368.
+
+Workspace crates bumped: `claudectl-core` and `claudectl-tui` → 0.53.0 (the `CoordView` trait gained a method).
+
 ## [0.57.3] - 2026-06-22
 
 ### Fixed — notification cooldown + unified toggle (#364)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.57.3"
+version = "0.58.0"
 edition = "2024"
 # MSRV — bumped to 1.88 in #328 so cargo-install on older toolchains
 # emits a clean "rustc too old" error instead of opaque transitive-dep
@@ -50,8 +50,8 @@ path = "src/lib.rs"
 # published to crates.io. Local builds always use the path; crates.io strips
 # the path and resolves the published version. Bump both when the workspace
 # crates change.
-claudectl-core = { path = "crates/claudectl-core", version = "0.52.2" }
-claudectl-tui = { path = "crates/claudectl-tui", version = "0.52.2" }
+claudectl-core = { path = "crates/claudectl-core", version = "0.53.0" }
+claudectl-tui = { path = "crates/claudectl-tui", version = "0.53.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }

--- a/crates/claudectl-core/Cargo.toml
+++ b/crates/claudectl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-core"
-version = "0.52.2"
+version = "0.53.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Foundational types and IO primitives for claudectl. Shared across the TUI, the binary, and future crates."

--- a/crates/claudectl-tui/Cargo.toml
+++ b/crates/claudectl-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-tui"
-version = "0.52.2"
+version = "0.53.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Terminal UI, dashboard recording, and demo-mode fixtures for claudectl. Splits out of the binary so the TUI can evolve independently of the brain/coord/bus subsystems."
@@ -23,7 +23,7 @@ relay = []
 hive = []
 
 [dependencies]
-claudectl-core = { path = "../claudectl-core", version = "0.52.2" }
+claudectl-core = { path = "../claudectl-core", version = "0.53.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde_json = "1"


### PR DESCRIPTION
Releases the Supervisor TUI panel (#374, merged to `main`; closes part of #368).

Minor bump — new feature, and the `CoordView` trait gained `tasks()` (a breaking change for the 0.x library crates). All three workspace crates are published to crates.io independently, so all three bump:

| crate | from | to |
|---|---|---|
| `claudectl` | 0.57.3 | **0.58.0** |
| `claudectl-core` | 0.52.2 | **0.53.0** |
| `claudectl-tui` | 0.52.2 | **0.53.0** |

Inter-crate version requirements + `Cargo.lock` updated; `CHANGELOG.md` entry added; `claudectl --version` → `0.58.0` verified.

After merge, pushing the `v0.58.0` tag triggers `release.yml` → tarballs + crates.io (core → tui → claudectl) + Homebrew tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
