### PR TITLE
feat(forecast): EWMA burn rate + budget-ETA band (#370 increment 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to claudectl are documented here.
 
 ## [Unreleased]
 
+### Added — budget-ETA cost forecasting (#370, increment 1)
+- The dashboard detail panel now shows a **Budget ETA** when a per-session budget is set: smoothed time-to-cap with a p10/p90 band (e.g. `~1h20m  (range ~40m–~3h10m)`).
+- Burn rate is now folded into an **EWMA** (~45s half-life) instead of being read off a single tick, so the forecast tracks real spend regime changes without flickering on bursty token usage. The ETA interval comes from the p10/p90 of recent samples, so auto-actions can later gate on the conservative bound.
+- New pure, fully-tested `claudectl_core::forecast` module (EWMA, percentile, ETA band, formatting). Model routing — the other half of #370 — is a separate increment.
+
 ### Added — supervisor tasks.toml scaffolding + validation (#371)
 - **`claudectl supervisor init`** scaffolds a documented starter `tasks.toml` in the cwd (every optional key present but commented). Refuses to overwrite without `--force`.
 - **`claudectl supervisor validate <file>`** parses + validates without submitting, reporting the first problem with context — missing required field, dangling `depends_on`, or duplicate task name — instead of failing at insert time. `supervisor run` now runs the same validation before inserting.

--- a/crates/claudectl-core/src/forecast.rs
+++ b/crates/claudectl-core/src/forecast.rs
@@ -1,0 +1,176 @@
+//! Cost burn-rate smoothing + budget-ETA forecasting (#370).
+//!
+//! Agent token spend is bursty — one large tool result or context dump spikes
+//! cost for a single tick — so an *instantaneous* burn rate (one tick's cost
+//! delta) flickers, and any ETA derived from it jumps around and triggers false
+//! "about to blow budget" alarms. Two fixes, both here and both pure:
+//!
+//! 1. Smooth the rate with an EWMA (exponentially-weighted moving average) at a
+//!    fixed half-life, so the rate tracks real regime changes without lurching.
+//! 2. Because the burn distribution is heavy-tailed, report the budget ETA as an
+//!    interval (from the p90/p10 of recent samples) rather than a single point.
+//!
+//! All functions are deterministic and take their inputs explicitly so the
+//! forecasting math is unit-testable without a clock or a live session.
+
+/// How many recent instantaneous burn samples to retain per session for the
+/// percentile band.
+pub const BURN_SAMPLE_CAP: usize = 30;
+
+/// EWMA half-life in wall-clock seconds. A sample's influence halves every
+/// ~45s, which smooths tick-to-tick noise while still reacting within a minute.
+pub const BURN_HALF_LIFE_SECS: f64 = 45.0;
+
+/// EWMA weight on the newest sample for a given half-life. `half_life` and
+/// `interval` share a unit (seconds). Larger interval (or shorter half-life)
+/// ⇒ more weight on the new sample.
+pub fn alpha_for_half_life(half_life_secs: f64, interval_secs: f64) -> f64 {
+    if half_life_secs <= 0.0 {
+        return 1.0;
+    }
+    1.0 - 0.5_f64.powf(interval_secs / half_life_secs)
+}
+
+/// One EWMA step. `prev == None` seeds the average with the sample.
+pub fn ewma(prev: Option<f64>, sample: f64, alpha: f64) -> f64 {
+    match prev {
+        Some(p) => alpha * sample + (1.0 - alpha) * p,
+        None => sample,
+    }
+}
+
+/// Linear-interpolated percentile of an unsorted slice. `p` in `0.0..=1.0`.
+/// Returns `None` for an empty slice.
+pub fn percentile(samples: &[f64], p: f64) -> Option<f64> {
+    if samples.is_empty() {
+        return None;
+    }
+    let mut v: Vec<f64> = samples.to_vec();
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let p = p.clamp(0.0, 1.0);
+    let idx = p * (v.len() as f64 - 1.0);
+    let lo = idx.floor() as usize;
+    let hi = idx.ceil() as usize;
+    let frac = idx - lo as f64;
+    Some(v[lo] + (v[hi] - v[lo]) * frac)
+}
+
+/// Hours until `headroom_usd` is exhausted at `burn_per_hr`. `None` when the
+/// burn is effectively zero (never runs out); `Some(0.0)` when headroom is
+/// already gone.
+pub fn eta_hours(headroom_usd: f64, burn_per_hr: f64) -> Option<f64> {
+    if burn_per_hr <= 1e-6 {
+        return None;
+    }
+    if headroom_usd <= 0.0 {
+        return Some(0.0);
+    }
+    Some(headroom_usd / burn_per_hr)
+}
+
+/// Budget-ETA interval. `low` is the soonest exhaustion (computed from the fast
+/// p90 burn), `high` the latest (slow p10 burn), `mid` from the smoothed rate.
+/// Auto-actions should gate on `low` (the conservative bound), not `mid`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EtaBand {
+    pub low_hours: Option<f64>,
+    pub mid_hours: Option<f64>,
+    pub high_hours: Option<f64>,
+}
+
+/// Forecast time-to-budget from current headroom, the smoothed burn, and the
+/// recent sample window. Falls back to the smoothed rate when there aren't
+/// enough samples for meaningful percentiles.
+pub fn budget_eta_band(headroom_usd: f64, smoothed_burn: f64, samples: &[f64]) -> EtaBand {
+    let p90 = percentile(samples, 0.9).unwrap_or(smoothed_burn);
+    let p10 = percentile(samples, 0.1).unwrap_or(smoothed_burn);
+    EtaBand {
+        low_hours: eta_hours(headroom_usd, p90),
+        mid_hours: eta_hours(headroom_usd, smoothed_burn),
+        high_hours: eta_hours(headroom_usd, p10),
+    }
+}
+
+/// Human-readable ETA: `"~12m"`, `"~3h40m"`, `">24h"`, `"now"`, or `"—"`.
+pub fn format_eta(hours: Option<f64>) -> String {
+    match hours {
+        None => "—".into(),
+        Some(h) if h <= 0.0 => "now".into(),
+        Some(h) if h >= 24.0 => ">24h".into(),
+        Some(h) => {
+            let total_min = (h * 60.0).round() as i64;
+            let hh = total_min / 60;
+            let mm = total_min % 60;
+            if hh > 0 {
+                format!("~{hh}h{mm:02}m")
+            } else {
+                format!("~{mm}m")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ewma_seeds_then_smooths() {
+        let a = 0.5;
+        let seeded = ewma(None, 10.0, a);
+        assert_eq!(seeded, 10.0);
+        // One step toward a smaller sample moves halfway at alpha=0.5.
+        assert_eq!(ewma(Some(10.0), 0.0, a), 5.0);
+    }
+
+    #[test]
+    fn ewma_resists_a_single_spike() {
+        // A small alpha (long half-life) barely reacts to one big spike.
+        let alpha = alpha_for_half_life(45.0, 2.0);
+        let after = ewma(Some(1.0), 100.0, alpha);
+        assert!(after < 6.0, "one spike moved EWMA too far: {after}");
+    }
+
+    #[test]
+    fn alpha_in_unit_range_and_monotonic() {
+        let a = alpha_for_half_life(45.0, 2.0);
+        assert!(a > 0.0 && a < 1.0);
+        // Shorter half-life ⇒ more weight on the new sample.
+        assert!(alpha_for_half_life(10.0, 2.0) > a);
+    }
+
+    #[test]
+    fn percentile_interpolates() {
+        let s = [1.0, 2.0, 3.0, 4.0];
+        assert_eq!(percentile(&s, 0.0), Some(1.0));
+        assert_eq!(percentile(&s, 1.0), Some(4.0));
+        assert_eq!(percentile(&s, 0.5), Some(2.5));
+        assert_eq!(percentile(&[], 0.5), None);
+    }
+
+    #[test]
+    fn eta_hours_handles_zero_burn_and_spent_budget() {
+        assert_eq!(eta_hours(5.0, 0.0), None);
+        assert_eq!(eta_hours(0.0, 2.0), Some(0.0));
+        assert_eq!(eta_hours(10.0, 5.0), Some(2.0));
+    }
+
+    #[test]
+    fn band_orders_soonest_to_latest() {
+        // headroom $10; samples spread 1..10/hr, smoothed 4/hr.
+        let samples: Vec<f64> = (1..=10).map(|n| n as f64).collect();
+        let b = budget_eta_band(10.0, 4.0, &samples);
+        // fast burn (p90) exhausts sooner than slow burn (p10).
+        assert!(b.low_hours.unwrap() <= b.mid_hours.unwrap());
+        assert!(b.mid_hours.unwrap() <= b.high_hours.unwrap());
+    }
+
+    #[test]
+    fn format_eta_renders_buckets() {
+        assert_eq!(format_eta(None), "—");
+        assert_eq!(format_eta(Some(0.0)), "now");
+        assert_eq!(format_eta(Some(0.2)), "~12m");
+        assert_eq!(format_eta(Some(3.0 + 40.0 / 60.0)), "~3h40m");
+        assert_eq!(format_eta(Some(50.0)), ">24h");
+    }
+}

--- a/crates/claudectl-core/src/lib.rs
+++ b/crates/claudectl-core/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod config;
 pub mod discovery;
+pub mod forecast;
 pub mod health;
 pub mod helpers;
 pub mod history;

--- a/crates/claudectl-core/src/session.rs
+++ b/crates/claudectl-core/src/session.rs
@@ -123,6 +123,12 @@ pub struct ClaudeSession {
     pub context_max: u64,
     pub prev_cost_usd: f64,
     pub burn_rate_per_hr: f64,
+    /// EWMA-smoothed burn rate ($/hr) used for budget forecasting. Damps the
+    /// tick-to-tick flicker of `burn_rate_per_hr`. See `forecast` (#370).
+    pub burn_rate_ewma: f64,
+    /// Recent instantaneous burn samples ($/hr), capped at `BURN_SAMPLE_CAP`,
+    /// for the p10/p90 ETA band. In-memory only (rebuilt at runtime).
+    pub burn_samples: std::collections::VecDeque<f64>,
     pub subagent_count: usize,
     pub active_subagent_count: usize,
     pub active_subagent_jsonl_paths: Vec<PathBuf>,
@@ -328,6 +334,8 @@ impl ClaudeSession {
             context_max: 0,
             prev_cost_usd: 0.0,
             burn_rate_per_hr: 0.0,
+            burn_rate_ewma: 0.0,
+            burn_samples: std::collections::VecDeque::new(),
             subagent_count: 0,
             active_subagent_count: 0,
             active_subagent_jsonl_paths: Vec::new(),
@@ -397,6 +405,35 @@ impl ClaudeSession {
             self.current_window_errors = 0;
             self.window_tick_counter = 0;
         }
+    }
+
+    /// Fold the current instantaneous `burn_rate_per_hr` into the EWMA and the
+    /// rolling sample window. Call once per refresh after burn is recomputed.
+    /// `interval_secs` is the refresh cadence (shapes the EWMA half-life).
+    pub fn record_burn_sample(&mut self, interval_secs: f64) {
+        let sample = self.burn_rate_per_hr;
+        let alpha = crate::forecast::alpha_for_half_life(
+            crate::forecast::BURN_HALF_LIFE_SECS,
+            interval_secs,
+        );
+        let prev = if self.burn_samples.is_empty() {
+            None
+        } else {
+            Some(self.burn_rate_ewma)
+        };
+        self.burn_rate_ewma = crate::forecast::ewma(prev, sample, alpha);
+        self.burn_samples.push_back(sample);
+        while self.burn_samples.len() > crate::forecast::BURN_SAMPLE_CAP {
+            self.burn_samples.pop_front();
+        }
+    }
+
+    /// Forecast time-to-budget for this session given a per-session cap, as a
+    /// p10/p90 interval. `None` when the session isn't burning or has no cap.
+    pub fn budget_eta(&self, budget_usd: f64) -> crate::forecast::EtaBand {
+        let headroom = budget_usd - self.cost_usd;
+        let samples: Vec<f64> = self.burn_samples.iter().copied().collect();
+        crate::forecast::budget_eta_band(headroom, self.burn_rate_ewma, &samples)
     }
 
     /// Render the sparkline as unicode block characters.
@@ -863,6 +900,35 @@ mod tests {
             cwd: "/tmp/project".into(),
             started_at: 0,
         })
+    }
+
+    #[test]
+    fn record_burn_sample_smooths_and_caps_window() {
+        let mut s = make_session();
+        // A steady burn settles the EWMA near the true rate and fills the window.
+        for _ in 0..crate::forecast::BURN_SAMPLE_CAP + 10 {
+            s.burn_rate_per_hr = 6.0;
+            s.record_burn_sample(2.0);
+        }
+        assert_eq!(s.burn_samples.len(), crate::forecast::BURN_SAMPLE_CAP);
+        assert!(
+            (s.burn_rate_ewma - 6.0).abs() < 0.5,
+            "ewma: {}",
+            s.burn_rate_ewma
+        );
+    }
+
+    #[test]
+    fn budget_eta_forecasts_time_to_cap() {
+        let mut s = make_session();
+        for _ in 0..20 {
+            s.burn_rate_per_hr = 5.0;
+            s.record_burn_sample(2.0);
+        }
+        s.cost_usd = 5.0; // $5 spent of a $15 cap ⇒ $10 headroom at ~$5/hr ≈ 2h
+        let band = s.budget_eta(15.0);
+        let mid = band.mid_hours.expect("burning, so an ETA exists");
+        assert!((mid - 2.0).abs() < 0.4, "eta hours: {mid}");
     }
 
     #[test]

--- a/crates/claudectl-tui/src/app.rs
+++ b/crates/claudectl-tui/src/app.rs
@@ -795,6 +795,10 @@ impl App {
                     }
                 }
             }
