### PR TITLE
feat(supervisor): tasks.toml scaffolding + validation (#371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to claudectl are documented here.
 
 ## [Unreleased]
 
+### Added — supervisor tasks.toml scaffolding + validation (#371)
+- **`claudectl supervisor init`** scaffolds a documented starter `tasks.toml` in the cwd (every optional key present but commented). Refuses to overwrite without `--force`.
+- **`claudectl supervisor validate <file>`** parses + validates without submitting, reporting the first problem with context — missing required field, dangling `depends_on`, or duplicate task name — instead of failing at insert time. `supervisor run` now runs the same validation before inserting.
+- New **`examples/tasks/`** directory: `fan-out.toml`, `dependency-chain.toml`, `verify-then-merge.toml`. A test asserts the scaffold and all shipped examples parse and validate.
+
 ### Documented — MSRV (#328)
 - README install section now states the **rustc 1.88+** requirement for source builds, so users on an older toolchain get a clear fix (`rustup update stable`) instead of an opaque transitive-dependency error. The `rust-version = "1.88"` pin was already in all three crate manifests; this closes the remaining doc gap.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -189,7 +189,9 @@ Durable task lifecycles on top of the bus. See the [README's Supervisor section]
 
 | Command | Description |
 |---------|-------------|
-| `supervisor run <tasks.toml> [--dry-run]` | Batch-submit one or more tasks from a TOML file (RFC §4 shape) |
+| `supervisor init [--force]` | Scaffold a documented starter `tasks.toml` in the cwd (won't clobber without `--force`) |
+| `supervisor validate <tasks.toml>` | Parse + validate without submitting — reports the first problem (missing field, dangling `depends_on`, duplicate name) |
+| `supervisor run <tasks.toml> [--dry-run]` | Batch-submit one or more tasks from a TOML file (RFC §4 shape); validated before insert |
 | `supervisor submit --name --cwd --prompt [--role ...]` | One-shot inline submission |
 | `supervisor status [--state STATE]` | Compact task table; optional state filter (`PENDING` / `RUNNING` / `DONE` / `NEEDS_HUMAN` / …) |
 | `supervisor logs <task_id>` | Task detail + full transition log |

--- a/examples/tasks/dependency-chain.toml
+++ b/examples/tasks/dependency-chain.toml
@@ -1,0 +1,24 @@
+# dependency-chain.toml — ordered tasks via depends_on.
+# `migrate` runs first; `backfill` waits for it; `verify-data` waits for
+# backfill. The supervisor won't assign a task until every name in its
+# depends_on list has reached a terminal DONE state.
+#
+#   claudectl supervisor validate examples/tasks/dependency-chain.toml
+#   claudectl supervisor run examples/tasks/dependency-chain.toml
+
+[[task]]
+name = "migrate"
+cwd = "."
+prompt = "Write and apply the schema migration for the new users table."
+
+[[task]]
+name = "backfill"
+cwd = "."
+prompt = "Backfill the new users table from the legacy store."
+depends_on = ["migrate"]
+
+[[task]]
+name = "verify-data"
+cwd = "."
+prompt = "Verify row counts match between legacy and new tables."
+depends_on = ["backfill"]

--- a/examples/tasks/fan-out.toml
+++ b/examples/tasks/fan-out.toml
@@ -1,0 +1,26 @@
+# fan-out.toml — independent tasks that run in parallel.
+# No depends_on, so the supervisor assigns all three on the same tick
+# (subject to the max-concurrent ceiling). Use this shape when you want
+# several agents working unrelated areas of the codebase at once.
+#
+#   claudectl supervisor run examples/tasks/fan-out.toml --dry-run
+#   claudectl supervisor run examples/tasks/fan-out.toml
+
+[[task]]
+name = "docs-sweep"
+cwd = "."
+prompt = "Find and fix stale references in the docs/ directory."
+role = "docs"
+
+[[task]]
+name = "dep-audit"
+cwd = "."
+prompt = "Audit Cargo.toml dependencies for CVEs and unused crates; report only."
+role = "security"
+
+[[task]]
+name = "test-coverage"
+cwd = "."
+prompt = "Add unit tests for the least-covered module you can find."
+role = "backend"
+budget_usd = 5.0

--- a/examples/tasks/verify-then-merge.toml
+++ b/examples/tasks/verify-then-merge.toml
@@ -1,0 +1,21 @@
+# verify-then-merge.toml — a single task gated by verifiers.
+# On VERIFYING the supervisor runs the verifiers in order and stops at the
+# first FAIL. A `run` verifier passes on exit code 0; a `brain` verifier
+# asks the local LLM a yes/no question. Use this shape when a task must
+# prove itself before it counts as DONE.
+#
+#   claudectl supervisor run examples/tasks/verify-then-merge.toml
+
+[[task]]
+name = "fix-flaky-test"
+cwd = "."
+prompt = "Diagnose and fix the flaky test in the auth module."
+role = "backend"
+max_retries = 3
+budget_usd = 8.0
+
+[[task.verify]]
+run = "cargo test --quiet"
+
+[[task.verify]]
+brain = "Did the fix address the root cause rather than just adding a retry or sleep?"

--- a/src/coord/supervisor_cli.rs
+++ b/src/coord/supervisor_cli.rs
@@ -28,6 +28,21 @@ pub enum SupervisorCommand {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Scaffold a starter `tasks.toml` in the current directory, with the
+    /// full key set documented inline. Refuses to clobber an existing file
+    /// unless `--force`.
+    Init {
+        /// Overwrite an existing tasks.toml.
+        #[arg(long)]
+        force: bool,
+    },
+    /// Parse + validate a `tasks.toml` without submitting anything. Reports
+    /// the first problem with a clear message (missing field, dangling
+    /// dependency, duplicate name) instead of failing at insert time.
+    Validate {
+        /// Path to the `tasks.toml` to check.
+        file: PathBuf,
+    },
     /// Submit a single task inline. Useful for one-shot scripts that
     /// don't want to author a TOML file.
     Submit {
@@ -73,6 +88,8 @@ pub enum SupervisorCommand {
 pub fn dispatch(cmd: &SupervisorCommand) -> io::Result<()> {
     match cmd {
         SupervisorCommand::Run { file, dry_run } => run_from_file(file, *dry_run),
+        SupervisorCommand::Init { force } => write_scaffold(*force),
+        SupervisorCommand::Validate { file } => validate_from_file(file),
         SupervisorCommand::Submit {
             name,
             cwd,
@@ -135,6 +152,7 @@ fn submit_inline(
 fn run_from_file(path: &PathBuf, dry_run: bool) -> io::Result<()> {
     let body = std::fs::read_to_string(path)?;
     let parsed: TaskFile = toml_parse(&body).map_err(io::Error::other)?;
+    validate_tasks(&parsed).map_err(io::Error::other)?;
     if dry_run {
         for task in &parsed.task {
             println!("[dry-run] would submit: {}", task.name);
@@ -254,6 +272,100 @@ fn set_drain(enabled: bool) -> io::Result<()> {
                 println!("(no drain marker)");
             }
             Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+// ---------- Scaffolding + validation (#371) ----------------------------------
+
+/// Starter `tasks.toml` written by `supervisor init`. Every optional key is
+/// present but commented, so the file both runs as-is and documents the schema.
+/// Kept in sync with `TaskEntry` / `toml_parse` — the test below asserts it
+/// parses and validates.
+const SCAFFOLD: &str = r#"# tasks.toml — claudectl supervisor task declarations (RFC §4 shape).
+#   Submit:    claudectl supervisor run tasks.toml
+#   Preview:   claudectl supervisor run tasks.toml --dry-run
+#   Validate:  claudectl supervisor validate tasks.toml
+
+[[task]]
+name = "example-task"
+cwd = "."
+prompt = "Describe the work this agent should do."
+# role = "backend"             # bus role to assign this task to
+# model = "claude-opus-4-8"    # model override for the spawned session
+# budget_usd = 5.0             # per-task spend cap
+# max_retries = 2              # retry budget (default comes from config)
+# timeout_min = 30             # wall-clock timeout
+# depends_on = ["other-task"]  # run only after these task names finish
+
+# Verifier gates run in order on VERIFYING; the first FAIL stops the task.
+# [[task.verify]]
+# run = "cargo test"           # shell command — non-zero exit is a FAIL
+#
+# [[task.verify]]
+# brain = "Did the change keep the public API stable?"
+"#;
+
+/// Write the scaffold to `./tasks.toml`. Refuses to overwrite without `force`.
+fn write_scaffold(force: bool) -> io::Result<()> {
+    let path = PathBuf::from("tasks.toml");
+    if path.exists() && !force {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "tasks.toml already exists — pass --force to overwrite",
+        ));
+    }
+    std::fs::write(&path, SCAFFOLD)?;
+    println!("wrote {}", path.display());
+    println!("next: edit it, then `claudectl supervisor run tasks.toml --dry-run`");
+    Ok(())
+}
+
+/// Parse + validate a file without touching the store.
+fn validate_from_file(path: &PathBuf) -> io::Result<()> {
+    let body = std::fs::read_to_string(path)?;
+    let parsed = toml_parse(&body).map_err(io::Error::other)?;
+    validate_tasks(&parsed).map_err(io::Error::other)?;
+    println!("{}: {} task(s), valid", path.display(), parsed.task.len());
+    Ok(())
+}
+
+/// Semantic checks the structural TOML reader can't make: required fields are
+/// present, dependency names resolve within the file, and names are unique.
+/// Returns the first problem with enough context to fix it.
+fn validate_tasks(tf: &TaskFile) -> Result<(), String> {
+    if tf.task.is_empty() {
+        return Err("no [[task]] blocks found".into());
+    }
+    let names: Vec<&str> = tf.task.iter().map(|t| t.name.as_str()).collect();
+    let mut seen = std::collections::HashSet::new();
+    for (i, t) in tf.task.iter().enumerate() {
+        let label = if t.name.trim().is_empty() {
+            format!("task #{}", i + 1)
+        } else {
+            format!("task #{} ({})", i + 1, t.name)
+        };
+        if t.name.trim().is_empty() {
+            return Err(format!("{label}: missing required `name`"));
+        }
+        if t.cwd.trim().is_empty() {
+            return Err(format!("{label}: missing required `cwd`"));
+        }
+        if t.prompt.trim().is_empty() {
+            return Err(format!("{label}: missing required `prompt`"));
+        }
+        if !seen.insert(t.name.as_str()) {
+            return Err(format!("{label}: duplicate task name `{}`", t.name));
+        }
+        if let Some(deps) = &t.depends_on {
+            for d in deps {
+                if !names.contains(&d.as_str()) {
+                    return Err(format!(
+                        "{label}: depends_on `{d}` — no task with that name in this file"
+                    ));
+                }
+            }
         }
     }
     Ok(())
@@ -499,5 +611,70 @@ prompt = "do"
 flavour = "vanilla"
 "#;
         assert!(toml_parse(body).is_err());
+    }
+
+    #[test]
+    fn scaffold_parses_and_validates() {
+        let parsed = toml_parse(SCAFFOLD).expect("scaffold parses");
+        assert_eq!(parsed.task.len(), 1);
+        validate_tasks(&parsed).expect("scaffold validates");
+    }
+
+    #[test]
+    fn shipped_examples_parse_and_validate() {
+        for body in [
+            include_str!("../../examples/tasks/fan-out.toml"),
+            include_str!("../../examples/tasks/dependency-chain.toml"),
+            include_str!("../../examples/tasks/verify-then-merge.toml"),
+        ] {
+            let parsed = toml_parse(body).expect("example parses");
+            validate_tasks(&parsed).expect("example validates");
+        }
+    }
+
+    #[test]
+    fn validate_rejects_missing_required_field() {
+        // Empty prompt — structurally valid TOML, semantically incomplete.
+        let body = r#"
+[[task]]
+name = "x"
+cwd = "/x"
+prompt = ""
+"#;
+        let parsed = toml_parse(body).expect("parse");
+        let err = validate_tasks(&parsed).unwrap_err();
+        assert!(err.contains("prompt"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_dangling_dependency() {
+        let body = r#"
+[[task]]
+name = "a"
+cwd = "/a"
+prompt = "do a"
+depends_on = ["ghost"]
+"#;
+        let parsed = toml_parse(body).expect("parse");
+        let err = validate_tasks(&parsed).unwrap_err();
+        assert!(err.contains("ghost"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_names() {
+        let body = r#"
+[[task]]
+name = "dup"
+cwd = "/a"
+prompt = "do a"
+
+[[task]]
+name = "dup"
+cwd = "/b"
+prompt = "do b"
+"#;
+        let parsed = toml_parse(body).expect("parse");
+        let err = validate_tasks(&parsed).unwrap_err();
+        assert!(err.contains("duplicate"), "got: {err}");
     }
 }


### PR DESCRIPTION
Closes #371. Part of epic #367 (developer effectiveness) — a quick win that lowers the on-ramp to the supervisor panel shipped in #368.

## Why
The supervisor's only on-ramp was a hand-written `tasks.toml`, and the structural TOML reader didn't catch semantic mistakes — an empty `[[task]]` parsed fine and then produced a task with empty name/cwd/prompt at insert time.

## What
- **`claudectl supervisor init [--force]`** — scaffold a documented starter `tasks.toml` in the cwd (every optional key present but commented, so it runs as-is *and* documents the schema). Refuses to overwrite without `--force`.
- **`claudectl supervisor validate <file>`** — parse + validate without submitting, reporting the first problem with context: missing required field, dangling `depends_on`, or duplicate task name. `supervisor run` now runs the same validation **before** inserting.
- **`examples/tasks/`** — `fan-out.toml`, `dependency-chain.toml`, `verify-then-merge.toml`. A test asserts the scaffold and all shipped examples parse and validate, so they can't silently rot.

## Testing
- 5 new tests (scaffold round-trip, examples round-trip, missing-field / dangling-dep / duplicate-name rejection). `cargo test` 785 pass.
- clippy `-D warnings` + fmt clean; both default and minimal (`--no-default-features --features hive`) builds compile.
- Smoke-tested end-to-end: `init` → `validate` → `run --dry-run` → `init` refuses overwrite → shipped example validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
