### PR TITLE
chore: bump to 0.63.0 — dev-effectiveness epic complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,20 @@ All notable changes to claudectl are documented here.
 
 ## [Unreleased]
 
+## [0.63.0] - 2026-07-01
+
+### Added — brain "why" + decision audit log (#372, closes the issue)
+- Every brain decision now carries an auditable **"why"**: a `DecisionCause` (source · rule · few-shot ids) rides on each suggestion, captured at decision time and persisted as three backwards-compatible `DecisionRecord` fields. `DecisionRecord::why()` renders a one-line cause (`via llm · 92% confidence · 2 past example(s)`), surfaced inline in `--brain-query` JSON and the Brain Review detail panel (via the `DecisionSummary` DTO).
+- **One-key correct-and-learn** (`[c]` in `--brain-review`): pick the right answer and it's recorded as a canonical example, so the next similar decision improves.
+- New **`--brain-export [md|json]`** with `--project`/`--pid` filters — a readable decision timeline to paste into a PR or hand to a teammate. Backed by the new `brain::audit` module.
+
+### Added — `claudectl demo` guided tour (#373, closes the issue)
+- New **`claudectl demo`** subcommand launches the dashboard in demo mode with a 7-step narrated overlay over the existing fixtures: stall detection, budget/cost warnings, conflict alerts, the brain's "why", and verified tasks. `space`/`→` advance, `←` back, `Esc` drops into the live demo; the scene is pinned per step so the moment stays on screen. No live Claude sessions required.
+
 ### Added — PR auto-post on task DONE (#369, closes the issue)
 - With `CLAUDECTL_PR_AUTO_POST=1` set in the supervisor daemon's environment, the reconciler now runs the `supervisor pr` flow automatically when a task reaches DONE — posting the summary comment + `claudectl/verifier` commit status to its branch's PR. Opt-in (off by default), and the post runs on a **detached thread** so git/gh latency never blocks the reconciler tick. The transition is committed before the post fires, so a failed post is logged, never propagated. This completes #369.
+
+With #372/#373 this closes the **developer-effectiveness epic (#367)**. Workspace crates bumped: `claudectl-core` and `claudectl-tui` → 0.58.0 (new `DecisionSummary` "why" fields; public `DemoTour` + `ui::demo_tour`).
 
 ## [0.62.0] - 2026-06-29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2024"
 # MSRV — bumped to 1.88 in #328 so cargo-install on older toolchains
 # emits a clean "rustc too old" error instead of opaque transitive-dep
@@ -50,8 +50,8 @@ path = "src/lib.rs"
 # published to crates.io. Local builds always use the path; crates.io strips
 # the path and resolves the published version. Bump both when the workspace
 # crates change.
-claudectl-core = { path = "crates/claudectl-core", version = "0.57.0" }
-claudectl-tui = { path = "crates/claudectl-tui", version = "0.57.0" }
+claudectl-core = { path = "crates/claudectl-core", version = "0.58.0" }
+claudectl-tui = { path = "crates/claudectl-tui", version = "0.58.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }

--- a/crates/claudectl-core/Cargo.toml
+++ b/crates/claudectl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-core"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Foundational types and IO primitives for claudectl. Shared across the TUI, the binary, and future crates."

--- a/crates/claudectl-tui/Cargo.toml
+++ b/crates/claudectl-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-tui"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Terminal UI, dashboard recording, and demo-mode fixtures for claudectl. Splits out of the binary so the TUI can evolve independently of the brain/coord/bus subsystems."
@@ -23,7 +23,7 @@ relay = []
 hive = []
 
 [dependencies]
-claudectl-core = { path = "../claudectl-core", version = "0.57.0" }
+claudectl-core = { path = "../claudectl-core", version = "0.58.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde_json = "1"


### PR DESCRIPTION
Version bump to ship the developer-effectiveness work.

Minor bump (new public API). All three workspace crates move together:

| crate | from | to |
|---|---|---|
| `claudectl` | 0.62.0 | **0.63.0** |
| `claudectl-core` | 0.57.0 | **0.58.0** (new `DecisionSummary` `why`/`decision_source`/`rule_name` fields) |
| `claudectl-tui` | 0.57.0 | **0.58.0** (public `DemoTour` + `ui::demo_tour` overlay) |

Ships since 0.62.0:
- **#372** brain "why" + decision audit log (`--brain-export`, correct-and-learn)
- **#373** `claudectl demo` guided tour
- **#369** PR auto-post on task DONE

With #372/#373 this **closes the developer-effectiveness epic (#367)**. Inter-crate version reqs updated; CHANGELOG `[Unreleased]` → `[0.63.0]`. Tagging `v0.63.0` after merge triggers the release workflow (crates.io publish + GitHub release + Homebrew bottle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)