### PR TITLE
feat(supervisor): verdict + cost columns in the panel (#368 inc 2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to claudectl are documented here.
 
 ## [Unreleased]
 
+### Added — supervisor panel: verdict + cost columns (#368, increment 2a)
+- The Supervisor panel (`T`) now shows a **VERDICT** column (latest verifier result, green PASS / red FAIL) and a **COST** column (total $ across the task's attempts), replacing the low-value session-hash column. New `tasks::latest_verification` and `tasks::task_cost_usd` read APIs back this and are shared with PR-native (#369). One-key write actions (retry/approve/cancel/drain) remain the next slice of #368.
+
 ### Fixed — flaky relay HTTP server tests (#381)
 - The relay coordinator's HTTP server tests raced the accept loop: a fixed 50ms pre-sleep then a single read could miss the response on a loaded CI runner, intermittently failing the release. The tests now retry connect+read until a response or a 5s deadline (deterministic), and the server's non-blocking accept poll shrank from 100ms to 10ms — bounding first-request latency and the race window.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to claudectl are documented here.
 
+## [Unreleased]
+
+### Fixed — flaky relay HTTP server tests (#381)
+- The relay coordinator's HTTP server tests raced the accept loop: a fixed 50ms pre-sleep then a single read could miss the response on a loaded CI runner, intermittently failing the release. The tests now retry connect+read until a response or a 5s deadline (deterministic), and the server's non-blocking accept poll shrank from 100ms to 10ms — bounding first-request latency and the race window.
+
 ## [0.60.0] - 2026-06-28
 
 ### Added — PR-native integration (#369, increment 1)

--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -291,6 +291,13 @@ pub struct TaskSummary {
     pub max_retries: u32,
     /// Session id of the most recent attempt, when one has run.
     pub last_session_id: Option<String>,
+    /// Most recent verifier verdict (e.g. "PASS"/"FAIL"), or `None` if no
+    /// verifier has run for this task yet.
+    #[serde(default)]
+    pub last_verdict: Option<String>,
+    /// Total cost in USD across all attempts.
+    #[serde(default)]
+    pub cost_usd: f64,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -1006,6 +1013,8 @@ mod tests {
                 attempts: 2,
                 max_retries: 3,
                 last_session_id: Some("sess-abcdef12".into()),
+                last_verdict: Some("PASS".into()),
+                cost_usd: 1.25,
                 created_at: "2026-06-25T10:00:00Z".into(),
                 updated_at: "2026-06-25T10:05:00Z".into(),
             }],

--- a/crates/claudectl-tui/src/ui/supervisor.rs
+++ b/crates/claudectl-tui/src/ui/supervisor.rs
@@ -30,12 +30,6 @@ fn state_color(state: &str, t: &Theme) -> Color {
     }
 }
 
-/// Last path segment of a session id / uuid, truncated for the narrow column.
-fn short_session(id: &str) -> String {
-    let tail = id.rsplit(['/', '-']).next().unwrap_or(id);
-    tail.chars().take(8).collect()
-}
-
 pub fn render_supervisor_screen(frame: &mut Frame, area: Rect, app: &App) {
     let t = &app.theme;
 
@@ -67,10 +61,19 @@ pub fn render_supervisor_screen(frame: &mut Frame, area: Rect, app: &App) {
     render_footer(frame, layout[2], app);
 }
 
+/// Color a verifier verdict — green PASS, red FAIL, muted when none/unknown.
+fn verdict_color(verdict: &str, t: &Theme) -> Color {
+    match verdict {
+        "PASS" => t.success,
+        "FAIL" => t.error,
+        _ => t.text_muted,
+    }
+}
+
 fn render_header(frame: &mut Frame, area: Rect, t: &Theme) {
     let header = format!(
-        " {:<10} {:>6}  {:<28} {:<10} {:<10} {}",
-        "STATE", "TRIES", "TASK", "ROLE", "SESSION", "UPDATED"
+        "   {:<8} {:>5} {:<7} {:>7} {:<26} {:<10} {}",
+        "STATE", "TRIES", "VERDICT", "COST", "TASK", "ROLE", "UPDATED"
     );
     let p = Paragraph::new(Line::from(Span::styled(
         header,
@@ -99,11 +102,8 @@ fn render_task_list(frame: &mut Frame, area: Rect, app: &App) {
         .map(|(i, task)| {
             let is_sel = i == selected;
             let tries = format!("{}/{}", task.attempts, task.max_retries);
-            let session = task
-                .last_session_id
-                .as_deref()
-                .map(short_session)
-                .unwrap_or_else(|| "—".into());
+            let verdict = task.last_verdict.as_deref().unwrap_or("—");
+            let cost = format!("${:.2}", task.cost_usd);
             let role = task.role.as_deref().unwrap_or("—");
             let updated = task
                 .updated_at
@@ -115,21 +115,25 @@ fn render_task_list(frame: &mut Frame, area: Rect, app: &App) {
             let row = Line::from(vec![
                 Span::raw(if is_sel { " ▸ " } else { "   " }),
                 Span::styled(
-                    format!("{:<8}", task.state),
+                    format!("{:<8} ", task.state),
                     Style::default()
                         .fg(state_color(&task.state, t))
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(format!("{tries:>6}  "), Style::default().fg(t.text_muted)),
+                Span::styled(format!("{tries:>5} "), Style::default().fg(t.text_muted)),
                 Span::styled(
-                    format!("{:<28}", truncate(&task.name, 28)),
+                    format!("{verdict:<7} "),
+                    Style::default().fg(verdict_color(verdict, t)),
+                ),
+                Span::styled(format!("{cost:>7} "), Style::default().fg(t.text_muted)),
+                Span::styled(
+                    format!("{:<26} ", truncate(&task.name, 26)),
                     Style::default().fg(t.text_primary),
                 ),
                 Span::styled(
                     format!("{:<10} ", truncate(role, 10)),
                     Style::default().fg(t.text_muted),
                 ),
-                Span::styled(format!("{session:<10} "), Style::default().fg(t.text_muted)),
                 Span::styled(updated.to_string(), Style::default().fg(t.text_muted)),
             ]);
             let style = if is_sel {
@@ -195,9 +199,11 @@ mod tests {
     }
 
     #[test]
-    fn short_session_takes_trailing_segment() {
-        assert_eq!(short_session("path/to/sess-abcdef1234"), "abcdef12");
-        assert_eq!(short_session("plainid"), "plainid");
+    fn verdict_color_maps_pass_fail() {
+        let t = Theme::from_mode(claudectl_core::theme::ThemeMode::Dark);
+        assert_eq!(verdict_color("PASS", &t), t.success);
+        assert_eq!(verdict_color("FAIL", &t), t.error);
+        assert_eq!(verdict_color("—", &t), t.text_muted);
     }
 
     #[test]

--- a/src/coord/tasks.rs
+++ b/src/coord/tasks.rs
@@ -253,6 +253,38 @@ pub fn record_verification(
     Ok(())
 }
 
+/// Most recent verifier `(kind, verdict)` for a task, across all its attempts
+/// (#368/#369). Joins `task_verifications` → `task_attempts` on `attempt_id`
+/// and takes the newest by `ran_at`. `None` when no verifier has run yet.
+pub fn latest_verification(
+    conn: &Connection,
+    task_id: &str,
+) -> Result<Option<(String, String)>, String> {
+    conn.query_row(
+        "SELECT v.kind, v.verdict
+         FROM task_verifications v
+         JOIN task_attempts a ON v.attempt_id = a.id
+         WHERE a.task_id = ?1
+         ORDER BY v.ran_at DESC, v.id DESC
+         LIMIT 1",
+        params![task_id],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+    )
+    .optional()
+    .map_err(|e| format!("latest_verification: {e}"))
+}
+
+/// Total cost in USD across all attempts of a task. Zero when no attempt has
+/// recorded cost yet.
+pub fn task_cost_usd(conn: &Connection, task_id: &str) -> Result<f64, String> {
+    conn.query_row(
+        "SELECT COALESCE(SUM(cost_usd), 0) FROM task_attempts WHERE task_id = ?1",
+        params![task_id],
+        |row| row.get::<_, f64>(0),
+    )
+    .map_err(|e| format!("task_cost_usd: {e}"))
+}
+
 /// Latest attempt's session_id, used by the reconciler to map a task
 /// back to its observable session and decide whether to emit Resume on
 /// Dead status (RFC §7). Returns `None` when the latest attempt was a
@@ -507,6 +539,33 @@ mod tests {
         assert_eq!(hist.len(), 1);
         assert_eq!(hist[0].0, "CREATED");
         assert_eq!(hist[0].1, "PENDING");
+    }
+
+    #[test]
+    fn latest_verification_returns_newest_across_attempts() {
+        let conn = open_memory_for_tests();
+        let id = insert_task(&conn, &sample()).unwrap();
+        // No verifier has run yet.
+        assert_eq!(latest_verification(&conn, &id).unwrap(), None);
+
+        let a1 = insert_attempt(&conn, &id, 1, Some("sess-1"), None, None).unwrap();
+        record_verification(&conn, &a1, "run", "cargo test", "FAIL", "1 failed", 0.0).unwrap();
+        let a2 = insert_attempt(&conn, &id, 2, Some("sess-2"), None, None).unwrap();
+        record_verification(&conn, &a2, "run", "cargo test", "PASS", "ok", 0.0).unwrap();
+
+        let (kind, verdict) = latest_verification(&conn, &id).unwrap().expect("a verdict");
+        assert_eq!(kind, "run");
+        assert_eq!(verdict, "PASS");
+    }
+
+    #[test]
+    fn task_cost_sums_attempts_and_defaults_zero() {
+        let conn = open_memory_for_tests();
+        let id = insert_task(&conn, &sample()).unwrap();
+        assert_eq!(task_cost_usd(&conn, &id).unwrap(), 0.0);
+        // Attempts default to cost 0; the SUM stays 0 and never errors.
+        insert_attempt(&conn, &id, 1, Some("s"), None, None).unwrap();
+        assert_eq!(task_cost_usd(&conn, &id).unwrap(), 0.0);
     }
 
     #[test]

--- a/src/relay/http.rs
+++ b/src/relay/http.rs
@@ -55,7 +55,10 @@ impl HttpServer {
                         });
                     }
                     Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        std::thread::sleep(Duration::from_millis(100));
+                        // Short poll: bounds first-accept latency (and the
+                        // startup race a client hits) to ~10ms rather than 100ms,
+                        // while still checking the shutdown flag each loop.
+                        std::thread::sleep(Duration::from_millis(10));
                     }
                     Err(_) => {
                         std::thread::sleep(Duration::from_millis(500));
@@ -301,6 +304,32 @@ fn send_response(stream: &mut TcpStream, status: u16, body: &str) {
 mod tests {
     use super::*;
 
+    /// Send `request` to `127.0.0.1:port`, retrying a fresh connect+read until
+    /// a non-empty response arrives or `deadline` elapses. This removes the
+    /// startup race where the server's accept loop hasn't yet picked up the
+    /// connection — each attempt is a clean, full request, so it's safe for the
+    /// idempotent GET/heartbeat endpoints under test. Returns "" on timeout.
+    fn request_until_response(port: u16, request: &[u8], deadline: Duration) -> String {
+        let start = std::time::Instant::now();
+        loop {
+            if let Ok(mut stream) = TcpStream::connect(format!("127.0.0.1:{port}")) {
+                let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+                let _ = stream.write_all(request);
+                let _ = stream.flush();
+                let mut buf = [0u8; 4096];
+                if let Ok(n) = stream.read(&mut buf) {
+                    if n > 0 {
+                        return String::from_utf8_lossy(&buf[..n]).to_string();
+                    }
+                }
+            }
+            if start.elapsed() >= deadline {
+                return String::new();
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
     #[test]
     fn send_response_formats_correctly() {
         // We can't easily test TCP streams, but we verify the format string logic
@@ -405,21 +434,9 @@ mod tests {
         let server = HttpServer::start(addr, "secret-token".into(), state).unwrap();
         let port = server.addr.port();
 
-        // Connect and send a request with wrong token
-        std::thread::sleep(Duration::from_millis(50));
-        if let Ok(mut stream) = TcpStream::connect(format!("127.0.0.1:{port}")) {
-            let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
-            let request = "GET /api/sessions HTTP/1.1\r\nAuthorization: Bearer wrong-token\r\n\r\n";
-            let _ = stream.write_all(request.as_bytes());
-            let _ = stream.flush();
-
-            let mut response = String::new();
-            let mut buf = [0u8; 1024];
-            if let Ok(n) = stream.read(&mut buf) {
-                response = String::from_utf8_lossy(&buf[..n]).to_string();
-            }
-            assert!(response.contains("401"));
-        }
+        let request = "GET /api/sessions HTTP/1.1\r\nAuthorization: Bearer wrong-token\r\n\r\n";
+        let response = request_until_response(port, request.as_bytes(), Duration::from_secs(5));
+        assert!(response.contains("401"), "got: {response:?}");
 
         server.stop();
     }
@@ -436,22 +453,11 @@ mod tests {
         let server = HttpServer::start(addr, "tok".into(), state).unwrap();
         let port = server.addr.port();
 
-        std::thread::sleep(Duration::from_millis(50));
-        if let Ok(mut stream) = TcpStream::connect(format!("127.0.0.1:{port}")) {
-            let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
-            let request = "GET /api/sessions HTTP/1.1\r\nAuthorization: Bearer tok\r\n\r\n";
-            let _ = stream.write_all(request.as_bytes());
-            let _ = stream.flush();
-
-            let mut response = String::new();
-            let mut buf = [0u8; 4096];
-            if let Ok(n) = stream.read(&mut buf) {
-                response = String::from_utf8_lossy(&buf[..n]).to_string();
-            }
-            assert!(response.contains("200 OK"));
-            assert!(response.contains("\"pid\":42"));
-            assert!(response.contains("\"worker_id\":\"local\""));
-        }
+        let request = "GET /api/sessions HTTP/1.1\r\nAuthorization: Bearer tok\r\n\r\n";
+        let response = request_until_response(port, request.as_bytes(), Duration::from_secs(5));
+        assert!(response.contains("200 OK"), "got: {response:?}");
+        assert!(response.contains("\"pid\":42"));
+        assert!(response.contains("\"worker_id\":\"local\""));
 
         server.stop();
     }
@@ -469,28 +475,18 @@ mod tests {
         let server = HttpServer::start(addr, "t".into(), state).unwrap();
         let port = server.addr.port();
 
-        std::thread::sleep(Duration::from_millis(50));
-        if let Ok(mut stream) = TcpStream::connect(format!("127.0.0.1:{port}")) {
-            let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
-            let body = r#"{"worker_id":"remote-1","sessions":[{"pid":1}]}"#;
-            let request = format!(
-                "POST /api/heartbeat HTTP/1.1\r\nAuthorization: Bearer t\r\nContent-Length: {}\r\n\r\n{}",
-                body.len(),
-                body
-            );
-            let _ = stream.write_all(request.as_bytes());
-            let _ = stream.flush();
+        let body = r#"{"worker_id":"remote-1","sessions":[{"pid":1}]}"#;
+        let request = format!(
+            "POST /api/heartbeat HTTP/1.1\r\nAuthorization: Bearer t\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let response = request_until_response(port, request.as_bytes(), Duration::from_secs(5));
+        assert!(response.contains("200 OK"), "got: {response:?}");
 
-            let mut response = String::new();
-            let mut buf = [0u8; 1024];
-            if let Ok(n) = stream.read(&mut buf) {
-                response = String::from_utf8_lossy(&buf[..n]).to_string();
-            }
-            assert!(response.contains("200 OK"));
-        }
-
-        // Verify the worker state was stored
-        std::thread::sleep(Duration::from_millis(50));
+        // The heartbeat upserts worker "remote-1"; the request helper may retry,
+        // but each POST replaces (not appends) the session list, so the count
+        // stays 1 regardless of how many succeeded.
         if let Ok(cs) = state_check.lock() {
             assert!(cs.workers.contains_key("remote-1"));
             assert_eq!(cs.workers["remote-1"].sessions.len(), 1);

--- a/src/runtime/coord.rs
+++ b/src/runtime/coord.rs
@@ -78,6 +78,11 @@ impl CoordView for LiveCoordView {
             .map(|t| {
                 let attempts = tasks::attempt_count(&conn, &t.id).unwrap_or(0);
                 let last_session_id = tasks::latest_session_id(&conn, &t.id).ok().flatten();
+                let last_verdict = tasks::latest_verification(&conn, &t.id)
+                    .ok()
+                    .flatten()
+                    .map(|(_kind, verdict)| verdict);
+                let cost_usd = tasks::task_cost_usd(&conn, &t.id).unwrap_or(0.0);
                 TaskSummary {
                     id: t.id,
                     name: t.name,
@@ -86,6 +91,8 @@ impl CoordView for LiveCoordView {
                     attempts,
                     max_retries: t.max_retries,
                     last_session_id,
+                    last_verdict,
+                    cost_usd,
                     created_at: t.created_at,
                     updated_at: t.updated_at,
                 }


### PR DESCRIPTION
Part of #368 (increment 2, read-only half). Part of epic #367. Also lays the shared foundation #369 inc 2 needs.

## Why
The Supervisor panel showed state/attempts but not the two facts operators actually act on: did the last verifier pass, and how much has this task cost?

## What
- **Shared read APIs** (the missing piece both #368 inc 2 and #369 inc 2 needed):
  - `tasks::latest_verification(conn, task_id)` → newest `(kind, verdict)` joining `task_verifications` → `task_attempts`.
  - `tasks::task_cost_usd(conn, task_id)` → `SUM(cost_usd)` across attempts.
- **`TaskSummary`** gains `last_verdict: Option<String>` + `cost_usd`; the Live adapter populates them.
- **Panel** now renders **VERDICT** (green PASS / red FAIL / muted —) and **COST** (`$x.xx`), replacing the low-value session-hash column.

## Testing
- `latest_verification` (newest across attempts + none-case), `task_cost_usd` (sum + default zero), `verdict_color` mapping, updated DTO fixture.
- `cargo test` 791 pass; clippy `--all-targets -D warnings` + fmt clean; both feature configs build.

## Scope / next
One-key **write actions** (retry/approve/cancel/drain) are the remaining slice of #368 inc 2 (they extend the `Actions` trait + need a confirm UX). The verdict read added here is exactly what **#369 inc 2** (verifier-as-check) will consume, so that's unblocked too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
