### PR TITLE
feat(supervisor): panel write actions — cancel + drain (#368 inc 2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to claudectl are documented here.
 
 ## [Unreleased]
 
+### Added — supervisor panel write actions (#368, increment 2b)
+- The Supervisor panel (`T`) is now operational: **`c`** cancels the selected task (double-tap to confirm — moves it to CANCELLED) and **`d`** toggles the supervisor **drain** marker (reconciler stops issuing new assignments while running tasks finish). Both route through new `Actions::cancel_task` / `Actions::set_supervisor_drain` methods; the footer + help reflect the keys. One-key retry/approve are a later slice.
+
 ### Added — verifier-as-check (#369, increment 2)
 - `claudectl supervisor pr <task_id>` now also sets a **`claudectl/verifier` commit status** on the branch's HEAD, reflecting the task's latest verifier verdict (PASS → success, FAIL → failure, none → pending). It rides the existing best-effort path — the status post can't undo the comment already landed, and a missing `gh`/repo just appends a skip note. Auto-posting on task DONE from the reconciler is the remaining slice of #369.
 

--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -467,6 +467,16 @@ pub trait Actions: Send + Sync {
     /// Returns `Err` when the bus feature is compiled out or the DB write
     /// fails. See issue #307.
     fn bind_bus_role(&self, name: &str, cwd: &str, pid: u32) -> Result<(), String>;
+
+    /// Cancel a supervisor task (move it to CANCELLED). Used by the Supervisor
+    /// panel's one-key cancel (#368). `Err` when the `coord` feature is compiled
+    /// out, the task is already terminal, or the store write fails.
+    fn cancel_task(&self, task_id: &str) -> Result<(), String>;
+
+    /// Set or clear the supervisor drain marker. When draining, the reconciler
+    /// stops issuing new task assignments while letting running tasks finish.
+    /// `Err` when the `coord` feature is compiled out.
+    fn set_supervisor_drain(&self, draining: bool) -> Result<(), String>;
 }
 
 // ============================================================================
@@ -722,6 +732,12 @@ pub enum MockAction {
         cwd: String,
         pid: u32,
     },
+    CancelTask {
+        task_id: String,
+    },
+    SetSupervisorDrain {
+        draining: bool,
+    },
 }
 
 impl PartialEq for ObservationInput {
@@ -915,6 +931,22 @@ impl Actions for MockRuntime {
             });
         Ok(())
     }