+            // Fold the instantaneous rate into the smoothed EWMA + sample window
+            // used for budget forecasting (#370). The 2s constant matches the
+            // `* 1800.0` per-hour conversion above (3600 / 1800 = 2s ticks).
+            session.record_burn_sample(2.0);
         }
 
         // Budget enforcement

--- a/crates/claudectl-tui/src/ui/detail.rs
+++ b/crates/claudectl-tui/src/ui/detail.rs
@@ -123,6 +123,23 @@ pub fn render_detail_panel(frame: &mut Frame, area: Rect, session: &ClaudeSessio
         detail_line("  Estimate", &estimate, t),
     ];
 
+    // Budget ETA forecast (#370): smoothed time-to-cap with a p10/p90 band, only
+    // when a per-session budget is configured.
+    if let Some(budget) = app.budget_usd {
+        if budget > 0.0 {
+            let band = session.budget_eta(budget);
+            let mid = claudectl_core::forecast::format_eta(band.mid_hours);
+            let eta_text = if band.mid_hours.is_none() {
+                format!("{mid} (not burning)")
+            } else {
+                let soonest = claudectl_core::forecast::format_eta(band.low_hours);
+                let latest = claudectl_core::forecast::format_eta(band.high_hours);
+                format!("{mid}  (range {soonest}–{latest})")
+            };
+            lines.push(detail_line("  Budget ETA", &eta_text, t));
+        }
+    }
+
     // Cognitive Health section
     if session.has_usage_metrics() && session.decay_score > 0 {
         lines.push(Line::from(""));

--- a/src/brain/decisions.rs
+++ b/src/brain/decisions.rs
@@ -1118,6 +1118,8 @@ mod tests {
             context_max: 100000,
             prev_cost_usd: 3.0,
             burn_rate_per_hr: 2.5,
+            burn_rate_ewma: 2.5,
+            burn_samples: std::collections::VecDeque::new(),
             subagent_count: 1,
             active_subagent_count: 0,
             active_subagent_jsonl_paths: vec![],


### PR DESCRIPTION
Part of #370 (increment 1 — cost forecasting). Part of epic #367.

## Why
Agent token spend is bursty — one large tool result or context dump spikes a single tick — so the existing burn rate (`delta * 1800` per tick) flickers, and any ETA off it jumps around and would trigger false "about to blow budget" alarms. (This is exactly the failure mode flagged in the issue thread.)

## What
- **`claudectl_core::forecast`** — new pure, fully-tested module: `ewma` + `alpha_for_half_life`, interpolated `percentile`, `eta_hours`, a p10/p90 `EtaBand`, and `format_eta`.
- **Smoothing** — `ClaudeSession` gains `burn_rate_ewma` + a capped `burn_samples` window, folded in each refresh via `record_burn_sample` (~45s half-life). Sessions persist across ticks, so the EWMA lives on the session.
- **Forecast** — `session.budget_eta(budget)` returns soonest/mid/latest from headroom + recent samples. The detail panel shows **Budget ETA** with the band when a per-session budget is set, e.g. `~1h20m  (range ~40m–~3h10m)`.

Per the issue's design note, the ETA is an **interval, not a point**, and the conservative bound (`low_hours`, from the fast p90 burn) is what a future auto-action should gate on. **Model routing — the other half of #370 — is a separate increment** (overlaps #240).

## Testing
- 7 forecast unit tests (EWMA seed/spike-resistance, alpha range, percentile interp, eta edge cases, band ordering, formatting) + 2 session tests (EWMA settle/cap, ETA accuracy).
- `cargo test` 785 pass; clippy `--all-targets -D warnings` + fmt clean; both default and minimal builds compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
