### PR TITLE
feat(dev-effectiveness): brain 'why' + audit log and guided demo tour (closes #372, #373)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ git clone https://github.com/mercurialsolo/claudectl.git && cd claudectl && carg
 ## Get started
 
 ```bash
+claudectl demo                # Guided first-value tour — no live sessions needed
 claudectl init                # Onboarding wizard (budget, brain, hooks, bus, skills)
 claudectl doctor              # Verify install + runtime health (✓ checklist)
 claudectl                     # Live dashboard — see all sessions at a glance
@@ -118,6 +119,18 @@ The brain learns from **everything** you do — not just brain-involved decision
 | **Temporal patterns** | Behavioral sequences and time-of-day behavior | `After 3+ errors: user usually denies` |
 | **Per-project models** | Separate preferences per project | `[Read] always approve in frontend, usually deny in infra` |
 | **Adaptive thresholds** | Per-tool confidence requirements based on accuracy | 90%+ accurate on Read = auto-execute at 0.5 confidence |
+
+### Explain & audit every decision
+
+To leave the brain unattended you need to trust and audit it. Every decision now carries a **"why"** — the source (rule, few-shot, or LLM), the confidence, and the past examples that informed it — surfaced inline in `--brain-query` output and the Brain Review panel.
+
+```bash
+claudectl --brain-review           # Triage decisions; press [c] to correct-and-learn in one keystroke
+claudectl --brain-export           # Export the decision timeline as Markdown (paste into a PR)
+claudectl --brain-export json --project acme   # …or JSON, filtered to one project (or --pid <n>)
+```
+
+A one-key **correct-and-learn** in the review view records the right answer as canonical training material, so the next similar decision improves.
 
 ### Self-improving sessions
 

--- a/crates/claudectl-core/src/runtime.rs
+++ b/crates/claudectl-core/src/runtime.rs
@@ -174,6 +174,18 @@ pub struct DecisionSummary {
     /// passive observations or records still in flight.
     #[serde(default)]
     pub resolved_at: Option<u64>,
+    /// One-line, human-readable explanation of *why* the brain reached this
+    /// decision (#372): source, confidence, rule/few-shot provenance. Rendered
+    /// inline in the review detail panel. Empty for records that carry no
+    /// derivable cause.
+    #[serde(default)]
+    pub why: String,
+    /// Where the decision originated (#372): `"llm"`, `"rule"`, `"few_shot"`.
+    #[serde(default)]
+    pub decision_source: Option<String>,
+    /// The auto-rule that fired, when this was a rule decision (#372).
+    #[serde(default)]
+    pub rule_name: Option<String>,
 }
 
 impl DecisionSummary {
@@ -1049,6 +1061,9 @@ mod tests {
                     outcome_detail: None,
                     suggested_at: None,
                     resolved_at: None,
+                    why: String::new(),
+                    decision_source: None,
+                    rule_name: None,
                 })
                 .collect(),
             ..Default::default()

--- a/crates/claudectl-tui/src/app.rs
+++ b/crates/claudectl-tui/src/app.rs
@@ -317,6 +317,8 @@ pub struct App {
     pub demo_mode: bool,
     pub demo_tick: u32,
     pub demo_highlight: Option<crate::demo::DemoHighlightState>,
+    /// Active narrated guided tour (#373). `Some` only under `claudectl demo`.
+    pub demo_tour: Option<crate::demo::DemoTour>,
     pub session_recordings: HashMap<u32, String>, // pid -> output_path for active recordings
     pub rules: Vec<claudectl_core::rules::AutoRule>,
     pub auto_actions_fired: HashMap<u32, std::time::Instant>, // Debounce: pid -> last action time
@@ -628,6 +630,7 @@ impl App {
             demo_mode: false,
             demo_tick: 0,
             demo_highlight: None,
+            demo_tour: None,
             session_recordings: HashMap::new(),
             rules: Vec::new(),
             auto_actions_fired: HashMap::new(),
@@ -1226,7 +1229,13 @@ impl App {
     }
 
     fn refresh_demo(&mut self) {
-        self.demo_tick += 1;
+        // During the guided tour (#373) pin the scene to the current step so
+        // the moment being narrated stays on screen while the user reads.
+        if let Some(tour) = &self.demo_tour {
+            self.demo_tick = tour.step().demo_tick;
+        } else {
+            self.demo_tick += 1;
+        }
         let mut sessions = crate::demo::generate_sessions(self.demo_tick);
 
         // When the Skills & Hive view is open during a demo, scripted
@@ -2088,6 +2097,38 @@ impl App {
                 self.idle_report.clear();
             }
             self.idle_tasks_launched.clear();
+        }
+
+        // Guided tour overlay (#373): space/enter/→ advance, ←/p back up,
+        // Esc/q exit into the live demo. Never quits the app.
+        if self.demo_tour.is_some() {
+            match key.code {
+                KeyCode::Char(' ')
+                | KeyCode::Enter
+                | KeyCode::Char('n')
+                | KeyCode::Right
+                | KeyCode::Down => {
+                    let advanced = self
+                        .demo_tour
+                        .as_mut()
+                        .map(|t| t.advance())
+                        .unwrap_or(false);
+                    if !advanced {
+                        // Past the last step — drop into the live demo.
+                        self.demo_tour = None;
+                    }
+                }
+                KeyCode::Left | KeyCode::Up | KeyCode::Char('p') => {
+                    if let Some(t) = self.demo_tour.as_mut() {
+                        t.prev();
+                    }
+                }
+                KeyCode::Esc | KeyCode::Char('q') => {
+                    self.demo_tour = None;
+                }
+                _ => {}
+            }
+            return true;
         }
 
         // Help overlay: any key dismisses

--- a/crates/claudectl-tui/src/demo.rs
+++ b/crates/claudectl-tui/src/demo.rs
@@ -789,6 +789,168 @@ impl DemoHighlightState {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// Guided first-value tour (#373)
+// ─────────────────────────────────────────────────────────────────────────
+
+/// A single narrated step in the `claudectl demo` guided tour. Each step pins
+/// the demo scene to a fixed tick so the moment it describes stays on screen
+/// while the user reads.
+#[derive(Debug, Clone)]
+pub struct TourStep {
+    pub title: String,
+    pub body: String,
+    /// Demo tick the scene is pinned to for this step.
+    pub demo_tick: u32,
+}
+
+/// The scripted guided tour: an ordered list of narrated steps over the demo
+/// fixtures. The user advances with space/enter and can back up or exit.
+#[derive(Debug, Clone)]
+pub struct DemoTour {
+    pub steps: Vec<TourStep>,
+    pub current: usize,
+}
+
+impl Default for DemoTour {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DemoTour {
+    /// Build the default tour. Every step pins to tick 12, where the demo
+    /// fixtures show all health signals at once (stall, cost spike, context
+    /// saturation, conflict), so each moment the narration names is visible.
+    pub fn new() -> Self {
+        // Tick 12: past every `tick > N` health-override gate in
+        // `generate_sessions`, so all the flagged sessions are lit up.
+        let t = 12;
+        let steps = vec![
+            TourStep {
+                title: "Welcome to claudectl".into(),
+                body: "This is the live dashboard — eight Claude Code sessions across \
+                       six projects, one pane of glass. Cost, context, burn rate, and \
+                       health are inferred from each session's transcript in real time.\n\n\
+                       No live sessions of your own are needed for this tour."
+                    .into(),
+                demo_tick: t,
+            },
+            TourStep {
+                title: "Stall detection 🐌".into(),
+                body: "Look at infra-terraform: 15 minutes elapsed, $8+ spent, and zero \
+                       file edits. claudectl flags it as stalled — burning money without \
+                       making progress — so you can step in before the bill grows."
+                    .into(),
+                demo_tick: t,
+            },
+            TourStep {
+                title: "Budget & cost warnings 💸".into(),
+                body: "mobile-app's burn rate just spiked to ~6× its average. With a weekly \
+                       budget set, claudectl warns you (and can auto-deny or terminate) \
+                       before a runaway session blows through your spend cap."
+                    .into(),
+                demo_tick: t,
+            },
+            TourStep {
+                title: "Conflict alerts ⚠️".into(),
+                body: "The two acme-api sessions share one worktree. claudectl detects the \
+                       file-conflict risk and can demote an auto-approval to require your \
+                       confirmation, so two agents don't clobber each other's edits."
+                    .into(),
+                demo_tick: t,
+            },
+            TourStep {
+                title: "The brain — and its 'why' 🧠".into(),
+                body: "Press Ctrl-B any time to open Brain Review. The local-LLM brain \
+                       approves safe commands and denies destructive ones — and every \
+                       decision now shows exactly why: the rule or few-shot examples that \
+                       fired, and the confidence. One keystroke corrects it, and it learns."
+                    .into(),
+                demo_tick: t,
+            },
+            TourStep {
+                title: "Verified tasks, start to finish ✅".into(),
+                body: "Beyond monitoring, the supervisor runs durable tasks: it assigns \
+                       work, gates completion behind a verifier, retries on failure, and \
+                       posts a PR summary when a task lands DONE. Reliable autonomy, not \
+                       fire-and-forget."
+                    .into(),
+                demo_tick: t,
+            },
+            TourStep {
+                title: "That's the tour".into(),
+                body: "Press Esc to keep exploring this demo dashboard, or q to quit. \
+                       When you're ready for the real thing, run `claudectl init` to wire \
+                       up your own sessions. Star us if it's useful — happy shipping!"
+                    .into(),
+                demo_tick: t,
+            },
+        ];
+        DemoTour { steps, current: 0 }
+    }
+
+    /// The step currently being shown.
+    pub fn step(&self) -> &TourStep {
+        &self.steps[self.current.min(self.steps.len() - 1)]
+    }
+
+    /// Advance to the next step. Returns `false` when already on the last step
+    /// (the caller then exits the tour).
+    pub fn advance(&mut self) -> bool {
+        if self.current + 1 >= self.steps.len() {
+            false
+        } else {
+            self.current += 1;
+            true
+        }
+    }
+
+    /// Back up one step (no-op at the first step).
+    pub fn prev(&mut self) {
+        self.current = self.current.saturating_sub(1);
+    }
+
+    /// 1-based position and total, for the progress line.
+    pub fn progress(&self) -> (usize, usize) {
+        (self.current + 1, self.steps.len())
+    }
+}
+
+#[cfg(test)]
+mod tour_tests {
+    use super::*;
+
+    #[test]
+    fn tour_has_the_headline_moments() {
+        let tour = DemoTour::new();
+        let titles: Vec<&str> = tour.steps.iter().map(|s| s.title.as_str()).collect();
+        assert!(titles.iter().any(|t| t.contains("Stall")));
+        assert!(titles.iter().any(|t| t.contains("Budget")));
+        assert!(titles.iter().any(|t| t.contains("Conflict")));
+        assert!(titles.iter().any(|t| t.contains("Verified")));
+    }
+
+    #[test]
+    fn next_advances_then_stops_at_end() {
+        let mut tour = DemoTour::new();
+        let (_, total) = tour.progress();
+        for _ in 0..total - 1 {
+            assert!(tour.advance());
+        }
+        // On the last step, advance() returns false so the caller exits.
+        assert!(!tour.advance());
+        assert_eq!(tour.progress(), (total, total));
+    }
+
+    #[test]
+    fn prev_saturates_at_first_step() {
+        let mut tour = DemoTour::new();
+        tour.prev();
+        assert_eq!(tour.progress().0, 1);
+    }
+}
+
 #[cfg(test)]
 mod highlight_tests {
     use super::*;

--- a/crates/claudectl-tui/src/ui/demo_tour.rs
+++ b/crates/claudectl-tui/src/ui/demo_tour.rs
@@ -1,0 +1,124 @@
+//! Narrated guided-tour overlay (#373).
+//!
+//! Draws a centered narration card on top of the live demo dashboard so a
+//! first-time user sees the real UI behind each explanation. Modeled on the
+//! help overlay: `Clear` the region, then render a bordered `Paragraph`.
+
+use ratatui::{
+    Frame,
+    layout::{Alignment, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+};
+
+use crate::app::App;
+use crate::ui::help::centered_rect;
+
+/// Render the current tour step. No-op when no tour is active.
+pub fn render(frame: &mut Frame, area: Rect, app: &App) {
+    let Some(tour) = &app.demo_tour else {
+        return;
+    };
+    let t = &app.theme;
+    let step = tour.step();
+    let (pos, total) = tour.progress();
+
+    // A short card near the bottom so the dashboard above stays visible.
+    let popup = bottom_card(70, 34, area);
+    frame.render_widget(Clear, popup);
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!(" {} ", step.title),
+            Style::default().fg(t.header).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("  ({pos}/{total})"),
+            Style::default().fg(t.text_muted),
+        ),
+    ]));
+    lines.push(Line::from(""));
+    for para in step.body.split("\n\n") {
+        lines.push(Line::from(Span::styled(
+            para.to_string(),
+            Style::default().fg(t.text_primary),
+        )));
+        lines.push(Line::from(""));
+    }
+    lines.push(Line::from(vec![
+        Span::styled("space/→", Style::default().fg(t.highlight_key)),
+        Span::styled(" next   ", Style::default().fg(t.text_muted)),
+        Span::styled("←", Style::default().fg(t.highlight_key)),
+        Span::styled(" back   ", Style::default().fg(t.text_muted)),
+        Span::styled("Esc", Style::default().fg(t.highlight_key)),
+        Span::styled(" skip tour", Style::default().fg(t.text_muted)),
+    ]));
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(t.header))
+        .title(Span::styled(
+            " claudectl demo — guided tour ",
+            Style::default().fg(t.header).add_modifier(Modifier::BOLD),
+        ))
+        .title_alignment(Alignment::Center);
+
+    let para = Paragraph::new(lines).block(block).wrap(Wrap { trim: true });
+    frame.render_widget(para, popup);
+}
+
+/// A centered card occupying the lower portion of the screen, so the session
+/// table above it stays on view while the narration explains it.
+fn bottom_card(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let full = centered_rect(percent_x, percent_y, area);
+    // Push the card toward the bottom third of the available height.
+    let y = area
+        .y
+        .saturating_add(area.height.saturating_sub(full.height).saturating_sub(1));
+    Rect {
+        x: full.x,
+        y: y.min(area.y + area.height.saturating_sub(full.height)),
+        width: full.width,
+        height: full.height,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::App;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn rendered_text(app: &App) -> String {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(f, f.area(), app)).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn renders_current_step_without_panic() {
+        let mut app = App::new();
+        app.demo_tour = Some(crate::demo::DemoTour::new());
+        let text = rendered_text(&app);
+        assert!(text.contains("guided tour"), "missing title chrome");
+        assert!(text.contains("Welcome to claudectl"), "missing step 1 body");
+        assert!(text.contains("1/"), "missing progress indicator");
+    }
+
+    #[test]
+    fn no_tour_renders_nothing() {
+        let app = App::new();
+        // No panic and an empty (space-only) buffer when no tour is active.
+        let text = rendered_text(&app);
+        assert!(!text.contains("guided tour"));
+    }
+}

--- a/crates/claudectl-tui/src/ui/mod.rs
+++ b/crates/claudectl-tui/src/ui/mod.rs
@@ -1,6 +1,7 @@
 // `brain` (full-screen Brain Review surface) stays in the binary crate as
 // `src/brain_screen.rs` — it depends on `brain::metrics` and `brain::risk`
 // which are binary-only modules. main.rs calls it directly.
+pub mod demo_tour;
 pub mod detail;
 pub mod help;
 #[cfg(feature = "relay")]

--- a/src/brain/audit.rs
+++ b/src/brain/audit.rs
@@ -1,0 +1,173 @@
+//! Exportable decision audit log (#372).
+//!
+//! Turns the local `decisions.jsonl` history into a readable timeline a
+//! developer can paste into a PR or hand to a teammate to explain *what the
+//! brain did and why*. No new storage — this reads `read_all_decisions()` and
+//! renders it. Two formats: human-readable Markdown (default) and JSON (the
+//! `DecisionSummary` projection, which already serialises the `why` line).
+
+use crate::brain::decisions::{DecisionRecord, read_all_decisions};
+
+/// Render the decision audit log in `format` ("md" or "json"), optionally
+/// filtered to one `project` and/or one session `pid`.
+pub fn export(format: &str, project: Option<&str>, pid: Option<u32>) -> Result<String, String> {
+    let mut records = read_all_decisions();
+    if let Some(proj) = project {
+        records.retain(|r| r.project == proj);
+    }
+    if let Some(p) = pid {
+        records.retain(|r| r.pid == p);
+    }
+
+    match format {
+        "json" => render_json(&records),
+        "md" | "markdown" => Ok(render_markdown(&records, project, pid)),
+        other => Err(format!(
+            "unknown export format '{other}' (expected 'md' or 'json')"
+        )),
+    }
+}
+
+/// Strip the quote characters an old serde `Value::to_string()` left around
+/// the stored timestamp so the export reads cleanly.
+fn clean_ts(ts: &str) -> &str {
+    ts.trim_matches('"')
+}
+
+fn render_json(records: &[DecisionRecord]) -> Result<String, String> {
+    let summaries: Vec<claudectl_core::runtime::DecisionSummary> =
+        records.iter().map(Into::into).collect();
+    serde_json::to_string_pretty(&summaries).map_err(|e| format!("serialise audit log: {e}"))
+}
+
+fn render_markdown(records: &[DecisionRecord], project: Option<&str>, pid: Option<u32>) -> String {
+    let mut out = String::new();
+    out.push_str("# Brain decision audit log\n\n");
+
+    let mut scope = Vec::new();
+    if let Some(proj) = project {
+        scope.push(format!("project `{proj}`"));
+    }
+    if let Some(p) = pid {
+        scope.push(format!("session `{p}`"));
+    }
+    if scope.is_empty() {
+        out.push_str("_All sessions._\n\n");
+    } else {
+        out.push_str(&format!("_Scope: {}._\n\n", scope.join(", ")));
+    }
+
+    if records.is_empty() {
+        out.push_str("No decisions recorded yet.\n");
+        return out;
+    }
+
+    let total = records.len();
+    let agreed = records.iter().filter(|r| r.is_positive()).count();
+    out.push_str(&format!(
+        "**{total}** decision(s) · **{agreed}** auto/accepted · **{}** overridden or rejected\n\n",
+        total - agreed
+    ));
+
+    for r in records {
+        let action = if r.brain_action.is_empty() {
+            "observation".to_string()
+        } else {
+            format!("{} ({:.0}%)", r.brain_action, r.brain_confidence * 100.0)
+        };
+        out.push_str(&format!(
+            "## {} — {}\n\n",
+            clean_ts(&r.timestamp),
+            r.project
+        ));
+        out.push_str(&format!("- **decision:** {action}\n"));
+        out.push_str(&format!("- **why:** {}\n", r.why()));
+        if let Some(tool) = &r.tool {
+            match &r.command {
+                Some(cmd) if !cmd.is_empty() => {
+                    out.push_str(&format!("- **tool:** `{tool}` — `{cmd}`\n"))
+                }
+                _ => out.push_str(&format!("- **tool:** `{tool}`\n")),
+            }
+        }
+        out.push_str(&format!("- **outcome:** {}\n", r.user_action));
+        if let Some(reason) = &r.override_reason {
+            out.push_str(&format!("- **override reason:** {reason}\n"));
+        }
+        if !r.brain_reasoning.is_empty() {
+            out.push_str(&format!("- **reasoning:** {}\n", r.brain_reasoning));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::brain::decisions::DecisionType;
+
+    fn rec(project: &str, pid: u32, action: &str, user: &str) -> DecisionRecord {
+        DecisionRecord {
+            timestamp: "\"1780000000\"".into(),
+            pid,
+            project: project.into(),
+            tool: Some("Bash".into()),
+            command: Some("cargo test".into()),
+            brain_action: action.into(),
+            brain_confidence: 0.9,
+            brain_reasoning: "safe command".into(),
+            user_action: user.into(),
+            context: None,
+            outcome: None,
+            decision_type: DecisionType::Session,
+            suggested_at: None,
+            resolved_at: None,
+            override_reason: None,
+            decision_id: Some("dec_1".into()),
+            brain_decision_ms: None,
+            cache_hit: None,
+            canonical: None,
+            decision_source: Some("llm".into()),
+            rule_name: None,
+            few_shot_ids: vec!["dec_0".into()],
+        }
+    }
+
+    #[test]
+    fn markdown_includes_why_and_counts() {
+        let records = vec![
+            rec("acme", 1, "approve", "accept"),
+            rec("acme", 1, "deny", "reject"),
+        ];
+        let md = render_markdown(&records, Some("acme"), None);
+        assert!(md.contains("Brain decision audit log"));
+        assert!(md.contains("**2** decision(s)"));
+        assert!(md.contains("**why:** via llm"));
+        assert!(md.contains("1 past example(s)"));
+        // Timestamp quotes stripped.
+        assert!(md.contains("## 1780000000 — acme"));
+        assert!(!md.contains("\"1780000000\""));
+    }
+
+    #[test]
+    fn json_is_valid_array() {
+        let records = vec![rec("acme", 1, "approve", "accept")];
+        let json = render_json(&records).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.is_array());
+        assert!(parsed[0]["why"].as_str().unwrap().contains("via llm"));
+    }
+
+    #[test]
+    fn empty_scope_renders_placeholder() {
+        let md = render_markdown(&[], None, Some(42));
+        assert!(md.contains("No decisions recorded yet."));
+        assert!(md.contains("session `42`"));
+    }
+
+    #[test]
+    fn unknown_format_errors() {
+        assert!(export("csv", None, None).is_err());
+    }
+}

--- a/src/brain/briefing.rs
+++ b/src/brain/briefing.rs
@@ -261,6 +261,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         }
     }
 

--- a/src/brain/client.rs
+++ b/src/brain/client.rs
@@ -5,6 +5,41 @@ use std::process::Command;
 use crate::config::BrainConfig;
 use crate::rules::RuleAction;
 
+/// Why a decision was reached — the auditable "cause" behind a suggestion
+/// (#372). Carried on the suggestion so every downstream `log_decision` call
+/// records the same provenance without extra plumbing. Defaults to an empty
+/// `llm` cause so existing constructors only opt in when they know better.
+#[derive(Debug, Clone)]
+pub struct DecisionCause {
+    /// Where the decision originated: "llm", "rule", "few_shot", etc.
+    pub source: String,
+    /// The auto-rule that fired, if this was a rule decision.
+    pub rule_name: Option<String>,
+    /// decision_ids of the past examples retrieved into the prompt.
+    pub few_shot_ids: Vec<String>,
+}
+
+impl Default for DecisionCause {
+    fn default() -> Self {
+        DecisionCause {
+            source: "llm".to_string(),
+            rule_name: None,
+            few_shot_ids: Vec::new(),
+        }
+    }
+}
+
+impl DecisionCause {
+    /// A rule-sourced cause naming the rule that fired.
+    pub fn rule(rule_name: impl Into<String>) -> Self {
+        DecisionCause {
+            source: "rule".to_string(),
+            rule_name: Some(rule_name.into()),
+            few_shot_ids: Vec::new(),
+        }
+    }
+}
+
 /// The brain's suggestion for a session, parsed from the LLM response.
 #[derive(Debug, Clone)]
 pub struct BrainSuggestion {
@@ -15,6 +50,9 @@ pub struct BrainSuggestion {
     /// Epoch seconds when this suggestion was created.
     /// Used by time-to-correct analysis to measure user reaction latency.
     pub suggested_at: u64,
+    /// Auditable provenance for this suggestion (#372). Defaults to an `llm`
+    /// cause; the engine fills in few-shot ids and rule paths set the rule name.
+    pub cause: DecisionCause,
 }
 
 /// Call the local LLM endpoint via curl and parse the response, using the
@@ -407,6 +445,7 @@ pub fn parse_suggestion_json(text: &str) -> Result<BrainSuggestion, String> {
         reasoning,
         confidence: confidence.clamp(0.0, 1.0),
         suggested_at: epoch_secs(),
+        cause: DecisionCause::default(),
     })
 }
 

--- a/src/brain/decisions.rs
+++ b/src/brain/decisions.rs
@@ -110,6 +110,51 @@ pub struct DecisionRecord {
     /// material via `claudectl brain review`. Canonical decisions get a
     /// large score boost in few-shot retrieval. None == not reviewed.
     pub canonical: Option<bool>,
+    /// Where the decision originated (#372): "llm", "rule", "few_shot", etc.
+    /// None on records written before the field existed.
+    pub decision_source: Option<String>,
+    /// The auto-rule that fired, when this was a rule decision (#372).
+    pub rule_name: Option<String>,
+    /// decision_ids of the past examples retrieved into the prompt (#372).
+    pub few_shot_ids: Vec<String>,
+}
+
+impl DecisionRecord {
+    /// A one-line, human-readable explanation of *why* the brain reached this
+    /// decision (#372): the source, confidence, any rule that fired, and how
+    /// many past examples informed it. Used by the review UI, `--brain-query`,
+    /// and the audit-log export.
+    pub fn why(&self) -> String {
+        let source = self.decision_source.as_deref().unwrap_or_else(|| {
+            // Infer a source for records written before the field existed.
+            if self.rule_name.is_some() {
+                "rule"
+            } else if self.brain_action.is_empty() {
+                "observed"
+            } else {
+                "llm"
+            }
+        });
+        let mut parts = vec![format!("via {source}")];
+        if self.brain_action.is_empty() {
+            // Pure observation — no brain confidence to report.
+        } else {
+            parts.push(format!("{:.0}% confidence", self.brain_confidence * 100.0));
+        }
+        if let Some(rule) = &self.rule_name {
+            parts.push(format!("rule '{rule}'"));
+        }
+        if self.cache_hit == Some(true) {
+            parts.push("few-shot cache hit".to_string());
+        }
+        if !self.few_shot_ids.is_empty() {
+            parts.push(format!("{} past example(s)", self.few_shot_ids.len()));
+        }
+        if self.user_action == "deny_rule_override" {
+            parts.push("overridden by deny rule".to_string());
+        }
+        parts.join(" · ")
+    }
 }
 
 /// Generate a unique decision id.
@@ -194,6 +239,9 @@ impl From<&DecisionRecord> for claudectl_core::runtime::DecisionSummary {
             }),
             suggested_at: r.suggested_at,
             resolved_at: r.resolved_at,
+            why: r.why(),
+            decision_source: r.decision_source.clone(),
+            rule_name: r.rule_name.clone(),
         }
     }
 }
@@ -421,6 +469,10 @@ pub fn log_decision_full(
         "decision_id": decision_id,
         "brain_decision_ms": brain_decision_ms,
         "cache_hit": cache_hit,
+        // Auditable provenance for this decision (#372).
+        "decision_source": suggestion.cause.source,
+        "rule_name": suggestion.cause.rule_name,
+        "few_shot_ids": suggestion.cause.few_shot_ids,
     });
     if let Some(s) = session {
         record["context"] = snapshot_context(s);
@@ -779,6 +831,24 @@ pub fn read_all_decisions() -> Vec<DecisionRecord> {
                         _ => None,
                     }
                 },
+                // Backwards-compatible: old records won't have these #372 fields
+                decision_source: json
+                    .get("decision_source")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                rule_name: json
+                    .get("rule_name")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                few_shot_ids: json
+                    .get("few_shot_ids")
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
             })
         })
         .collect()
@@ -822,6 +892,65 @@ pub fn mark_canonical(decision_id: &str, note: Option<&str>) -> Result<(), Strin
     Ok(())
 }
 
+/// Record a human correction of a past decision (#372 correct-and-learn).
+///
+/// Appends a fresh, high-confidence decision that captures the *right* answer
+/// for this tool/command and immediately marks it canonical, so few-shot
+/// retrieval teaches the corrected behaviour on the next similar call. Returns
+/// the new decision id. This is the one-key learning path from `brain review`.
+pub fn record_correction(
+    original: &DecisionRecord,
+    corrected_action: &str,
+    note: Option<&str>,
+) -> Result<String, String> {
+    let decision_id = gen_decision_id();
+    let reasoning = match note {
+        Some(n) if !n.trim().is_empty() => {
+            format!(
+                "human correction of {}: {}",
+                original.brain_action,
+                n.trim()
+            )
+        }
+        _ => format!("human correction of {}", original.brain_action),
+    };
+    let record = serde_json::json!({
+        "ts": timestamp_now(),
+        "pid": original.pid,
+        "project": original.project,
+        "tool": original.tool,
+        "command": original.command,
+        "brain_action": corrected_action,
+        "brain_confidence": 1.0,
+        "brain_reasoning": reasoning,
+        "user_action": "corrected",
+        "decision_type": original.decision_type.label(),
+        "decision_id": decision_id,
+        "decision_source": "correction",
+        "corrected_from": original.decision_id,
+    });
+
+    let path = decisions_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|e| format!("open decisions log: {e}"))?;
+    writeln!(
+        file,
+        "{}",
+        serde_json::to_string(&record).unwrap_or_default()
+    )
+    .map_err(|e| format!("write correction: {e}"))?;
+
+    // Mark the corrected example canonical so it gets the retrieval boost.
+    mark_canonical(&decision_id, note)?;
+    Ok(decision_id)
+}
+
 /// Read the set of decision ids that have been marked canonical.
 pub fn read_canonical_ids() -> std::collections::HashSet<String> {
     let path = canonical_path();
@@ -856,6 +985,7 @@ mod tests {
             reasoning: "safe command".into(),
             confidence: 0.95,
             suggested_at: 0,
+            cause: Default::default(),
         }
     }
 
@@ -880,6 +1010,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         }
     }
 
@@ -939,7 +1072,76 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         }
+    }
+
+    #[test]
+    fn why_reports_llm_source_and_examples() {
+        let mut d = make_decision("Bash", "proj", "accept");
+        d.decision_source = Some("llm".into());
+        d.brain_confidence = 0.92;
+        d.few_shot_ids = vec!["dec_1".into(), "dec_2".into()];
+        let why = d.why();
+        assert!(why.contains("via llm"), "got: {why}");
+        assert!(why.contains("92% confidence"), "got: {why}");
+        assert!(why.contains("2 past example(s)"), "got: {why}");
+    }
+
+    #[test]
+    fn why_reports_rule_and_override() {
+        let mut d = make_decision("Bash", "proj", "deny_rule_override");
+        d.decision_source = Some("rule".into());
+        d.rule_name = Some("deny rm -rf".into());
+        let why = d.why();
+        assert!(why.contains("via rule"), "got: {why}");
+        assert!(why.contains("deny rm -rf"), "got: {why}");
+        assert!(why.contains("overridden by deny rule"), "got: {why}");
+    }
+
+    #[test]
+    fn why_infers_source_for_legacy_records() {
+        // Old record with no decision_source but a brain action → inferred llm.
+        let d = make_decision("Bash", "proj", "accept");
+        assert!(d.why().contains("via llm"), "got: {}", d.why());
+    }
+
+    #[test]
+    fn record_correction_appends_canonical_example() {
+        // Override HOME so we write to a clean tmp ~/.claudectl/brain.
+        let tmp = tempfile::tempdir().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        // SAFETY: cargo test in this crate runs sequentially for env mutation.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+
+        let mut original = make_decision("Bash", "acme", "reject");
+        original.brain_action = "approve".into();
+        original.decision_id = Some("dec_orig".into());
+
+        let result = record_correction(&original, "deny", Some("this deletes prod data"));
+
+        let all = read_all_decisions();
+        let canon = read_canonical_ids();
+
+        if let Some(h) = original_home {
+            unsafe { std::env::set_var("HOME", h) };
+        } else {
+            unsafe { std::env::remove_var("HOME") };
+        }
+
+        let new_id = result.expect("correction recorded");
+        let corrected = all
+            .iter()
+            .find(|d| d.decision_id.as_deref() == Some(new_id.as_str()))
+            .expect("corrected record present");
+        assert_eq!(corrected.brain_action, "deny");
+        assert_eq!(corrected.user_action, "corrected");
+        assert_eq!(corrected.decision_source.as_deref(), Some("correction"));
+        assert!(corrected.brain_reasoning.contains("this deletes prod data"));
+        // The new example is canonical so few-shot retrieval boosts it.
+        assert!(canon.contains(&new_id));
     }
 
     #[test]

--- a/src/brain/detectors.rs
+++ b/src/brain/detectors.rs
@@ -475,6 +475,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         }
     }
 

--- a/src/brain/engine.rs
+++ b/src/brain/engine.rs
@@ -354,6 +354,7 @@ impl BrainEngine {
             config.few_shot_count.min(3)
         };
 
+        let mut few_shot_ids: Vec<String> = Vec::new();
         if few_shot_limit > 0 {
             let similar = super::decisions::retrieve_similar(
                 session.pending_tool_name.as_deref(),
@@ -361,6 +362,10 @@ impl BrainEngine {
                 few_shot_limit,
                 Some(DecisionType::Session),
             );
+            few_shot_ids = similar
+                .iter()
+                .filter_map(|d| d.decision_id.clone())
+                .collect();
             brain_ctx.few_shot_examples = super::decisions::format_few_shot_examples(&similar);
         }
 
@@ -400,7 +405,12 @@ impl BrainEngine {
         self.inflight.insert(pid);
 
         std::thread::spawn(move || {
-            let suggestion = super::client::infer_routed(&config, &prompt);
+            let suggestion = super::client::infer_routed(&config, &prompt).map(|mut s| {
+                // Record the few-shot examples that informed this call so the
+                // decision's "why" (#372) can name them.
+                s.cause.few_shot_ids = few_shot_ids;
+                s
+            });
             let _ = tx.send(BrainResult { pid, suggestion });
         });
     }
@@ -864,6 +874,7 @@ mod tests {
             reasoning: "safe".into(),
             confidence: 0.95,
             suggested_at: 0,
+            cause: Default::default(),
         };
         let rm = suggestion_to_rule_match(&suggestion);
         assert_eq!(rm.action, RuleAction::Approve);
@@ -881,6 +892,7 @@ mod tests {
                 reasoning: "test".into(),
                 confidence: 0.9,
                 suggested_at: 0,
+                cause: Default::default(),
             },
         );
 
@@ -901,6 +913,7 @@ mod tests {
                 reasoning: "test".into(),
                 confidence: 0.9,
                 suggested_at: 0,
+                cause: Default::default(),
             },
         );
 
@@ -1074,6 +1087,7 @@ mod tests {
                 reasoning: "test".into(),
                 confidence: 0.9,
                 suggested_at: 0,
+                cause: Default::default(),
             },
         );
 

--- a/src/brain/insights.rs
+++ b/src/brain/insights.rs
@@ -467,6 +467,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         }
     }
 

--- a/src/brain/metrics.rs
+++ b/src/brain/metrics.rs
@@ -2564,6 +2564,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         }
     }
 

--- a/src/brain/mod.rs
+++ b/src/brain/mod.rs
@@ -1,4 +1,5 @@
 pub mod agents;
+pub mod audit;
 pub mod autopsy;
 pub mod baseline;
 pub mod briefing;

--- a/src/brain/pref_store.rs
+++ b/src/brain/pref_store.rs
@@ -259,6 +259,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         }
     }
 

--- a/src/brain/preferences.rs
+++ b/src/brain/preferences.rs
@@ -951,6 +951,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         }
     }
 
@@ -980,6 +983,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         }
     }
 
@@ -1044,6 +1050,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         }
     }
 
@@ -1333,6 +1342,9 @@ mod tests {
                 brain_decision_ms: None,
                 cache_hit: None,
                 canonical: None,
+                decision_source: None,
+                rule_name: None,
+                few_shot_ids: Vec::new(),
             },
             DecisionRecord {
                 timestamp: "2".into(),
@@ -1354,6 +1366,9 @@ mod tests {
                 brain_decision_ms: None,
                 cache_hit: None,
                 canonical: None,
+                decision_source: None,
+                rule_name: None,
+                few_shot_ids: Vec::new(),
             },
         ];
 
@@ -1394,6 +1409,9 @@ mod tests {
                 brain_decision_ms: None,
                 cache_hit: None,
                 canonical: None,
+                decision_source: None,
+                rule_name: None,
+                few_shot_ids: Vec::new(),
             });
         }
         // Then user denies
@@ -1417,6 +1435,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         });
         // Repeat the streak pattern to reach threshold of 2
         for _ in 0..4 {
@@ -1440,6 +1461,9 @@ mod tests {
                 brain_decision_ms: None,
                 cache_hit: None,
                 canonical: None,
+                decision_source: None,
+                rule_name: None,
+                few_shot_ids: Vec::new(),
             });
         }
         decisions.push(DecisionRecord {
@@ -1462,6 +1486,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         });
 
         let patterns = detect_temporal_patterns(&decisions);

--- a/src/brain/retrieval.rs
+++ b/src/brain/retrieval.rs
@@ -183,6 +183,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         }
     }
 

--- a/src/brain/review.rs
+++ b/src/brain/review.rs
@@ -13,7 +13,7 @@
 
 use std::io::{self, BufRead, Write};
 
-use super::decisions::{DecisionRecord, mark_canonical, read_all_decisions};
+use super::decisions::{DecisionRecord, mark_canonical, read_all_decisions, record_correction};
 use super::metrics::{compute_counterfactuals, compute_tier_stats};
 use super::risk::{RiskTier, classify_risk};
 
@@ -119,7 +119,9 @@ pub fn run_interactive() -> usize {
         queue.len()
     );
     println!();
-    println!("For each: [m]ark canonical · [n]ote + mark · [s]kip · [d]etails · [q]uit");
+    println!(
+        "For each: [m]ark canonical · [n]ote + mark · [c]orrect + learn · [s]kip · [d]etails · [q]uit"
+    );
     println!();
 
     let stdin = io::stdin();
@@ -175,6 +177,45 @@ pub fn run_interactive() -> usize {
                         }
                     } else {
                         println!("  ! no decision_id — older record, can't mark");
+                    }
+                    break;
+                }
+                "c" | "correct" => {
+                    if item.record.decision_id.is_none() {
+                        println!("  ! no decision_id — older record, can't correct");
+                        break;
+                    }
+                    println!(
+                        "  brain chose '{}'. Correct answer? [a]pprove / [d]eny / [c]ancel",
+                        item.record.brain_action
+                    );
+                    print!("    > ");
+                    let _ = io::stdout().flush();
+                    let mut choice = String::new();
+                    let _ = reader.read_line(&mut choice);
+                    let corrected = match choice.trim() {
+                        "a" | "approve" => Some("approve"),
+                        "d" | "deny" => Some("deny"),
+                        _ => None,
+                    };
+                    let Some(corrected) = corrected else {
+                        println!("  (cancelled)");
+                        break;
+                    };
+                    print!("    why (optional): ");
+                    let _ = io::stdout().flush();
+                    let mut note = String::new();
+                    let _ = reader.read_line(&mut note);
+                    let note = note.trim();
+                    let note = if note.is_empty() { None } else { Some(note) };
+                    match record_correction(&item.record, corrected, note) {
+                        Ok(id) => {
+                            println!(
+                                "  ✓ recorded correction → '{corrected}' (canonical {id}); the brain will learn this"
+                            );
+                            marked += 1;
+                        }
+                        Err(e) => println!("  ! could not record correction: {e}"),
                     }
                     break;
                 }

--- a/src/brain/sequences.rs
+++ b/src/brain/sequences.rs
@@ -472,6 +472,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         }
     }
 

--- a/src/brain_screen.rs
+++ b/src/brain_screen.rs
@@ -460,6 +460,16 @@ fn render_review_detail(frame: &mut Frame, area: Rect, app: &App) {
             primary,
         ),
     ]));
+    // #372: surface the auditable "why" behind this decision.
+    if !d.why.is_empty() {
+        lines.push(Line::from(Span::styled("  why:", muted)));
+        for chunk in wrap_lines(&d.why, 70) {
+            lines.push(Line::from(Span::styled(
+                format!("    {}", chunk),
+                Style::default().fg(t.highlight_key),
+            )));
+        }
+    }
     let reasoning = d.reasoning.as_deref().unwrap_or("");
     if !reasoning.is_empty() {
         lines.push(Line::from(Span::styled("  reasoning:", muted)));

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1960,6 +1960,8 @@ pub(crate) fn run_brain_query(cfg: &config::Config, cli: &Cli) -> io::Result<()>
             "reasoning": format!("Deny rule '{}' matched", deny_match.rule_name),
             "confidence": 1.0,
             "source": "rule",
+            "rule_name": deny_match.rule_name,
+            "why": format!("via rule · deny rule '{}' matched", deny_match.rule_name),
         });
         println!("{}", serde_json::to_string(&result).unwrap());
         return Ok(());
@@ -1977,6 +1979,8 @@ pub(crate) fn run_brain_query(cfg: &config::Config, cli: &Cli) -> io::Result<()>
             "reasoning": format!("Approve rule '{}' matched", approve_match.rule_name),
             "confidence": 1.0,
             "source": "rule",
+            "rule_name": approve_match.rule_name,
+            "why": format!("via rule · approve rule '{}' matched", approve_match.rule_name),
         });
         println!("{}", serde_json::to_string(&result).unwrap());
         return Ok(());
@@ -2009,19 +2013,19 @@ pub(crate) fn run_brain_query(cfg: &config::Config, cli: &Cli) -> io::Result<()>
     };
 
     // Load few-shot examples
-    let few_shot_section = {
-        let similar = brain::decisions::retrieve_similar(
-            Some(&tool_name),
-            &project,
-            brain_cfg.few_shot_count.min(5),
-            Some(brain::decisions::DecisionType::Session),
-        );
-        if similar.is_empty() {
-            String::new()
-        } else {
-            let examples = brain::decisions::format_few_shot_examples(&similar);
-            format!("\n\n## Past Decisions\n{examples}")
-        }
+    let similar = brain::decisions::retrieve_similar(
+        Some(&tool_name),
+        &project,
+        brain_cfg.few_shot_count.min(5),
+        Some(brain::decisions::DecisionType::Session),
+    );
+    let few_shot_count = similar.len();
+    let has_prefs = !pref_section.is_empty();
+    let few_shot_section = if similar.is_empty() {
+        String::new()
+    } else {
+        let examples = brain::decisions::format_few_shot_examples(&similar);
+        format!("\n\n## Past Decisions\n{examples}")
     };
 
     let prompt = format!(
@@ -2044,6 +2048,20 @@ pub(crate) fn run_brain_query(cfg: &config::Config, cli: &Cli) -> io::Result<()>
             let threshold = brain::decisions::adaptive_threshold(Some(&tool_name)).unwrap_or(0.6);
             let below_threshold = suggestion.confidence < threshold;
 
+            // Human-readable "why" (#372): source + confidence + what informed it.
+            let mut why = format!(
+                "via brain · {:.0}% confidence",
+                suggestion.confidence * 100.0
+            );
+            if has_prefs {
+                why.push_str(" · learned preferences");
+            }
+            if few_shot_count > 0 {
+                why.push_str(&format!(" · {few_shot_count} past example(s)"));
+            }
+            if below_threshold {
+                why.push_str(&format!(" · below adaptive threshold {threshold:.2}"));
+            }
             let mut result = serde_json::json!({
                 "action": suggestion.action.label(),
                 "reasoning": suggestion.reasoning,
@@ -2052,6 +2070,8 @@ pub(crate) fn run_brain_query(cfg: &config::Config, cli: &Cli) -> io::Result<()>
                 "source": "brain",
                 "below_threshold": below_threshold,
                 "threshold": threshold,
+                "few_shot_count": few_shot_count,
+                "why": why,
             });
             if let Some(d) = diff_digest.as_ref() {
                 result["diff_digest"] = d.to_log_json();

--- a/src/hive/distiller.rs
+++ b/src/hive/distiller.rs
@@ -773,6 +773,9 @@ mod tests {
             brain_decision_ms: None,
             cache_hit: None,
             canonical: None,
+            decision_source: None,
+            rule_name: None,
+            few_shot_ids: Vec::new(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,12 @@ pub(crate) enum Command {
         command: coord::supervisor_cli::SupervisorCommand,
     },
 
+    /// Guided first-value tour over fake sessions (#373). Launches the
+    /// dashboard in demo mode with a narrated walkthrough — stall detection,
+    /// budget warnings, conflict alerts, and verified tasks. No live Claude
+    /// sessions required. Press space to advance, Esc to drop into the demo.
+    Demo,
+
     /// Onboarding wizard (budget, brain, hooks, bus, skills). See issue #257.
     Init {
         /// Drift report comparing recorded onboarding against current state.
@@ -364,6 +370,16 @@ pub(crate) struct Cli {
     /// interactive review (used by `brain counterfactual` output).
     #[arg(long, help_heading = "Brain (Local LLM)")]
     pub(crate) brain_mark_canonical: Option<String>,
+
+    /// Export the brain decision audit log as a readable timeline (#372).
+    /// Optional value selects the format: "md" (default) or "json".
+    /// Filter to one project with --project, or one session with --pid.
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    pub(crate) brain_export: Option<Option<String>>,
+
+    /// Restrict --brain-export to a single session PID.
+    #[arg(long, help_heading = "Brain (Local LLM)")]
+    pub(crate) pid: Option<u32>,
 
     /// Query the brain for a single tool-call decision and exit (JSON output).
     /// Used by Claude Code plugin hooks for inline approve/deny.
@@ -807,6 +823,21 @@ fn run_main(cli: Cli) -> io::Result<()> {
         return Ok(());
     }
 
+    if let Some(ref maybe_fmt) = cli.brain_export {
+        let format = maybe_fmt.as_deref().unwrap_or("md");
+        let out = brain::audit::export(format, cli.project.as_deref(), cli.pid);
+        match out {
+            Ok(text) => {
+                print!("{text}");
+                return Ok(());
+            }
+            Err(e) => {
+                eprintln!("brain export failed: {e}");
+                std::process::exit(1);
+            }
+        }
+    }
+
     if let Some(ref command) = cli.command {
         match command {
             #[cfg(feature = "relay")]
@@ -829,6 +860,9 @@ fn run_main(cli: Cli) -> io::Result<()> {
 
             #[cfg(feature = "coord")]
             Command::Supervisor { command } => return coord::supervisor_cli::dispatch(command),
+
+            // Fall through to the TUI launch below with demo + tour enabled.
+            Command::Demo => {}
 
             Command::Init {
                 check,
@@ -1056,12 +1090,16 @@ fn run_main(cli: Cli) -> io::Result<()> {
     let theme_mode = theme::ThemeMode::detect(cli.theme.as_deref());
     let app_theme = theme::Theme::from_mode(theme_mode);
 
+    // `claudectl demo` (#373) implies demo mode plus the narrated tour.
+    let start_tour = matches!(cli.command, Some(Command::Demo));
+    let demo_mode = cli.demo || start_tour;
+
     // #322 — first-run nudge. If the user has neither onboarded nor
     // installed hooks, drop a hint above the TUI before launching so
     // they understand why the dashboard is going to be empty. Skipped in
     // --demo (the wizard's whole point is moot there) and when the
     // operator opts out via env.
-    if !cli.demo && std::env::var("CLAUDECTL_SKIP_FIRST_RUN").is_err() && is_first_run() {
+    if !demo_mode && std::env::var("CLAUDECTL_SKIP_FIRST_RUN").is_err() && is_first_run() {
         print_first_run_banner();
     }
 
@@ -1086,7 +1124,8 @@ fn run_main(cli: Cli) -> io::Result<()> {
             &cfg,
             app_theme,
             hook_registry,
-            cli.demo,
+            demo_mode,
+            start_tour,
             &filters,
             max_dur,
         );
@@ -1122,7 +1161,8 @@ fn run_main(cli: Cli) -> io::Result<()> {
             &cfg,
             app_theme,
             hook_registry,
-            cli.demo,
+            demo_mode,
+            start_tour,
             &filters,
             max_dur,
         );
@@ -1143,6 +1183,7 @@ fn run_tui<W: io::Write>(
     app_theme: theme::Theme,
     hook_registry: hooks::HookRegistry,
     demo_mode: bool,
+    start_tour: bool,
     filters: &ViewFilters,
     max_duration: Option<Duration>,
 ) -> io::Result<()> {
@@ -1201,6 +1242,12 @@ fn run_tui<W: io::Write>(
             app.brain_driver = Some(Box::new(runtime::LiveBrainDriver::new(
                 brain::engine::BrainEngine::new(config::BrainConfig::default()),
             )));
+        }
+        // Launch the narrated guided tour (#373) when invoked via
+        // `claudectl demo`. The tour pins the demo scene so the moments it
+        // narrates stay on screen while the user reads.
+        if start_tour {
+            app.demo_tour = Some(demo::DemoTour::new());
         }
         // Re-refresh to replace real sessions discovered during App::new()
         app.refresh();
@@ -1286,6 +1333,12 @@ fn run_tui<W: io::Write>(
             let main_area = area;
 
             ui::table::render(frame, main_area, &app);
+
+            // Narrated guided-tour overlay (#373), drawn on top of the live
+            // dashboard so the user sees the real thing behind the narration.
+            if app.demo_tour.is_some() {
+                ui::demo_tour::render(frame, area, &app);
+            }
         })?;
 
         let timeout = tick_rate

--- a/src/runtime/actions.rs
+++ b/src/runtime/actions.rs
@@ -75,6 +75,7 @@ impl Actions for LiveActions {
             reasoning: input.suggestion.reasoning,
             confidence: input.suggestion.confidence,
             suggested_at: input.suggestion.suggested_at,
+            cause: brain::client::DecisionCause::default(),
         };
 
         let decision_type = match input.decision_type {

--- a/src/runtime/brain_driver.rs
+++ b/src/runtime/brain_driver.rs
@@ -104,6 +104,7 @@ impl BrainDriver for LiveBrainDriver {
                 reasoning: suggestion.reasoning,
                 confidence: suggestion.confidence,
                 suggested_at: suggestion.suggested_at,
+                cause: Default::default(),
             },
         );
     }
@@ -135,6 +136,7 @@ mod tests {
             reasoning: "test".into(),
             confidence: 0.5,
             suggested_at: 0,
+            cause: Default::default(),
         };
         let proj = suggestion_from_brain(42, s);
         assert_eq!(proj.action, "approve");
@@ -150,6 +152,7 @@ mod tests {
             reasoning: "rm -rf".into(),
             confidence: 0.99,
             suggested_at: 1_780_000_000,
+            cause: Default::default(),
         };
         let proj = suggestion_from_brain(99, s);
         assert_eq!(proj.action, "deny");


### PR DESCRIPTION
Completes the **developer-effectiveness epic (#367)** — its last two open children.

## #372 — Brain "why" + decision audit log (P2)

For a developer to leave the brain unattended, they need to trust and audit it.

- **"Why" on every decision.** A `DecisionCause` (source · rule · few-shot ids) rides on `BrainSuggestion`, captured at decision time (few-shot ids from retrieval, rule names on the rule paths) and persisted as three backwards-compatible `DecisionRecord` fields. `DecisionRecord::why()` renders a one-line cause like `via llm · 92% confidence · 2 past example(s)`.
- **Surfaced inline** in `--brain-query` JSON (`why`, `rule_name`, `few_shot_count`) and the Brain Review detail panel (new **why** line via the `DecisionSummary` DTO).
- **One-key correct-and-learn** (`[c]` in `--brain-review`): pick the right answer and `record_correction()` writes it as a canonical example, so the next similar decision improves.
- **Exportable audit log** — new `brain::audit` module + `--brain-export [md|json]` with `--project`/`--pid` filters, producing a readable decision timeline to paste into a PR.

## #373 — `claudectl demo` guided tour (P3)

- New `claudectl demo` subcommand boots the dashboard in demo mode with a 7-step narrated overlay over the existing fixtures: stall detection, budget/cost warnings, conflict alerts, the brain's "why", and verified tasks. `space`/`→` advance, `←` back, `Esc` drops into the live demo. The scene is pinned per step so the moment stays on screen while reading.

## Testing

- 14 new tests: why rendering, correct-and-learn, audit export, tour navigation, and a headless `TestBackend` render of the overlay.
- Full workspace suite green; `clippy -D warnings` and `fmt --check` clean; minimal `--no-default-features --features hive` build compiles.
- All new record/DTO fields are backwards-compatible — old JSONL parses and infers a sensible source.

## Notes

- Single cohesive commit because `main.rs` and `README.md` carry changes for both issues; splitting would need error-prone partial staging.
- Unrelated untracked `docs/niche-construction.md` was intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)