+    fn cancel_task(&self, task_id: &str) -> Result<(), String> {
+        self.actions_log
+            .lock()
+            .expect("actions_log poisoned")
+            .push(MockAction::CancelTask {
+                task_id: task_id.into(),
+            });
+        Ok(())
+    }
+    fn set_supervisor_drain(&self, draining: bool) -> Result<(), String> {
+        self.actions_log
+            .lock()
+            .expect("actions_log poisoned")
+            .push(MockAction::SetSupervisorDrain { draining });
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -1054,6 +1086,21 @@ mod tests {
         // through the trait by going via the *original* Arc through inspecting
         // the trait's behavior — the integration test in the binary covers
         // that surface. Here we just assert the calls succeeded.
+    }
+
+    #[test]
+    fn actions_task_writes_record_in_log() {
+        let mock = MockRuntime::default();
+        // MockRuntime itself implements Actions; call directly so we can read
+        // the recorded log via the public `actions()` accessor.
+        mock.cancel_task("t-1").unwrap();
+        mock.set_supervisor_drain(true).unwrap();
+        let actions = mock.actions();
+        assert!(matches!(&actions[0], MockAction::CancelTask { task_id } if task_id == "t-1"));
+        assert!(matches!(
+            actions[1],
+            MockAction::SetSupervisorDrain { draining: true }
+        ));
     }
 
     #[test]

--- a/crates/claudectl-tui/src/app.rs
+++ b/crates/claudectl-tui/src/app.rs
@@ -357,6 +357,12 @@ pub struct App {
     pub supervisor_selected: usize,
     #[cfg(feature = "coord")]
     pub supervisor_status_msg: Option<String>,
+    /// Task index armed for cancel — the first `c` arms, the second confirms.
+    #[cfg(feature = "coord")]
+    pub supervisor_pending_cancel: Option<usize>,
+    /// Local view of the supervisor drain marker, toggled by `d`.
+    #[cfg(feature = "coord")]
+    pub supervisor_draining: bool,
     // Relay peers panel (feature-gated)
     #[cfg(feature = "relay")]
     pub show_peers_panel: bool,
@@ -647,6 +653,10 @@ impl App {
             coord_tick: 0,
             #[cfg(feature = "coord")]
             coord_tasks: Vec::new(),
+            #[cfg(feature = "coord")]
+            supervisor_pending_cancel: None,
+            #[cfg(feature = "coord")]
+            supervisor_draining: false,
             #[cfg(feature = "coord")]
             show_supervisor: false,
             #[cfg(feature = "coord")]
@@ -1506,6 +1516,8 @@ impl App {
     /// Read-only for now (#368, increment 1).
     #[cfg(feature = "coord")]
     fn handle_supervisor_key(&mut self, key: KeyEvent) {
+        // Any key other than a second `c` disarms a pending cancel.
+        let was_armed = self.supervisor_pending_cancel.take();
         match key.code {
             KeyCode::Esc | KeyCode::Char('T') | KeyCode::Char('q') => {
                 self.show_supervisor = false;
@@ -1530,7 +1542,50 @@ impl App {
             KeyCode::Char('G') | KeyCode::End => {
                 self.supervisor_selected = self.coord_tasks.len().saturating_sub(1);
             }
+            // Cancel selected task — double-tap `c` to confirm (destructive).
+            KeyCode::Char('c') => self.handle_supervisor_cancel(was_armed),
+            // Toggle the supervisor drain marker.
+            KeyCode::Char('d') => self.handle_supervisor_drain_toggle(),
             _ => {}
+        }
+    }
+
+    #[cfg(feature = "coord")]
+    fn handle_supervisor_cancel(&mut self, was_armed: Option<usize>) {
+        let Some(task) = self.coord_tasks.get(self.supervisor_selected) else {
+            return;
+        };
+        let id = task.id.clone();
+        let name = task.name.clone();
+        if was_armed == Some(self.supervisor_selected) {
+            // Second press on the same row — execute.
+            match self.runtime.actions.cancel_task(&id) {
+                Ok(()) => {
+                    self.supervisor_status_msg = Some(format!("Cancelled {name}"));
+                    self.coord_refresh();
+                }
+                Err(e) => self.supervisor_status_msg = Some(format!("Cancel failed: {e}")),
+            }
+        } else {
+            // First press — arm and prompt for confirmation.
+            self.supervisor_pending_cancel = Some(self.supervisor_selected);
+            self.supervisor_status_msg = Some(format!("Press c again to cancel {name}"));
+        }
+    }
+
+    #[cfg(feature = "coord")]
+    fn handle_supervisor_drain_toggle(&mut self) {
+        let target = !self.supervisor_draining;
+        match self.runtime.actions.set_supervisor_drain(target) {
+            Ok(()) => {
+                self.supervisor_draining = target;
+                self.supervisor_status_msg = Some(if target {
+                    "Draining — reconciler will stop issuing new assignments".into()
+                } else {
+                    "Drain cleared — new assignments resume".into()
+                });
+            }
+            Err(e) => self.supervisor_status_msg = Some(format!("Drain toggle failed: {e}")),
         }
     }
 

--- a/crates/claudectl-tui/src/ui/help.rs
+++ b/crates/claudectl-tui/src/ui/help.rs
@@ -124,7 +124,7 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
         ]),
         Line::from(vec![
             Span::styled("  T              ", Style::default().fg(t.highlight_key)),
-            Span::raw("  Supervisor — task ledger (state, attempts, session)"),
+            Span::raw("  Supervisor — task ledger; c cancel, d drain, r refresh"),
         ]),
         Line::from(vec![
             Span::styled("  ?              ", Style::default().fg(t.highlight_key)),

--- a/crates/claudectl-tui/src/ui/supervisor.rs
+++ b/crates/claudectl-tui/src/ui/supervisor.rs
@@ -165,6 +165,17 @@ fn render_footer(frame: &mut Frame, area: Rect, app: &App) {
     let hint = Line::from(vec![
         Span::styled("  j/k", Style::default().fg(t.highlight_key)),
         Span::styled(" move  ", Style::default().fg(t.text_muted)),
+        Span::styled("c", Style::default().fg(t.highlight_key)),
+        Span::styled(" cancel  ", Style::default().fg(t.text_muted)),
+        Span::styled("d", Style::default().fg(t.highlight_key)),
+        Span::styled(
+            if app.supervisor_draining {
+                " undrain  "
+            } else {
+                " drain  "
+            },
+            Style::default().fg(t.text_muted),
+        ),
         Span::styled("r", Style::default().fg(t.highlight_key)),
         Span::styled(" refresh  ", Style::default().fg(t.text_muted)),
         Span::styled("Esc/T", Style::default().fg(t.highlight_key)),

--- a/src/runtime/actions.rs
+++ b/src/runtime/actions.rs
@@ -112,6 +112,55 @@ impl Actions for LiveActions {
             Err("bus feature not compiled in this build".into())
         }
     }
+
+    fn cancel_task(&self, task_id: &str) -> Result<(), String> {
+        #[cfg(feature = "coord")]
+        {
+            use crate::coord::tasks::{self, TaskState};
+            let mut conn = crate::coord::store::open()?;
+            let task = tasks::get_task(&conn, task_id)?
+                .ok_or_else(|| format!("task {task_id} not found"))?;
+            if task.state.is_terminal() {
+                return Err(format!("task already {}", task.state.as_str()));
+            }
+            tasks::transition(
+                &mut conn,
+                task_id,
+                task.state,
+                TaskState::Cancelled,
+                "operator-cancel",
+            )
+        }
+        #[cfg(not(feature = "coord"))]
+        {
+            let _ = task_id;
+            Err("coord feature not compiled in this build".into())
+        }
+    }
+
+    fn set_supervisor_drain(&self, draining: bool) -> Result<(), String> {
+        #[cfg(feature = "coord")]
+        {
+            let path = crate::coord::supervisor_cli::drain_marker_path();
+            if draining {
+                if let Some(parent) = path.parent() {
+                    fs::create_dir_all(parent).map_err(|e| format!("create drain dir: {e}"))?;
+                }
+                fs::write(&path, b"draining\n").map_err(|e| format!("write drain marker: {e}"))
+            } else {
+                match fs::remove_file(&path) {
+                    Ok(()) => Ok(()),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                    Err(e) => Err(format!("clear drain marker: {e}")),
+                }
+            }
+        }
+        #[cfg(not(feature = "coord"))]
+        {
+            let _ = draining;
+            Err("coord feature not compiled in this build".into())
+        }
+    }
 }
 
 /// Inverse of `crate::runtime::brain::parse_gate_mode` — writes the canonical


### PR DESCRIPTION
Part of #368 (increment 2 — write surface). Makes the Supervisor panel operational, not just a read-only ledger.

## What
- **`Actions` trait** gains `cancel_task` + `set_supervisor_drain`, following the feature-gated `bind_bus_role` pattern: `LiveActions` implements over coord (errs when the feature is compiled out), `MockRuntime` records to `actions_log`.
- `LiveActions::cancel_task` transitions the task to CANCELLED (refusing already-terminal tasks); `set_supervisor_drain` writes/removes the drain marker.
- **Panel keymap:** `c` cancels the selected task with a **double-tap confirm** (destructive — first press arms + prompts, second executes); `d` toggles the **drain** marker. Footer + help overlay advertise the keys.

## Testing
- MockRuntime records both task actions (contract test).
- `cargo test` 792 pass; clippy `--all-targets -D warnings` + fmt clean.
- Both feature configs build — the new TUI handlers are `#[cfg(feature = "coord")]`-gated, so the minimal relay/coord-off build still compiles (verified, since this is the kind of gap that's bitten before).

## Scope / next
One-key **retry** and **approve** (for NEEDS_HUMAN tasks) are a later slice — their semantics (re-queue vs reset) deserve their own design. Cancel + drain have clean, existing coord backing, so they land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
