### PR TITLE
chore: bump to 0.64.0 — demo-mode orientation tips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to claudectl are documented here.
 
 ## [Unreleased]
 
+## [0.64.0] - 2026-07-04
+
 ### Added — guided-tour orientation tips in demo mode (#373)
 - `claudectl --demo` now shows a rotating **orientation tip** in the dashboard title — a short tour of the key surfaces (status colors, the brain, health flags, `T`/`K`/`M` panels, per-session cost) so a first-time viewer understands what they're looking at, alongside the existing scripted activity narration in the status bar. Complements the modal `claudectl demo` guided tour shipped in 0.63.0.
+
+Workspace crate bumped: `claudectl-tui` → 0.59.0 (new public `demo_tour_tip`). `claudectl-core` unchanged at 0.58.0.
 
 ## [0.63.0] - 2026-07-01
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/claudectl-core", "crates/claudectl-tui"]
 
 [package]
 name = "claudectl"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2024"
 # MSRV — bumped to 1.88 in #328 so cargo-install on older toolchains
 # emits a clean "rustc too old" error instead of opaque transitive-dep
@@ -51,7 +51,7 @@ path = "src/lib.rs"
 # the path and resolves the published version. Bump both when the workspace
 # crates change.
 claudectl-core = { path = "crates/claudectl-core", version = "0.58.0" }
-claudectl-tui = { path = "crates/claudectl-tui", version = "0.58.0" }
+claudectl-tui = { path = "crates/claudectl-tui", version = "0.59.0" }
 ratatui = "0.29"
 crossterm = "0.28"
 serde = { version = "1", features = ["derive"] }

--- a/crates/claudectl-tui/Cargo.toml
+++ b/crates/claudectl-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudectl-tui"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Terminal UI, dashboard recording, and demo-mode fixtures for claudectl. Splits out of the binary so the TUI can evolve independently of the brain/coord/bus subsystems."


### PR DESCRIPTION
Ships the ambient guided-tour orientation tips (#398) that merged to main after v0.63.0 was cut — they've been sitting under `[Unreleased]`.

| crate | from | to |
|---|---|---|
| `claudectl` | 0.63.0 | **0.64.0** |
| `claudectl-tui` | 0.58.0 | **0.59.0** (new public `demo_tour_tip`) |
| `claudectl-core` | 0.58.0 | unchanged |

Only #398 landed since v0.63.0. Binary's `claudectl-tui` req updated to 0.59.0; CHANGELOG `[Unreleased]` → `[0.64.0]`. Tagging `v0.64.0` after merge triggers the release workflow (crates.io publish + GitHub release + Homebrew bottle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)