### PR TITLE
feat(supervisor): panel approve action — accept NEEDS_HUMAN as DONE (#368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to claudectl are documented here.
 
 ## [Unreleased]
 
+### Added — supervisor panel approve action (#368)
+- The Supervisor panel gains **`a`** to **approve** a `NEEDS_HUMAN` task — accept the work as-is and move it to DONE, an operator override of the verifier that escalated it. Routes through the new `Actions::approve_task`. With cancel (`c`), retry (`R`), and drain (`d`), the panel's operator action set is complete.
+
 ### Added — supervisor panel write actions (#368, increment 2b)
 - The Supervisor panel (`T`) is now operational: **`c`** cancels the selected task (double-tap to confirm — moves it to CANCELLED), **`R`** re-queues a failed/cancelled task (back to PENDING so the reconciler re-assigns it), and **`d`** toggles the supervisor **drain** marker (reconciler stops issuing new assignments while running tasks finish). All route through new `Actions::cancel_task` / `Actions::retry_task` / `Actions::set_supervisor_drain` methods; the footer + help reflect the keys. One-key approve for NEEDS_HUMAN tasks is a later slice.
 

--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -482,6 +482,11 @@ pub trait Actions: Send + Sync {
     /// reconciler re-assigns it). `Err` for a DONE task (nothing to retry), a
     /// still-active task, or when the `coord` feature is compiled out.
     fn retry_task(&self, task_id: &str) -> Result<(), String>;
+
+    /// Approve a NEEDS_HUMAN task — accept the work as-is and move it to DONE,
+    /// overriding the verifier that escalated it. `Err` when the task isn't in
+    /// NEEDS_HUMAN, or the `coord` feature is compiled out.
+    fn approve_task(&self, task_id: &str) -> Result<(), String>;
 }
 
 // ============================================================================
@@ -746,6 +751,9 @@ pub enum MockAction {
     RetryTask {
         task_id: String,
     },
+    ApproveTask {
+        task_id: String,
+    },
 }
 
 impl PartialEq for ObservationInput {
@@ -964,6 +972,15 @@ impl Actions for MockRuntime {
             });
         Ok(())
     }
