### PR TITLE
feat(supervisor): verifier-as-check — commit status from verdict (#369 inc 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to claudectl are documented here.
 
+## [Unreleased]
+
+### Added — verifier-as-check (#369, increment 2)
+- `claudectl supervisor pr <task_id>` now also sets a **`claudectl/verifier` commit status** on the branch's HEAD, reflecting the task's latest verifier verdict (PASS → success, FAIL → failure, none → pending). It rides the existing best-effort path — the status post can't undo the comment already landed, and a missing `gh`/repo just appends a skip note. Auto-posting on task DONE from the reconciler is the remaining slice of #369.
+
 ## [0.61.0] - 2026-06-29
 
 ### Fixed — headless relay delegate/interrupt actually send now (#378)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -196,7 +196,7 @@ Durable task lifecycles on top of the bus. See the [README's Supervisor section]
 | `supervisor status [--state STATE]` | Compact task table; optional state filter (`PENDING` / `RUNNING` / `DONE` / `NEEDS_HUMAN` / …) |
 | `supervisor logs <task_id>` | Task detail + full transition log |
 | `supervisor cancel <task_id>` | Idempotent move to CANCELLED |
-| `supervisor pr <task_id>` | Post a task summary as a comment on its branch's PR via `gh` (#369). Best-effort — no open PR / no `gh` / not a repo prints a skip and exits 0 |
+| `supervisor pr <task_id>` | Post a task summary comment on its branch's PR **and** set a `claudectl/verifier` commit status from the latest verdict, via `gh` (#369). Best-effort — no open PR / no `gh` / not a repo prints a skip and exits 0 |
 | `supervisor drain` | Set sentinel file at `~/.claudectl/coord/drain`; reconciler stops issuing new assignments |
 | `supervisor undrain` | Clear the drain marker |
 

--- a/src/coord/pr.rs
+++ b/src/coord/pr.rs
@@ -6,9 +6,10 @@
 //! clear skip message rather than failing the task. This mirrors the plugin
 //! hooks' "never block on integration" convention.
 //!
-//! Increment 1 (this file): `supervisor pr <task_id>` composes and posts a task
-//! summary comment. Verifier-as-check (a PR status check from the Run/Brain/Agent
-//! verdict) and auto-posting on task DONE are increment 2.
+//! `supervisor pr <task_id>` composes and posts a task summary comment, and
+//! reflects the latest verifier verdict as a GitHub commit status on HEAD
+//! (verifier-as-check). Auto-posting on task DONE from the reconciler is the
+//! remaining slice of #369.
 
 use std::path::Path;
 use std::process::Command;
@@ -79,6 +80,66 @@ pub fn build_pr_comment(task: &TaskRow, attempts: u32) -> String {
     s
 }
 
+/// Current HEAD commit SHA at `cwd`, or `None` outside a repo. Used as the
+/// target of the verifier status check.
+pub fn current_head_sha(cwd: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if sha.is_empty() { None } else { Some(sha) }
+}
+
+/// Map a verifier verdict to a GitHub commit-status `(state, description)`.
+/// Pure so the mapping is testable. Unknown / no verdict ⇒ `pending`.
+pub fn verdict_to_status(verdict: Option<&str>) -> (&'static str, &'static str) {
+    match verdict {
+        Some("PASS") => ("success", "claudectl verifier passed"),
+        Some("FAIL") => ("failure", "claudectl verifier failed"),
+        _ => ("pending", "claudectl verifier has not run"),
+    }
+}
+
+/// Post a commit status (#369 inc 2 — verifier-as-check) on `sha` via `gh api`.
+/// `gh` templates `{owner}`/`{repo}` from the repo at `cwd`. Best-effort.
+pub fn post_status_check(
+    cwd: &Path,
+    sha: &str,
+    state: &str,
+    description: &str,
+) -> Result<(), String> {
+    let out = Command::new("gh")
+        .current_dir(cwd)
+        .args([
+            "api",
+            "--method",
+            "POST",
+            &format!("repos/{{owner}}/{{repo}}/statuses/{sha}"),
+            "-f",
+            &format!("state={state}"),
+            "-f",
+            "context=claudectl/verifier",
+            "-f",
+            &format!("description={description}"),
+        ])
+        .output()
+        .map_err(|e| format!("gh not available: {e}"))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "gh status check failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ))
+    }
+}
+
 /// Post a comment to PR `pr` at `cwd` via `gh`. Best-effort: a missing `gh` or a
 /// failed call returns `Err` with the reason for the caller to surface as a skip.
 pub fn post_comment(cwd: &Path, pr: u64, body: &str) -> Result<(), String> {
@@ -112,7 +173,27 @@ pub fn post_task_summary(task_id: &str) -> Result<String, String> {
     let attempts = super::tasks::attempt_count(&conn, task_id).unwrap_or(0);
     let body = build_pr_comment(&task, attempts);
     post_comment(cwd, pr, &body)?;
-    Ok(format!("posted summary to PR #{pr} (branch {branch})"))
+
+    // Verifier-as-check (#369 inc 2): reflect the latest verdict as a commit
+    // status on HEAD. Best-effort — a failed status post doesn't undo the
+    // comment we already landed, so it's appended to the result, not returned
+    // as an error.
+    let mut extra = String::new();
+    if let Some(sha) = current_head_sha(cwd) {
+        let verdict = super::tasks::latest_verification(&conn, task_id)
+            .ok()
+            .flatten()
+            .map(|(_kind, verdict)| verdict);
+        let (state, desc) = verdict_to_status(verdict.as_deref());
+        let short = &sha[..sha.len().min(7)];
+        match post_status_check(cwd, &sha, state, desc) {
+            Ok(()) => extra = format!("; verifier status '{state}' on {short}"),
+            Err(e) => extra = format!("; status check skipped ({e})"),
+        }
+    }
+    Ok(format!(
+        "posted summary to PR #{pr} (branch {branch}){extra}"
+    ))
 }
 
 #[cfg(test)]
@@ -137,6 +218,14 @@ mod tests {
             created_at: "2026-06-28T10:00:00Z".into(),
             updated_at: "2026-06-28T10:05:00Z".into(),
         }
+    }
+
+    #[test]
+    fn verdict_maps_to_commit_status() {
+        assert_eq!(verdict_to_status(Some("PASS")).0, "success");
+        assert_eq!(verdict_to_status(Some("FAIL")).0, "failure");
+        assert_eq!(verdict_to_status(None).0, "pending");
+        assert_eq!(verdict_to_status(Some("weird")).0, "pending");
     }
 
     #[test]


