### PR TITLE
feat(tui): badge supervisor-task sessions in the dashboard (closes #368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to claudectl are documented here.
 
 ## [Unreleased]
 
+### Added — sessions↔tasks linkage in the dashboard (#368, closes the issue)
+- Sessions in the main dashboard table that are **supervisor task attempts** now carry a **`T`** badge (alongside the existing `L`/`H`/`I` coordination badges), so an operator can tell at a glance which live Claude sessions belong to a tracked task. With the panel write actions + verdict/cost columns already shipped, this completes #368.
+
 ### Added — supervisor panel approve action (#368)
 - The Supervisor panel gains **`a`** to **approve** a `NEEDS_HUMAN` task — accept the work as-is and move it to DONE, an operator override of the verifier that escalated it. Routes through the new `Actions::approve_task`. With cancel (`c`), retry (`R`), and drain (`d`), the panel's operator action set is complete.
 

--- a/crates/claudectl-tui/src/app.rs
+++ b/crates/claudectl-tui/src/app.rs
@@ -339,6 +339,10 @@ pub struct App {
     pub coord_handoffs: Vec<claudectl_core::runtime::HandoffSummary>,
     #[cfg(feature = "coord")]
     pub coord_lease_sessions: HashSet<String>,
+    /// Session ids that are supervisor task attempts (latest attempt per task),
+    /// used to badge them `T` in the session table (#368).
+    #[cfg(feature = "coord")]
+    pub coord_task_sessions: HashSet<String>,
     #[cfg(feature = "coord")]
     pub coord_handoff_sessions: HashSet<String>,
     #[cfg(feature = "coord")]
@@ -643,6 +647,8 @@ impl App {
             coord_handoffs: Vec::new(),
             #[cfg(feature = "coord")]
             coord_lease_sessions: HashSet::new(),
+            #[cfg(feature = "coord")]
+            coord_task_sessions: HashSet::new(),
             #[cfg(feature = "coord")]
             coord_handoff_sessions: HashSet::new(),
             #[cfg(feature = "coord")]
@@ -1479,6 +1485,11 @@ impl App {
         if self.supervisor_selected >= self.coord_tasks.len() {
             self.supervisor_selected = self.coord_tasks.len().saturating_sub(1);
         }
+        self.coord_task_sessions = self
+            .coord_tasks
+            .iter()
+            .filter_map(|t| t.last_session_id.clone())
+            .collect();
 
         self.coord_lease_sessions = self
             .coord_leases
@@ -1628,6 +1639,12 @@ impl App {
     #[cfg(feature = "coord")]
     pub fn session_has_lease(&self, session_id: &str) -> bool {
         self.coord_lease_sessions.contains(session_id)
+    }
+
+    /// Whether this session is the latest attempt of a supervisor task (#368).
+    #[cfg(feature = "coord")]
+    pub fn session_is_task(&self, session_id: &str) -> bool {
+        self.coord_task_sessions.contains(session_id)
     }
 
     #[cfg(feature = "coord")]

--- a/crates/claudectl-tui/src/ui/help.rs
+++ b/crates/claudectl-tui/src/ui/help.rs
@@ -183,6 +183,10 @@ pub fn render_help_overlay(frame: &mut Frame, area: Rect, app: &App) {
             Span::raw("before project = directory conflict"),
         ]),
         Line::from(vec![
+            Span::styled("  T  ", Style::default().fg(t.highlight_key)),
+            Span::raw("before project = supervisor task attempt"),
+        ]),
+        Line::from(vec![
             Span::styled("  (Xm Xs) ", Style::default().fg(t.highlight_key)),
             Span::raw("after Needs Input = wait time"),
         ]),

--- a/crates/claudectl-tui/src/ui/table.rs
+++ b/crates/claudectl-tui/src/ui/table.rs
@@ -491,13 +491,18 @@ fn session_row(s: &ClaudeSession, app: &App) -> Row<'static> {
         (false, false, true) => "REC ",
         (false, false, false) => "",
     };
-    // Coordination badges: L = active lease, H = pending handoff, I = pending interrupt
+    // Coordination badges: T = supervisor task, L = active lease,
+    // H = pending handoff, I = pending interrupt
     #[cfg(feature = "coord")]
     let prefix = {
+        let is_task = app.session_is_task(&s.session_id);
         let has_lease = app.session_has_lease(&s.session_id);
         let has_handoff = app.session_has_handoff(&s.session_id);
         let has_interrupt = app.session_has_interrupt(&s.session_id);
         let mut p = prefix.to_string();
+        if is_task {
+            p.push_str("T ");
+        }
         if has_lease {
             p.push_str("L ");
         }


### PR DESCRIPTION
Closes #368 — the final deliverable (sessions↔tasks linkage). Part of epic #367.

## What
Sessions in the main dashboard table that are the latest attempt of a supervisor task now show a **`T`** badge, next to the existing `L`/`H`/`I` coordination badges — so an operator can tell at a glance which live Claude sessions belong to a tracked task.

- App gains `coord_task_sessions` (a `HashSet<session_id>` built from each `TaskSummary.last_session_id` during `coord_refresh` — **no new query or contract method needed**) and a `session_is_task` helper mirroring `session_has_lease`.
- `table.rs` adds the `T` badge inside the existing `#[cfg(feature = "coord")]` prefix block; the help overlay documents it.

## Testing
- `cargo test` 792 pass; clippy `--all-targets -D warnings` + fmt clean; both feature configs build (everything coord-gated, so the minimal build is unaffected).

## #368 is now complete
- Supervisor TUI panel (#368 inc 1)
- Verdict + cost columns (#388)
- Write actions: cancel / retry / approve / drain (#392–#394)
- **Sessions↔tasks linkage (this PR)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
