### PR TITLE
feat(brain): model routing — escalate low-confidence decisions (#370 inc 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to claudectl are documented here.
 
+## [Unreleased]
+
+### Added — brain model routing (#370, increment 2)
+- The brain can now **escalate low-confidence decisions to a stronger model**. Set `escalation_model` (+ optional `escalation_threshold`, default 0.7) in the `[brain]` config: the cheap/primary `model` answers every gate decision, and only when it's uncertain is the prompt re-run on the stronger model. Off by default (no `escalation_model` ⇒ today's single-model behavior, byte-for-byte).
+- A failed escalation falls back to the primary suggestion rather than erroring, so routing never makes the brain less available than before.
+
 ## [0.59.0] - 2026-06-28
 
 ### Added — budget-ETA cost forecasting (#370, increment 1)

--- a/crates/claudectl-core/src/config.rs
+++ b/crates/claudectl-core/src/config.rs
@@ -19,6 +19,13 @@ pub struct BrainConfig {
     pub max_sessions: usize,
     pub orchestrate: bool,
     pub orchestrate_interval_secs: u64,
+    /// Optional stronger model to escalate to when the primary (`model`)
+    /// returns a low-confidence decision. `None` ⇒ routing off; every decision
+    /// uses `model` (today's behavior). See `brain::client::infer_routed` (#370).
+    pub escalation_model: Option<String>,
+    /// Confidence below which a primary-model decision is re-run on
+    /// `escalation_model`. Only consulted when an escalation model is set.
+    pub escalation_threshold: f64,
     /// Command prefixes that identify test-runner invocations. When one of
     /// these fails (non-zero exit), the reaper fans the failure out to recent
     /// brain-approved edits as a `TestFailed` outcome (#238). Empty disables
@@ -63,6 +70,8 @@ impl Default for BrainConfig {
             max_sessions: 10,
             orchestrate: false,
             orchestrate_interval_secs: 30,
+            escalation_model: None,
+            escalation_threshold: 0.7,
             test_runners: default_test_runners(),
         }
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,10 @@ warn_threshold = 75
 enabled = true
 endpoint = "http://localhost:11434/api/generate"
 model = "gemma4:e4b"
+# Optional model routing: a low-confidence decision from `model` is re-run on
+# `escalation_model`. Unset = no routing (every decision uses `model`).
+escalation_model = "gemma4:27b"
+escalation_threshold = 0.7
 auto = false
 timeout_ms = 5000
 max_context_tokens = 4000

--- a/src/brain/client.rs
+++ b/src/brain/client.rs
@@ -17,14 +17,65 @@ pub struct BrainSuggestion {
     pub suggested_at: u64,
 }
 
-/// Call the local LLM endpoint via curl and parse the response.
+/// Call the local LLM endpoint via curl and parse the response, using the
+/// model configured as the primary (`config.model`).
 pub fn infer(config: &BrainConfig, prompt: &str) -> Result<BrainSuggestion, String> {
+    infer_with_model(config, prompt, &config.model)
+}
+
+/// Whether a primary-model decision is too uncertain and should be re-run on
+/// the stronger escalation model. Pure so the routing policy is unit-testable
+/// without an LLM. Escalation only happens when a strong model is configured.
+pub fn should_escalate(confidence: f64, threshold: f64, has_strong_model: bool) -> bool {
+    has_strong_model && confidence < threshold
+}
+
+/// Two-tier routed inference (#370): ask the cheap/primary model first; if it
+/// returns a low-confidence decision and an `escalation_model` is configured,
+/// re-run the prompt on the stronger model and take that answer. With no
+/// escalation model this is byte-for-byte `infer`. A failed escalation falls
+/// back to the primary suggestion rather than erroring.
+pub fn infer_routed(config: &BrainConfig, prompt: &str) -> Result<BrainSuggestion, String> {
+    let primary = infer_with_model(config, prompt, &config.model)?;
+    let Some(strong) = config.escalation_model.as_deref() else {
+        return Ok(primary);
+    };
+    if !should_escalate(primary.confidence, config.escalation_threshold, true) {
+        return Ok(primary);
+    }
+    crate::logger::log(
+        "DEBUG",
+        &format!(
+            "brain routing: confidence {:.2} < {:.2}, escalating {} -> {strong}",
+            primary.confidence, config.escalation_threshold, config.model
+        ),
+    );
+    match infer_with_model(config, prompt, strong) {
+        Ok(escalated) => Ok(escalated),
+        Err(e) => {
+            crate::logger::log(
+                "WARN",
+                &format!("brain escalation to {strong} failed ({e}); using primary"),
+            );
+            Ok(primary)
+        }
+    }
+}
+
+/// Call the local LLM endpoint via curl with an explicit `model`, parsing the
+/// response. The model is a parameter so the router can target either the
+/// primary or the escalation model without cloning the whole config.
+fn infer_with_model(
+    config: &BrainConfig,
+    prompt: &str,
+    model: &str,
+) -> Result<BrainSuggestion, String> {
     let is_openai = is_openai_compatible(&config.endpoint);
 
     let payload = if is_openai {
         // OpenAI-compatible format (llama.cpp, vLLM, LM Studio)
         serde_json::json!({
-            "model": config.model,
+            "model": model,
             "messages": [
                 {"role": "user", "content": prompt}
             ],
@@ -34,7 +85,7 @@ pub fn infer(config: &BrainConfig, prompt: &str) -> Result<BrainSuggestion, Stri
     } else {
         // Ollama /api/generate format (default)
         serde_json::json!({
-            "model": config.model,
+            "model": model,
             "prompt": prompt,
             "stream": false,
             "format": "json",
@@ -369,6 +420,17 @@ fn epoch_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn escalate_only_when_uncertain_and_strong_model_present() {
+        // Low confidence + a strong model configured ⇒ escalate.
+        assert!(should_escalate(0.5, 0.7, true));
+        // Confident enough ⇒ keep the primary answer.
+        assert!(!should_escalate(0.7, 0.7, true));
+        assert!(!should_escalate(0.95, 0.7, true));
+        // No escalation model ⇒ never escalate, even when uncertain.
+        assert!(!should_escalate(0.1, 0.7, false));
+    }
 
     #[test]
     fn parse_approve_suggestion() {

--- a/src/brain/engine.rs
+++ b/src/brain/engine.rs
@@ -400,7 +400,7 @@ impl BrainEngine {
         self.inflight.insert(pid);
 
         std::thread::spawn(move || {
-            let suggestion = super::client::infer(&config, &prompt);
+            let suggestion = super::client::infer_routed(&config, &prompt);
             let _ = tx.send(BrainResult { pid, suggestion });
         });
     }
@@ -589,7 +589,7 @@ impl BrainEngine {
 
         // Use PID 0 as sentinel for orchestration results
         std::thread::spawn(move || {
-            let suggestion = super::client::infer(&config, &prompt);
+            let suggestion = super::client::infer_routed(&config, &prompt);
             let _ = tx.send(BrainResult { pid: 0, suggestion });
         });
 
@@ -831,6 +831,8 @@ mod tests {
             max_sessions: 10,
             orchestrate: false,
             orchestrate_interval_secs: 30,
+            escalation_model: None,
+            escalation_threshold: 0.7,
             test_runners: crate::config::default_test_runners(),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -818,6 +818,10 @@ impl Config {
 # enabled = true
 # endpoint = "http://localhost:11434/api/generate"
 # model = "gemma4:e4b"
+# Optional: escalate low-confidence decisions from `model` to a stronger model.
+# Unset = no routing (every decision uses `model`).
+# escalation_model = "gemma4:27b"
+# escalation_threshold = 0.7
 # auto = false
 # timeout_ms = 5000
 # max_context_tokens = 4000
@@ -1055,6 +1059,12 @@ fn parse_config_file(path: &PathBuf) -> Option<RawConfig> {
                     }
                     "endpoint" => brain.endpoint = unquote(value),
                     "model" => brain.model = unquote(value),
+                    "escalation_model" => brain.escalation_model = Some(unquote(value)),
+                    "escalation_threshold" => {
+                        if let Ok(v) = value.parse() {
+                            brain.escalation_threshold = v;
+                        }
+                    }
                     "auto" => {
                         if let Some(v) = parse_bool(value) {
                             brain.auto_mode = v;
@@ -1267,6 +1277,8 @@ fn known_keys(section: &str) -> Option<&'static [&'static str]> {
             "enabled",
             "endpoint",
             "model",
+            "escalation_model",
+            "escalation_threshold",
             "auto",
             "timeout_ms",
             "max_context_tokens",
@@ -1720,6 +1732,8 @@ action = "terminate"
 enabled = true
 endpoint = "http://localhost:8080/v1/chat"
 model = "llama3:8b"
+escalation_model = "llama3:70b"
+escalation_threshold = 0.6
 auto = true
 timeout_ms = 3000
 max_context_tokens = 8000
@@ -1733,6 +1747,8 @@ max_context_tokens = 8000
         assert!(brain.enabled);
         assert_eq!(brain.endpoint, "http://localhost:8080/v1/chat");
         assert_eq!(brain.model, "llama3:8b");
+        assert_eq!(brain.escalation_model.as_deref(), Some("llama3:70b"));
+        assert!((brain.escalation_threshold - 0.6).abs() < f64::EPSILON);
         assert!(brain.auto_mode);
         assert_eq!(brain.timeout_ms, 3000);
         assert_eq!(brain.max_context_tokens, 8000);


### PR DESCRIPTION
Closes #370 (increment 2 — model routing). Part of epic #367; complements the budget-ETA forecast from increment 1.

## Why
The brain queries a single local model for every gate decision. Tiered routing lets a cheap/fast model handle the obvious cases and only escalates the genuinely ambiguous ones to a stronger model — the exact pattern people DIY by hand (see the market evidence in #240). Direct latency/compute savings on the bulk of decisions.

## What
- **`BrainConfig`** gains `escalation_model: Option<String>` (None ⇒ routing off) and `escalation_threshold: f64` (default 0.7).
- **`client::infer`** now delegates to `infer_with_model(config, prompt, model)`. New **`infer_routed`**: ask the primary model; if it returns confidence below the threshold *and* an escalation model is set, re-run on the stronger model and take that answer. **`should_escalate`** is a pure, unit-tested policy function.
- **Fail-safe**: a failed escalation falls back to the primary suggestion rather than erroring, so routing never makes the brain less available than the single-model path.
- Engine gate + orchestration decisions use `infer_routed`; the eval harness stays on single-model `infer` (it measures one model's decision quality).
- TOML keys parsed + validated (`known_keys`), documented in the config template and `docs/configuration.md`.

**Off by default** — with no `escalation_model`, behavior is byte-for-byte identical to today.

## Testing
- `should_escalate` truth table (uncertain+strong ⇒ escalate; confident ⇒ no; no model ⇒ never) + brain config parse asserting the new fields.
- `cargo test` 786 pass; clippy `--all-targets -D warnings` + fmt clean; both default and minimal builds compile.

## Note / follow-up
This routes the **brain's own** model usage (cheap triage → strong on ambiguity). Routing the **managed Claude Code sessions'** model (Haiku-for-obvious, #240) is a related but distinct lever — worth a separate issue rather than folding in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
