### PR TITLE
feat(supervisor): PR-native task summaries via gh (#369 inc 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to claudectl are documented here.
 
 ## [Unreleased]
 
+### Added — PR-native integration (#369, increment 1)
+- **`claudectl supervisor pr <task_id>`** posts a task summary (state, attempts, role) as a comment on the PR for the task's branch, resolved via `git` + `gh`. Best-effort by construction: no open PR, no `gh`, or not a git repo prints a `skipped:` line and exits 0 — it never fails the task. Verifier-as-check and auto-posting on task DONE are increment 2.
+
 ### Added — brain model routing (#370, increment 2)
 - The brain can now **escalate low-confidence decisions to a stronger model**. Set `escalation_model` (+ optional `escalation_threshold`, default 0.7) in the `[brain]` config: the cheap/primary `model` answers every gate decision, and only when it's uncertain is the prompt re-run on the stronger model. Off by default (no `escalation_model` ⇒ today's single-model behavior, byte-for-byte).
 - A failed escalation falls back to the primary suggestion rather than erroring, so routing never makes the brain less available than before.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -196,6 +196,7 @@ Durable task lifecycles on top of the bus. See the [README's Supervisor section]
 | `supervisor status [--state STATE]` | Compact task table; optional state filter (`PENDING` / `RUNNING` / `DONE` / `NEEDS_HUMAN` / …) |
 | `supervisor logs <task_id>` | Task detail + full transition log |
 | `supervisor cancel <task_id>` | Idempotent move to CANCELLED |
+| `supervisor pr <task_id>` | Post a task summary as a comment on its branch's PR via `gh` (#369). Best-effort — no open PR / no `gh` / not a repo prints a skip and exits 0 |
 | `supervisor drain` | Set sentinel file at `~/.claudectl/coord/drain`; reconciler stops issuing new assignments |
 | `supervisor undrain` | Clear the drain marker |
 

--- a/src/coord/mod.rs
+++ b/src/coord/mod.rs
@@ -10,6 +10,7 @@ pub mod hook_events;
 pub mod injection;
 pub mod interrupt_bus;
 pub mod metrics;
+pub mod pr;
 pub mod promotion;
 pub mod resume;
 pub mod session_policy;

--- a/src/coord/pr.rs
+++ b/src/coord/pr.rs
@@ -1,0 +1,166 @@
+//! PR-native integration (#369): link a supervisor task to its branch's PR and
+//! post a summary comment.
+//!
+//! Best-effort by construction — every `git`/`gh` call returns `Option`/`Result`
+//! and a missing tool, no remote, detached HEAD, or no open PR degrades to a
+//! clear skip message rather than failing the task. This mirrors the plugin
+//! hooks' "never block on integration" convention.
+//!
+//! Increment 1 (this file): `supervisor pr <task_id>` composes and posts a task
+//! summary comment. Verifier-as-check (a PR status check from the Run/Brain/Agent
+//! verdict) and auto-posting on task DONE are increment 2.
+
+use std::path::Path;
+use std::process::Command;
+
+use super::tasks::{TaskRow, TaskState};
+
+/// Current git branch at `cwd`, or `None` outside a repo or on detached HEAD.
+pub fn current_branch(cwd: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let branch = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if branch.is_empty() || branch == "HEAD" {
+        None
+    } else {
+        Some(branch)
+    }
+}
+
+/// PR number for `branch` via `gh`, or `None` when gh is absent/unauthenticated
+/// or the branch has no open PR.
+pub fn pr_number_for_branch(cwd: &Path, branch: &str) -> Option<u64> {
+    let out = Command::new("gh")
+        .current_dir(cwd)
+        .args(["pr", "view", branch, "--json", "number", "-q", ".number"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_pr_number(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Parse the `gh pr view -q .number` output (a bare integer line).
+pub fn parse_pr_number(s: &str) -> Option<u64> {
+    s.trim().parse().ok()
+}
+
+/// Compose the PR comment body for a task. Pure so the formatting is testable
+/// without git/gh.
+pub fn build_pr_comment(task: &TaskRow, attempts: u32) -> String {
+    let icon = match task.state {
+        TaskState::Done => "✅",
+        TaskState::NeedsHuman | TaskState::Cancelled => "⚠️",
+        _ => "⏳",
+    };
+    let mut s = String::new();
+    s.push_str(&format!(
+        "### claudectl supervisor — {icon} {}\n\n",
+        task.name
+    ));
+    s.push_str(&format!("- **State:** `{}`\n", task.state.as_str()));
+    s.push_str(&format!(
+        "- **Attempts:** {}/{}\n",
+        attempts, task.max_retries
+    ));
+    if let Some(role) = &task.role {
+        s.push_str(&format!("- **Role:** {role}\n"));
+    }
+    s.push_str(&format!("- **Task id:** `{}`\n", task.id));
+    s.push_str("\n<sub>Posted by `claudectl supervisor pr`.</sub>\n");
+    s
+}
+
+/// Post a comment to PR `pr` at `cwd` via `gh`. Best-effort: a missing `gh` or a
+/// failed call returns `Err` with the reason for the caller to surface as a skip.
+pub fn post_comment(cwd: &Path, pr: u64, body: &str) -> Result<(), String> {
+    let out = Command::new("gh")
+        .current_dir(cwd)
+        .args(["pr", "comment", &pr.to_string(), "--body", body])
+        .output()
+        .map_err(|e| format!("gh not available: {e}"))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "gh pr comment failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ))
+    }
+}
+
+/// Orchestrate the task → branch → PR → comment flow. Returns a human status
+/// string on success, or an `Err` describing why it was skipped (no PR, no gh,
+/// not a repo). The CLI treats both as non-fatal.
+pub fn post_task_summary(task_id: &str) -> Result<String, String> {
+    let conn = super::store::open()?;
+    let task = super::tasks::get_task(&conn, task_id)?
+        .ok_or_else(|| format!("no such task: {task_id}"))?;
+    let cwd = Path::new(&task.cwd);
+    let branch = current_branch(cwd)
+        .ok_or_else(|| format!("{}: not a git repo or detached HEAD", task.cwd))?;
+    let pr = pr_number_for_branch(cwd, &branch)
+        .ok_or_else(|| format!("no open PR for branch `{branch}` (or gh unavailable)"))?;
+    let attempts = super::tasks::attempt_count(&conn, task_id).unwrap_or(0);
+    let body = build_pr_comment(&task, attempts);
+    post_comment(cwd, pr, &body)?;
+    Ok(format!("posted summary to PR #{pr} (branch {branch})"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task(state: TaskState) -> TaskRow {
+        TaskRow {
+            id: "t-123".into(),
+            name: "ship the thing".into(),
+            state,
+            role: Some("backend".into()),
+            cwd: "/tmp/proj".into(),
+            prompt: "do it".into(),
+            model: None,
+            budget_usd: None,
+            max_retries: 3,
+            timeout_min: 30,
+            depends_on: vec![],
+            policy: None,
+            verifiers: vec![],
+            created_at: "2026-06-28T10:00:00Z".into(),
+            updated_at: "2026-06-28T10:05:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn parse_pr_number_handles_bare_int_and_junk() {
+        assert_eq!(parse_pr_number("123\n"), Some(123));
+        assert_eq!(parse_pr_number("  42 "), Some(42));
+        assert_eq!(parse_pr_number(""), None);
+        assert_eq!(parse_pr_number("not-a-number"), None);
+    }
+
+    #[test]
+    fn comment_includes_task_facts() {
+        let body = build_pr_comment(&task(TaskState::Running), 1);
+        assert!(body.contains("ship the thing"));
+        assert!(body.contains("`RUNNING`"));
+        assert!(body.contains("1/3"));
+        assert!(body.contains("backend"));
+        assert!(body.contains("t-123"));
+    }
+
+    #[test]
+    fn comment_icon_reflects_outcome() {
+        assert!(build_pr_comment(&task(TaskState::Done), 1).contains("✅"));
+        assert!(build_pr_comment(&task(TaskState::NeedsHuman), 3).contains("⚠️"));
+        assert!(build_pr_comment(&task(TaskState::Running), 0).contains("⏳"));
+    }
+}

--- a/src/coord/supervisor_cli.rs
+++ b/src/coord/supervisor_cli.rs
@@ -75,6 +75,10 @@ pub enum SupervisorCommand {
     /// Move a task to CANCELLED. Idempotent — already-terminal tasks
     /// are left alone.
     Cancel { task_id: String },
+    /// Post a summary of a task as a comment on its branch's PR (#369).
+    /// Best-effort: no open PR / no `gh` / not a repo prints a skip and
+    /// exits 0 rather than failing.
+    Pr { task_id: String },
     /// Set a "drain" marker so the reconciler stops issuing new
     /// assignments while keeping running tasks alive. The marker is a
     /// sentinel file at `~/.claudectl/coord/drain`. Remove with
@@ -112,6 +116,7 @@ pub fn dispatch(cmd: &SupervisorCommand) -> io::Result<()> {
         SupervisorCommand::Status { state } => render_status(state.as_deref()),
         SupervisorCommand::Logs { task_id } => render_logs(task_id),
         SupervisorCommand::Cancel { task_id } => cancel_task(task_id),
+        SupervisorCommand::Pr { task_id } => post_pr_summary(task_id),
         SupervisorCommand::Drain => set_drain(true),
         SupervisorCommand::Undrain => set_drain(false),
     }
@@ -243,6 +248,17 @@ fn cancel_task(task_id: &str) -> io::Result<()> {
     )
     .map_err(io::Error::other)?;
     println!("cancelled {task_id}");
+    Ok(())
+}
+
+/// Post a task summary to its branch's PR (#369). Best-effort: anything that
+/// prevents posting (no PR, no `gh`, not a repo) prints a `skipped:` line and
+/// exits 0, so it's safe to call unconditionally from scripts or CI.
+fn post_pr_summary(task_id: &str) -> io::Result<()> {
+    match super::pr::post_task_summary(task_id) {
+        Ok(msg) => println!("{msg}"),
+        Err(reason) => println!("skipped: {reason}"),
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Part of #369 (increment 1 — link tasks to PRs + summary comments). Part of epic #367.

## Why
The supervisor produces durable, verified work, but it lived entirely outside the place reviewers actually look: the PR. This links a task to its branch's PR and posts a summary there.

## What
- New **`coord::pr`** module: `current_branch` (git), `pr_number_for_branch` (gh), pure `build_pr_comment` + `parse_pr_number`, `post_comment`, and `post_task_summary` (task → cwd → branch → PR → comment).
- **`claudectl supervisor pr <task_id>`** posts the summary (state, attempts, role, task id) as a PR comment.
- **Best-effort by construction:** no open PR, no `gh`, or not a git repo prints `skipped: <reason>` and **exits 0** — it never fails the task or a CI step (mirrors the plugin-hook "never block on integration" convention).

## Testing
- Unit tests for the pure parts: `parse_pr_number` (bare int + junk), comment composition, outcome-icon mapping. The `git`/`gh` shells are thin + best-effort (consistent with the existing untested git shells in `resume.rs`/`context.rs`).
- `cargo test` 789 pass; clippy `--all-targets -D warnings` + fmt clean; both feature configs build.
- Smoke-tested the binary: `supervisor pr <bogus>` → `skipped: no such task`, exit 0.

## Scope / follow-up (increment 2 of #369)
- **Verifier-as-check:** surface the Run/Brain/Agent verdict as a PR status check (needs a `task_verifications` read API — shared with #368 inc 2).
- **Auto-post on task DONE** from the reconciler (kept manual here to avoid network calls in the tick loop until the trigger policy is settled).

This increment routes the *supervisor task* path; session→PR linkage is a later consideration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
