### PR TITLE
chore: bump to 0.60.0 — model routing + PR-native summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to claudectl are documented here.
 
-## [Unreleased]
+## [0.60.0] - 2026-06-28
 
 ### Added — PR-native integration (#369, increment 1)
 - **`claudectl supervisor pr <task_id>`** posts a task summary (state, attempts, role) as a comment on the PR for the task's branch, resolved via `git` + `gh`. Best-effort by construction: no open PR, no `gh`, or not a git repo prints a `skipped:` line and exits 0 — it never fails the task. Verifier-as-check and auto-posting on task DONE are increment 2.
@@ -10,6 +10,8 @@ All notable changes to claudectl are documented here.
 ### Added — brain model routing (#370, increment 2)
 - The brain can now **escalate low-confidence decisions to a stronger model**. Set `escalation_model` (+ optional `escalation_threshold`, default 0.7) in the `[brain]` config: the cheap/primary `model` answers every gate decision, and only when it's uncertain is the prompt re-run on the stronger model. Off by default (no `escalation_model` ⇒ today's single-model behavior, byte-for-byte).
 - A failed escalation falls back to the primary suggestion rather than erroring, so routing never makes the brain less available than before.
+
+Workspace crates bumped: `claudectl-core` and `claudectl-tui` → 0.55.0 (new `BrainConfig` routing fields).
 
 ## [0.59.0] - 2026-06-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.59.0"
+version = "0.60.0"
 edition = "2024"
 # MSRV — bumped to 1.88 in #328 so cargo-install on older toolchains
 # emits a clean "rustc too old" error instead of opaque transitive-dep
@@ -50,8 +50,8 @@ path = "src/lib.rs"
 # published to crates.io. Local builds always use the path; crates.io strips
 # the path and resolves the published version. Bump both when the workspace
 # crates change.
-claudectl-core = { path = "crates/claudectl-core", version = "0.54.0" }
-claudectl-tui = { path = "crates/claudectl-tui", version = "0.54.0" }
+claudectl-core = { path = "crates/claudectl-core", version = "0.55.0" }
+claudectl-tui = { path = "crates/claudectl-tui", version = "0.55.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }

--- a/crates/claudectl-core/Cargo.toml
+++ b/crates/claudectl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-core"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Foundational types and IO primitives for claudectl. Shared across the TUI, the binary, and future crates."

--- a/crates/claudectl-tui/Cargo.toml
+++ b/crates/claudectl-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-tui"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Terminal UI, dashboard recording, and demo-mode fixtures for claudectl. Splits out of the binary so the TUI can evolve independently of the brain/coord/bus subsystems."
@@ -23,7 +23,7 @@ relay = []
 hive = []
 
 [dependencies]
-claudectl-core = { path = "../claudectl-core", version = "0.54.0" }
+claudectl-core = { path = "../claudectl-core", version = "0.55.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde_json = "1"


### PR DESCRIPTION
Bundles two merged features into a minor release.

| crate | from | to |
|---|---|---|
| `claudectl` | 0.59.0 | **0.60.0** |
| `claudectl-core` | 0.54.0 | **0.55.0** |
| `claudectl-tui` | 0.54.0 | **0.55.0** |

Minor bump — new public `BrainConfig` routing fields. (core changed → tui's dep requirement bumps → tui republishes too.)

Ships:
- **#370 inc 2** — brain model routing (`escalation_model` / `escalation_threshold`)
- **#369 inc 1** — `supervisor pr <task_id>` PR-native task summaries

Inter-crate version reqs + `Cargo.lock` updated; CHANGELOG `[Unreleased]` → `[0.60.0]`; `claudectl --version` → `0.60.0` verified.

After merge, push `v0.60.0` to trigger `release.yml` → tarballs + crates.io (core → tui → claudectl) + Homebrew tap. (Homebrew token was rotated last release, so that job should pass this time.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
