### PR TITLE
chore: bump to 0.62.0 — supervisor operations bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to claudectl are documented here.
 
-## [Unreleased]
+## [0.62.0] - 2026-06-29
 
 ### Added — sessions↔tasks linkage in the dashboard (#368, closes the issue)
 - Sessions in the main dashboard table that are **supervisor task attempts** now carry a **`T`** badge (alongside the existing `L`/`H`/`I` coordination badges), so an operator can tell at a glance which live Claude sessions belong to a tracked task. With the panel write actions + verdict/cost columns already shipped, this completes #368.
@@ -15,6 +15,8 @@ All notable changes to claudectl are documented here.
 
 ### Added — verifier-as-check (#369, increment 2)
 - `claudectl supervisor pr <task_id>` now also sets a **`claudectl/verifier` commit status** on the branch's HEAD, reflecting the task's latest verifier verdict (PASS → success, FAIL → failure, none → pending). It rides the existing best-effort path — the status post can't undo the comment already landed, and a missing `gh`/repo just appends a skip note. Auto-posting on task DONE from the reconciler is the remaining slice of #369.
+
+Workspace crates bumped: `claudectl-core` and `claudectl-tui` → 0.57.0 (new `Actions` task-control methods).
 
 ## [0.61.0] - 2026-06-29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2024"
 # MSRV — bumped to 1.88 in #328 so cargo-install on older toolchains
 # emits a clean "rustc too old" error instead of opaque transitive-dep
@@ -50,8 +50,8 @@ path = "src/lib.rs"
 # published to crates.io. Local builds always use the path; crates.io strips
 # the path and resolves the published version. Bump both when the workspace
 # crates change.
-claudectl-core = { path = "crates/claudectl-core", version = "0.56.0" }
-claudectl-tui = { path = "crates/claudectl-tui", version = "0.56.0" }
+claudectl-core = { path = "crates/claudectl-core", version = "0.57.0" }
+claudectl-tui = { path = "crates/claudectl-tui", version = "0.57.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }

--- a/crates/claudectl-core/Cargo.toml
+++ b/crates/claudectl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-core"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Foundational types and IO primitives for claudectl. Shared across the TUI, the binary, and future crates."

--- a/crates/claudectl-tui/Cargo.toml
+++ b/crates/claudectl-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-tui"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Terminal UI, dashboard recording, and demo-mode fixtures for claudectl. Splits out of the binary so the TUI can evolve independently of the brain/coord/bus subsystems."
@@ -23,7 +23,7 @@ relay = []
 hive = []
 
 [dependencies]
-claudectl-core = { path = "../claudectl-core", version = "0.56.0" }
+claudectl-core = { path = "../claudectl-core", version = "0.57.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde_json = "1"


### PR DESCRIPTION
Ships the operational supervisor panel + PR-native verifier check.

| crate | from | to |
|---|---|---|
| `claudectl` | 0.61.0 | **0.62.0** |
| `claudectl-core` | 0.56.0 | **0.57.0** |
| `claudectl-tui` | 0.56.0 | **0.57.0** |

Minor — new public `Actions` task-control methods.

Closes **#368** (supervisor TUI panel, all increments). Ships:
- verifier-as-check (#369 inc 2)
- panel write actions: cancel / retry / approve / drain
- sessions↔tasks `T` badge in the dashboard

Inter-crate reqs + `Cargo.lock` updated; CHANGELOG `[Unreleased]` → `[0.62.0]`; `claudectl --version` → `0.62.0` verified. After merge, push `v0.62.0` → tarballs + crates.io + Homebrew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
