### PR TITLE
feat(demo): guided-tour orientation tips (#373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to claudectl are documented here.
 
 ## [Unreleased]
 
+### Added — guided-tour orientation tips in demo mode (#373)
+- `claudectl --demo` now shows a rotating **orientation tip** in the dashboard title — a short tour of the key surfaces (status colors, the brain, health flags, `T`/`K`/`M` panels, per-session cost) so a first-time viewer understands what they're looking at, alongside the existing scripted activity narration in the status bar. Complements the modal `claudectl demo` guided tour shipped in 0.63.0.
+
 ## [0.63.0] - 2026-07-01
 
 ### Added — brain "why" + decision audit log (#372, closes the issue)

--- a/crates/claudectl-tui/src/demo.rs
+++ b/crates/claudectl-tui/src/demo.rs
@@ -444,6 +444,23 @@ pub fn demo_event(tick: u32) -> Option<DemoEvent> {
     }
 }
 
+/// Rotating orientation tip shown in the demo dashboard title (#373), so a
+/// first-time viewer understands what they're looking at. Cycles slowly through
+/// a short tour of the key surfaces — distinct from `demo_event`, which narrates
+/// simulated activity in the status bar.
+pub fn demo_tour_tip(tick: u32) -> &'static str {
+    const TIPS: &[&str] = &[
+        "Demo — this is your agent fleet: every running Claude Code session at a glance",
+        "Status colors: magenta = needs input, green = working, yellow = waiting",
+        "The brain auto-approves safe tool calls and blocks risky ones — watch the footer",
+        "Health flags catch stalls, cost spikes, loops, and context saturation",
+        "Press T for the Supervisor, K for Skills & Hive, M for Brain metrics",
+        "Cost and burn-rate are tracked per session — cap spend with --budget",
+    ];
+    // ~5 ticks per tip (~10s at the 2s demo cadence) so each is readable.
+    TIPS[((tick / 5) as usize) % TIPS.len()]
+}
+
 /// A scripted event in the demo timeline.
 pub struct DemoEvent {
     pub message: String,
@@ -955,6 +972,17 @@ mod tour_tests {
 mod highlight_tests {
     use super::*;
     use claudectl_core::transcript::{TranscriptEvent, parse_line};
+
+    #[test]
+    fn demo_tour_tip_rotates_and_is_nonempty() {
+        // Always returns a non-empty tip.
+        assert!(!demo_tour_tip(0).is_empty());
+        // Same tip held for ~5 ticks, then advances.
+        assert_eq!(demo_tour_tip(0), demo_tour_tip(4));
+        assert_ne!(demo_tour_tip(0), demo_tour_tip(5));
+        // Wraps around without panicking on large ticks.
+        let _ = demo_tour_tip(10_000);
+    }
 
     #[test]
     fn demo_highlight_generates_valid_jsonl() {

--- a/crates/claudectl-tui/src/ui/table.rs
+++ b/crates/claudectl-tui/src/ui/table.rs
@@ -344,6 +344,14 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         Style::default().fg(t.text_primary),
     )];
 
+    // Guided-tour orientation tip (#373) — only in demo mode.
+    if app.demo_mode {
+        title_spans.push(Span::styled(
+            format!("\u{2502} {} ", crate::demo::demo_tour_tip(app.demo_tick)),
+            Style::default().fg(t.highlight_key),
+        ));
+    }
+
     if !rec_indicator.is_empty() {
         title_spans.push(Span::styled(
             rec_indicator,


### PR DESCRIPTION
Part of #373 (demo tour). Part of epic #367.

## Why
The `--demo` mode already streams scripted brain/rule/health/hive activity to the status bar and auto-tours the panels — but it never *orients* a first-time viewer. This adds the missing layer.

## What
- **`demo_tour_tip(tick)`** — pure, cycles every ~5 ticks (~10s) through a short tour of the key surfaces: status colors, the brain (auto-approve/deny), health flags, the `T`/`K`/`M` panels, and per-session cost.
- Rendered as a rotating tip in the dashboard **table title**, only when `--demo` is active — no layout change, no effect on the real dashboard.

## Testing
- Tip rotation + non-empty + large-tick wrap test; `cargo test` 793 pass; clippy `--all-targets -D warnings` + fmt clean; both feature configs build.

## Scope
Part of #373 — the demo doesn't yet stage a **supervisor-task completion** (now that the panel exists, the demo could show a task going PENDING → DONE). That's the remaining piece; this PR delivers the orientation tips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
