### PR TITLE
chore: bump to 0.61.0 — relay delegate fix + panel verdict/cost + flaky test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to claudectl are documented here.
 
-## [Unreleased]
+## [0.61.0] - 2026-06-29
 
 ### Fixed — headless relay delegate/interrupt actually send now (#378)
 - `claudectl relay delegate <peer> "<prompt>"` and `relay interrupt` were no-ops outside the TUI: they built the message, printed a success line, and exited 0 without transmitting. They now open a one-shot authenticated connection to the peer (using the stored PSK + address, the same path `relay connect` uses) and send the frame — no running daemon required. On any failure (peer not paired, no address, connection refused) they print a clear error and **exit non-zero**, so scripts no longer mistake a built-but-unsent message for a delivered one.
@@ -13,6 +13,8 @@ All notable changes to claudectl are documented here.
 
 ### Fixed — flaky relay HTTP server tests (#381)
 - The relay coordinator's HTTP server tests raced the accept loop: a fixed 50ms pre-sleep then a single read could miss the response on a loaded CI runner, intermittently failing the release. The tests now retry connect+read until a response or a 5s deadline (deterministic), and the server's non-blocking accept poll shrank from 100ms to 10ms — bounding first-request latency and the race window.
+
+Workspace crates bumped: `claudectl-core` and `claudectl-tui` → 0.56.0 (new `TaskSummary` verdict + cost fields).
 
 ## [0.60.0] - 2026-06-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2024"
 # MSRV — bumped to 1.88 in #328 so cargo-install on older toolchains
 # emits a clean "rustc too old" error instead of opaque transitive-dep
@@ -50,8 +50,8 @@ path = "src/lib.rs"
 # published to crates.io. Local builds always use the path; crates.io strips
 # the path and resolves the published version. Bump both when the workspace
 # crates change.
-claudectl-core = { path = "crates/claudectl-core", version = "0.55.0" }
-claudectl-tui = { path = "crates/claudectl-tui", version = "0.55.0" }
+claudectl-core = { path = "crates/claudectl-core", version = "0.56.0" }
+claudectl-tui = { path = "crates/claudectl-tui", version = "0.56.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }

--- a/crates/claudectl-core/Cargo.toml
+++ b/crates/claudectl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-core"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Foundational types and IO primitives for claudectl. Shared across the TUI, the binary, and future crates."

--- a/crates/claudectl-tui/Cargo.toml
+++ b/crates/claudectl-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-tui"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Terminal UI, dashboard recording, and demo-mode fixtures for claudectl. Splits out of the binary so the TUI can evolve independently of the brain/coord/bus subsystems."
@@ -23,7 +23,7 @@ relay = []
 hive = []
 
 [dependencies]
-claudectl-core = { path = "../claudectl-core", version = "0.55.0" }
+claudectl-core = { path = "../claudectl-core", version = "0.56.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde_json = "1"


### PR DESCRIPTION
Bundles three merged changes into a minor release.

| crate | from | to |
|---|---|---|
| `claudectl` | 0.60.0 | **0.61.0** |
| `claudectl-core` | 0.55.0 | **0.56.0** |
| `claudectl-tui` | 0.55.0 | **0.56.0** |

Minor — new public `TaskSummary` fields (verdict + cost).

Ships:
- **#378** — headless `relay delegate`/`interrupt` actually transmit (+ non-zero exit on failure)
- **#368 inc 2a** — supervisor panel VERDICT + COST columns
- **#381** — flaky relay HTTP test made deterministic

Inter-crate reqs + `Cargo.lock` updated; CHANGELOG `[Unreleased]` → `[0.61.0]`; `claudectl --version` → `0.61.0` verified. After merge, push `v0.61.0` → tarballs + crates.io + Homebrew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
