### PR TITLE
chore: bump to 0.59.0 — forecasting + scaffolding + MSRV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to claudectl are documented here.
 
-## [Unreleased]
+## [0.59.0] - 2026-06-28
 
 ### Added — budget-ETA cost forecasting (#370, increment 1)
 - The dashboard detail panel now shows a **Budget ETA** when a per-session budget is set: smoothed time-to-cap with a p10/p90 band (e.g. `~1h20m  (range ~40m–~3h10m)`).
@@ -16,6 +16,8 @@ All notable changes to claudectl are documented here.
 
 ### Documented — MSRV (#328)
 - README install section now states the **rustc 1.88+** requirement for source builds, so users on an older toolchain get a clear fix (`rustup update stable`) instead of an opaque transitive-dependency error. The `rust-version = "1.88"` pin was already in all three crate manifests; this closes the remaining doc gap.
+
+Workspace crates bumped: `claudectl-core` and `claudectl-tui` → 0.54.0 (new `forecast` module + new public session API).
 
 ## [0.58.0] - 2026-06-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2024"
 # MSRV — bumped to 1.88 in #328 so cargo-install on older toolchains
 # emits a clean "rustc too old" error instead of opaque transitive-dep
@@ -50,8 +50,8 @@ path = "src/lib.rs"
 # published to crates.io. Local builds always use the path; crates.io strips
 # the path and resolves the published version. Bump both when the workspace
 # crates change.
-claudectl-core = { path = "crates/claudectl-core", version = "0.53.0" }
-claudectl-tui = { path = "crates/claudectl-tui", version = "0.53.0" }
+claudectl-core = { path = "crates/claudectl-core", version = "0.54.0" }
+claudectl-tui = { path = "crates/claudectl-tui", version = "0.54.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }

--- a/crates/claudectl-core/Cargo.toml
+++ b/crates/claudectl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-core"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Foundational types and IO primitives for claudectl. Shared across the TUI, the binary, and future crates."

--- a/crates/claudectl-tui/Cargo.toml
+++ b/crates/claudectl-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-tui"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Terminal UI, dashboard recording, and demo-mode fixtures for claudectl. Splits out of the binary so the TUI can evolve independently of the brain/coord/bus subsystems."
@@ -23,7 +23,7 @@ relay = []
 hive = []
 
 [dependencies]
-claudectl-core = { path = "../claudectl-core", version = "0.53.0" }
+claudectl-core = { path = "../claudectl-core", version = "0.54.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde_json = "1"


### PR DESCRIPTION
Bundles three merged changes into a minor release.

| crate | from | to |
|---|---|---|
| `claudectl` | 0.58.0 | **0.59.0** |
| `claudectl-core` | 0.53.0 | **0.54.0** |
| `claudectl-tui` | 0.53.0 | **0.54.0** |

Minor bump — new public `claudectl_core::forecast` module + new session forecasting API.

Ships:
- **#370 inc 1** — budget-ETA cost forecast (EWMA burn rate + p10/p90 band)
- **#371** — `supervisor init` / `validate` + `examples/tasks/`
- **#328** — README MSRV (rustc 1.88+) note

Inter-crate version reqs + `Cargo.lock` updated; CHANGELOG `[Unreleased]` promoted to `[0.59.0]`; `claudectl --version` → `0.59.0` verified.

After merge, push the `v0.59.0` tag to trigger `release.yml` → tarballs + crates.io (core → tui → claudectl) + Homebrew tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
