### PR TITLE
docs: note rustc 1.88+ MSRV in README (closes #328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to claudectl are documented here.
 
+## [Unreleased]
+
+### Documented — MSRV (#328)
+- README install section now states the **rustc 1.88+** requirement for source builds, so users on an older toolchain get a clear fix (`rustup update stable`) instead of an opaque transitive-dependency error. The `rust-version = "1.88"` pin was already in all three crate manifests; this closes the remaining doc gap.
+
 ## [0.58.0] - 2026-06-25
 
 ### Added — Supervisor TUI panel (#368)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ cargo install claudectl                       # Cargo (any platform)
 
 Both produce the same ~6 MB binary with bus/coord/relay/hive enabled — `claudectl bus`, `coord`, `relay`, and `hive` work out of the box. For the minimal ~3.5 MB sync-only build, opt out with `cargo install claudectl --no-default-features --features hive`.
 
+Building from source (Cargo) requires **rustc 1.88+**. Older toolchains fail with an opaque transitive-dependency error before the build starts — run `rustup update stable` first. The Homebrew bottle ships prebuilt and has no toolchain requirement.
+
 <details>
 <summary>Other methods</summary>
 


### PR DESCRIPTION
Closes #328.

The MSRV pin (`rust-version = "1.88"`) is already in all three crate manifests, so Cargo emits a clean error — but the README never documented it. This adds the requirement + the `rustup update stable` fix to the install section, plus a CHANGELOG note. Docs-only; no code change.

This finishes the last open item of #328 (the code pins landed earlier; README note + CHANGELOG were outstanding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
