### PR TITLE
feat(supervisor): auto-post PR summary on task DONE (closes #369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to claudectl are documented here.
 
+## [Unreleased]
+
+### Added — PR auto-post on task DONE (#369, closes the issue)
+- With `CLAUDECTL_PR_AUTO_POST=1` set in the supervisor daemon's environment, the reconciler now runs the `supervisor pr` flow automatically when a task reaches DONE — posting the summary comment + `claudectl/verifier` commit status to its branch's PR. Opt-in (off by default), and the post runs on a **detached thread** so git/gh latency never blocks the reconciler tick. The transition is committed before the post fires, so a failed post is logged, never propagated. This completes #369.
+
 ## [0.62.0] - 2026-06-29
 
 ### Added — sessions↔tasks linkage in the dashboard (#368, closes the issue)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -200,6 +200,8 @@ Durable task lifecycles on top of the bus. See the [README's Supervisor section]
 | `supervisor drain` | Set sentinel file at `~/.claudectl/coord/drain`; reconciler stops issuing new assignments |
 | `supervisor undrain` | Clear the drain marker |
 
+Set `CLAUDECTL_PR_AUTO_POST=1` in the supervisor daemon's environment to run the `supervisor pr` flow automatically whenever a task reaches DONE (#369). Off by default; the post runs on a detached thread so it never blocks the reconciler tick.
+
 Coord schema is gated on `PRAGMA user_version`. A binary that meets a newer schema (e.g. after `brew upgrade` without a follow-up `init --upgrade`) refuses to start with the exact remediation in the error.
 
 ### Ingest

--- a/src/coord/actuator.rs
+++ b/src/coord/actuator.rs
@@ -153,6 +153,7 @@ pub fn apply(conn: &mut Connection, fx: &dyn SideEffects, action: &Action) -> Re
                     TaskState::Done,
                     "no-verifiers",
                 )?;
+                maybe_auto_post_pr(task_id);
                 return Ok(());
             }
 
@@ -205,6 +206,7 @@ pub fn apply(conn: &mut Connection, fx: &dyn SideEffects, action: &Action) -> Re
                 TaskState::Done,
                 "verify-pass",
             )?;
+            maybe_auto_post_pr(task_id);
             Ok(())
         }
         Action::Resume { task_id, cause } => {
@@ -269,6 +271,34 @@ pub fn retry_prompt_for_fail(original_prompt: &str, verifier_kind: &str, output:
     super::verify::build_retry_prompt(original_prompt, verifier_kind, output)
 }
 
+/// Parse the `CLAUDECTL_PR_AUTO_POST` flag value. Pure so the gate is testable
+/// without touching the process environment.
+fn parse_auto_post_flag(value: Option<&str>) -> bool {
+    matches!(value.map(str::trim), Some("1" | "true" | "yes" | "on"))
+}
+
+/// Whether to auto-post a task's PR summary + verifier status when it reaches
+/// DONE. Opt-in via env so it never surprises a user, and so the reconciler's
+/// default behavior (no network calls) is unchanged.
+fn pr_auto_post_enabled() -> bool {
+    parse_auto_post_flag(std::env::var("CLAUDECTL_PR_AUTO_POST").ok().as_deref())
+}
+
+/// When enabled, post the task's PR summary + verifier status (#369) on a
+/// **detached** thread — git/gh can take seconds, and the reconciler tick must
+/// never block on them. Best-effort: the transition is already committed before
+/// this runs, so a failed post is logged, not propagated.
+fn maybe_auto_post_pr(task_id: &str) {
+    if !pr_auto_post_enabled() {
+        return;
+    }
+    let task_id = task_id.to_string();
+    std::thread::spawn(move || match super::pr::post_task_summary(&task_id) {
+        Ok(msg) => crate::logger::log("DEBUG", &format!("pr auto-post: {msg}")),
+        Err(e) => crate::logger::log("DEBUG", &format!("pr auto-post skipped: {e}")),
+    });
+}
+
 /// Connect the bus `message_id` to the attempt row. Separate from
 /// `insert_attempt` because the message id only exists after the bus
 /// publish succeeds, and we want the attempt row to exist *before* the
@@ -293,6 +323,16 @@ mod tests {
     use crate::coord::store;
     use crate::coord::supervisor::Action;
     use crate::coord::tasks::{NewTask, TaskState, get_task, insert_task, list_transitions};
+
+    #[test]
+    fn auto_post_flag_is_opt_in() {
+        assert!(parse_auto_post_flag(Some("1")));
+        assert!(parse_auto_post_flag(Some("true")));
+        assert!(parse_auto_post_flag(Some(" on ")));
+        assert!(!parse_auto_post_flag(Some("0")));
+        assert!(!parse_auto_post_flag(Some("")));
+        assert!(!parse_auto_post_flag(None));
+    }
 
     /// In-process recorder so tests can assert what side effects fired
     /// without standing up a real bus or terminal. The `shell_results`


### PR DESCRIPTION
Closes #369 — the remaining slice (auto-post on DONE). Part of epic #367.

## What
When a task reaches DONE, the reconciler can now run the `supervisor pr` flow automatically (summary comment + `claudectl/verifier` commit status), instead of requiring a manual `supervisor pr <task_id>`.

- Hooked at **both** DONE transitions in the actuator (no-verifiers graduation + verify-pass), **after** the transition commits.
- **Opt-in** via `CLAUDECTL_PR_AUTO_POST` (truthy). Off by default — the reconciler's default behavior (no network calls) is unchanged.
- Runs on a **detached thread**: git/gh can take seconds, and the reconciler tick must never block on them. Best-effort — the transition is already committed, so a failed post is logged, never propagated.
- `parse_auto_post_flag` is a pure, unit-tested gate; the env read just wraps it.

## Testing
- `auto_post_flag_is_opt_in` truth table; `cargo test` 793 pass; clippy `--all-targets -D warnings` + fmt clean; both feature configs build. (Existing actuator DONE tests are unaffected — the env is unset, so the hook is a no-op.)

## #369 done
verifier syntax + run/brain/agent gates (earlier) → `supervisor pr` comment (inc 1) → verifier-as-check (inc 2) → **auto-post on DONE (this PR)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