+    fn approve_task(&self, task_id: &str) -> Result<(), String> {
+        self.actions_log
+            .lock()
+            .expect("actions_log poisoned")
+            .push(MockAction::ApproveTask {
+                task_id: task_id.into(),
+            });
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -1113,6 +1130,7 @@ mod tests {
         mock.cancel_task("t-1").unwrap();
         mock.set_supervisor_drain(true).unwrap();
         mock.retry_task("t-2").unwrap();
+        mock.approve_task("t-3").unwrap();
         let actions = mock.actions();
         assert!(matches!(&actions[0], MockAction::CancelTask { task_id } if task_id == "t-1"));
         assert!(matches!(
@@ -1120,6 +1138,7 @@ mod tests {
             MockAction::SetSupervisorDrain { draining: true }
         ));
         assert!(matches!(&actions[2], MockAction::RetryTask { task_id } if task_id == "t-2"));
+        assert!(matches!(&actions[3], MockAction::ApproveTask { task_id } if task_id == "t-3"));
     }
 
     #[test]

--- a/crates/claudectl-tui/src/app.rs
+++ b/crates/claudectl-tui/src/app.rs
@@ -1546,6 +1546,8 @@ impl App {
             KeyCode::Char('c') => self.handle_supervisor_cancel(was_armed),
             // Re-queue a failed/cancelled task.
             KeyCode::Char('R') => self.handle_supervisor_retry(),
+            // Approve a NEEDS_HUMAN task — accept it as DONE.
+            KeyCode::Char('a') => self.handle_supervisor_approve(),
             // Toggle the supervisor drain marker.
             KeyCode::Char('d') => self.handle_supervisor_drain_toggle(),
             _ => {}
@@ -1565,6 +1567,22 @@ impl App {
                 self.coord_refresh();
             }
             Err(e) => self.supervisor_status_msg = Some(format!("Retry failed: {e}")),
+        }
+    }
+
+    #[cfg(feature = "coord")]
+    fn handle_supervisor_approve(&mut self) {
+        let Some(task) = self.coord_tasks.get(self.supervisor_selected) else {
+            return;
+        };
+        let id = task.id.clone();
+        let name = task.name.clone();
+        match self.runtime.actions.approve_task(&id) {
+            Ok(()) => {
+                self.supervisor_status_msg = Some(format!("Approved {name} (→ DONE)"));
+                self.coord_refresh();
+            }
+            Err(e) => self.supervisor_status_msg = Some(format!("Approve failed: {e}")),
         }
     }
 

--- a/crates/claudectl-tui/src/ui/help.rs
+++ b/crates/claudectl-tui/src/ui/help.rs
@@ -124,7 +124,7 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
         ]),
         Line::from(vec![
             Span::styled("  T              ", Style::default().fg(t.highlight_key)),
-            Span::raw("  Supervisor — task ledger; c cancel, R retry, d drain"),
+            Span::raw("  Supervisor — task ledger; c cancel, R retry, a approve, d drain"),
         ]),
         Line::from(vec![
             Span::styled("  ?              ", Style::default().fg(t.highlight_key)),

--- a/crates/claudectl-tui/src/ui/supervisor.rs
+++ b/crates/claudectl-tui/src/ui/supervisor.rs
@@ -169,6 +169,8 @@ fn render_footer(frame: &mut Frame, area: Rect, app: &App) {
         Span::styled(" cancel  ", Style::default().fg(t.text_muted)),
         Span::styled("R", Style::default().fg(t.highlight_key)),
         Span::styled(" retry  ", Style::default().fg(t.text_muted)),
+        Span::styled("a", Style::default().fg(t.highlight_key)),
+        Span::styled(" approve  ", Style::default().fg(t.text_muted)),
         Span::styled("d", Style::default().fg(t.highlight_key)),
         Span::styled(
             if app.supervisor_draining {

--- a/src/runtime/actions.rs
+++ b/src/runtime/actions.rs
@@ -159,6 +159,34 @@ impl Actions for LiveActions {
         }
     }
 
+    fn approve_task(&self, task_id: &str) -> Result<(), String> {
+        #[cfg(feature = "coord")]
+        {
+            use crate::coord::tasks::{self, TaskState};
+            let mut conn = crate::coord::store::open()?;
+            let task = tasks::get_task(&conn, task_id)?
+                .ok_or_else(|| format!("task {task_id} not found"))?;
+            match task.state {
+                TaskState::NeedsHuman => tasks::transition(
+                    &mut conn,
+                    task_id,
+                    TaskState::NeedsHuman,
+                    TaskState::Done,
+                    "operator-approve",
+                ),
+                other => Err(format!(
+                    "approve only applies to NEEDS_HUMAN tasks (state is {})",
+                    other.as_str()
+                )),
+            }
+        }
+        #[cfg(not(feature = "coord"))]
+        {
+            let _ = task_id;
+            Err("coord feature not compiled in this build".into())
+        }
+    }
+
     fn set_supervisor_drain(&self, draining: bool) -> Result<(), String> {
         #[cfg(feature = "coord")]
         {


### PR DESCRIPTION
Part of #368 (write surface). Completes the panel's operator action set: **cancel / retry / drain / approve**.

## What
- **`Actions::approve_task`** transitions a `NEEDS_HUMAN` task to `DONE` (`operator-approve`) — the human reviewed the escalation and accepts the work, overriding the verifier that escalated it. Refuses any other state. Feature-gated; MockRuntime records to the log.
- **Panel key `a`** approves the selected task; footer + help updated.

## Testing
- MockRuntime records the approve action. `cargo test` 792 pass; clippy `--all-targets -D warnings` + fmt clean; both feature configs build (handler coord-gated).

## Merge note
Branched off `main`, **not** the still-open #393 (retry), to avoid a stacked squash-merge. Both edit the `Actions` trait / panel keymap / footer, so expect a small, mechanical merge resolution when the second of {#393, this} lands — I'll handle it.

## #368 status after this
Write surface complete (cancel/retry/drain/approve) + verdict/cost columns (#388). The remaining #368 deliverable is **sessions↔tasks linkage in the main session table** (a different surface from the panel) — its own slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