### PR DESCRIPTION
Part of #369 (increment 2 — verifier-as-check). Builds on the verdict-read API shipped in #368 inc 2a.

## What
`claudectl supervisor pr <task_id>` now sets a **`claudectl/verifier` commit status** on the branch's HEAD reflecting the task's latest verifier verdict, alongside the summary comment it already posts:
- `verdict_to_status` (pure, tested) — PASS → `success`, FAIL → `failure`, none/unknown → `pending`.
- `current_head_sha` + `post_status_check` — `gh api --method POST repos/{owner}/{repo}/statuses/{sha}` (gh templates owner/repo from the repo at cwd).
- Wired into `post_task_summary` as **best-effort**: a failed status post can't undo the comment already landed, so it's appended to the result message rather than returned as an error. Reads the verdict via `tasks::latest_verification`.

## Testing
- `verdict_to_status` mapping test; `cargo test` 792 pass; clippy `--all-targets -D warnings` + fmt clean; both feature configs build.

## Remaining for #369
Auto-posting the summary + status on task **DONE** from the reconciler (so it's automatic, not just the manual `supervisor pr` verb). Kept separate to avoid network calls in the tick loop until the trigger policy is settled. As with the rest of the PR-native work, the live `gh` round-trip needs a real repo+PR to fully exercise; the pure mapping and best-effort skips are covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
