### PR TITLE
feat(supervisor): panel retry action — re-queue failed tasks (#368 inc 2c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to claudectl are documented here.
 ## [Unreleased]
 
 ### Added — supervisor panel write actions (#368, increment 2b)
-- The Supervisor panel (`T`) is now operational: **`c`** cancels the selected task (double-tap to confirm — moves it to CANCELLED) and **`d`** toggles the supervisor **drain** marker (reconciler stops issuing new assignments while running tasks finish). Both route through new `Actions::cancel_task` / `Actions::set_supervisor_drain` methods; the footer + help reflect the keys. One-key retry/approve are a later slice.
+- The Supervisor panel (`T`) is now operational: **`c`** cancels the selected task (double-tap to confirm — moves it to CANCELLED), **`R`** re-queues a failed/cancelled task (back to PENDING so the reconciler re-assigns it), and **`d`** toggles the supervisor **drain** marker (reconciler stops issuing new assignments while running tasks finish). All route through new `Actions::cancel_task` / `Actions::retry_task` / `Actions::set_supervisor_drain` methods; the footer + help reflect the keys. One-key approve for NEEDS_HUMAN tasks is a later slice.
 
 ### Added — verifier-as-check (#369, increment 2)
 - `claudectl supervisor pr <task_id>` now also sets a **`claudectl/verifier` commit status** on the branch's HEAD, reflecting the task's latest verifier verdict (PASS → success, FAIL → failure, none → pending). It rides the existing best-effort path — the status post can't undo the comment already landed, and a missing `gh`/repo just appends a skip note. Auto-posting on task DONE from the reconciler is the remaining slice of #369.

--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -477,6 +477,11 @@ pub trait Actions: Send + Sync {
     /// stops issuing new task assignments while letting running tasks finish.
     /// `Err` when the `coord` feature is compiled out.
     fn set_supervisor_drain(&self, draining: bool) -> Result<(), String>;
+
+    /// Re-queue a failed/cancelled task (move it back to PENDING so the
+    /// reconciler re-assigns it). `Err` for a DONE task (nothing to retry), a
+    /// still-active task, or when the `coord` feature is compiled out.
+    fn retry_task(&self, task_id: &str) -> Result<(), String>;
 }
 
 // ============================================================================
@@ -738,6 +743,9 @@ pub enum MockAction {
     SetSupervisorDrain {
         draining: bool,
     },
+    RetryTask {
+        task_id: String,
+    },
 }
 
 impl PartialEq for ObservationInput {
@@ -947,6 +955,15 @@ impl Actions for MockRuntime {
             .push(MockAction::SetSupervisorDrain { draining });
         Ok(())
     }
+    fn retry_task(&self, task_id: &str) -> Result<(), String> {
+        self.actions_log
+            .lock()
+            .expect("actions_log poisoned")
+            .push(MockAction::RetryTask {
+                task_id: task_id.into(),
+            });
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -1095,12 +1112,14 @@ mod tests {
         // the recorded log via the public `actions()` accessor.
         mock.cancel_task("t-1").unwrap();
         mock.set_supervisor_drain(true).unwrap();
+        mock.retry_task("t-2").unwrap();
         let actions = mock.actions();
         assert!(matches!(&actions[0], MockAction::CancelTask { task_id } if task_id == "t-1"));
         assert!(matches!(
             actions[1],
             MockAction::SetSupervisorDrain { draining: true }
         ));
+        assert!(matches!(&actions[2], MockAction::RetryTask { task_id } if task_id == "t-2"));
     }
 
     #[test]

--- a/crates/claudectl-tui/src/app.rs
+++ b/crates/claudectl-tui/src/app.rs
@@ -1544,9 +1544,27 @@ impl App {
             }
             // Cancel selected task — double-tap `c` to confirm (destructive).
             KeyCode::Char('c') => self.handle_supervisor_cancel(was_armed),
+            // Re-queue a failed/cancelled task.
+            KeyCode::Char('R') => self.handle_supervisor_retry(),
             // Toggle the supervisor drain marker.
             KeyCode::Char('d') => self.handle_supervisor_drain_toggle(),
             _ => {}
+        }
+    }
+
+    #[cfg(feature = "coord")]
+    fn handle_supervisor_retry(&mut self) {
+        let Some(task) = self.coord_tasks.get(self.supervisor_selected) else {
+            return;
+        };
+        let id = task.id.clone();
+        let name = task.name.clone();
+        match self.runtime.actions.retry_task(&id) {
+            Ok(()) => {
+                self.supervisor_status_msg = Some(format!("Re-queued {name}"));
+                self.coord_refresh();
+            }
+            Err(e) => self.supervisor_status_msg = Some(format!("Retry failed: {e}")),
         }
     }
 

--- a/crates/claudectl-tui/src/ui/help.rs
+++ b/crates/claudectl-tui/src/ui/help.rs
@@ -124,7 +124,7 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
         ]),
         Line::from(vec![
             Span::styled("  T              ", Style::default().fg(t.highlight_key)),
-            Span::raw("  Supervisor — task ledger; c cancel, d drain, r refresh"),
+            Span::raw("  Supervisor — task ledger; c cancel, R retry, d drain"),
         ]),
         Line::from(vec![
             Span::styled("  ?              ", Style::default().fg(t.highlight_key)),

--- a/crates/claudectl-tui/src/ui/supervisor.rs
+++ b/crates/claudectl-tui/src/ui/supervisor.rs
@@ -167,6 +167,8 @@ fn render_footer(frame: &mut Frame, area: Rect, app: &App) {
         Span::styled(" move  ", Style::default().fg(t.text_muted)),
         Span::styled("c", Style::default().fg(t.highlight_key)),
         Span::styled(" cancel  ", Style::default().fg(t.text_muted)),
+        Span::styled("R", Style::default().fg(t.highlight_key)),
+        Span::styled(" retry  ", Style::default().fg(t.text_muted)),
         Span::styled("d", Style::default().fg(t.highlight_key)),
         Span::styled(
             if app.supervisor_draining {

--- a/src/runtime/actions.rs
+++ b/src/runtime/actions.rs
@@ -138,6 +138,27 @@ impl Actions for LiveActions {
         }
     }
 
+    fn retry_task(&self, task_id: &str) -> Result<(), String> {
+        #[cfg(feature = "coord")]
+        {
+            use crate::coord::tasks::{self, TaskState};
+            let mut conn = crate::coord::store::open()?;
+            let task = tasks::get_task(&conn, task_id)?
+                .ok_or_else(|| format!("task {task_id} not found"))?;
+            match task.state {
+                TaskState::Done => Err("task already succeeded — nothing to retry".into()),
+                s if !s.is_terminal() => Err(format!("task is still active ({})", s.as_str())),
+                // NEEDS_HUMAN or CANCELLED → back to PENDING for re-assignment.
+                s => tasks::transition(&mut conn, task_id, s, TaskState::Pending, "operator-retry"),
+            }
+        }
+        #[cfg(not(feature = "coord"))]
+        {
+            let _ = task_id;
+            Err("coord feature not compiled in this build".into())
+        }
+    }
+
     fn set_supervisor_drain(&self, draining: bool) -> Result<(), String> {
         #[cfg(feature = "coord")]
         {


### PR DESCRIPTION
Part of #368 (write surface). Continues the panel write actions from cancel/drain (#392).

## What
- **`Actions::retry_task`** re-queues a `NEEDS_HUMAN` or `CANCELLED` task by transitioning it back to `PENDING` — the reconciler re-assigns PENDING tasks, so this is a clean "run it again." Refuses a `DONE` task ("nothing to retry") or a still-active one. Feature-gated like the other coord actions; `MockRuntime` records to the log.
- **Panel key `R`** retries the selected task with a status message; footer + help reflect it.

## Testing
- MockRuntime records the retry action (contract test extended).
- `cargo test` 792 pass; clippy `--all-targets -D warnings` + fmt clean; both feature configs build (the TUI handler is coord-gated).

## Scope / what's left on #368
One-key **approve** for `NEEDS_HUMAN` tasks is the last slice — its semantics (accept-as-DONE vs proceed) deserve a small design note, so it's separate. Cancel + drain (#392) and retry (here) cover the unambiguous operator actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
