### PR TITLE
Teams: serve fleet metrics endpoint + Grafana dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Three load-bearing properties from the design spec:
 - **Crash-safe by construction** — kill the headless daemon mid-tick, restart, and observed state re-converges from `~/.claudectl/coord/coord.db`. The ledger is the source of truth.
 - **Fail-closed verifiers** — a brain/agent verifier whose reply lacks the leading `PASS` / `FAIL:` marker is treated as FAIL. RFC §5 calls this the verifier-is-the-gradient principle: every FAIL output becomes the retry prompt the next attempt sees.
 
-Metrics: `claudectl supervisor` exposes a Prometheus exporter shape (`claudectl_tasks_by_state`, `claudectl_fleet_cost_usd_total`, `claudectl_retries_total`, `claudectl_verifier_pass_rate`). The headless flag that binds the listener is on the follow-up roadmap; the metrics surface itself is testable today via the `coord::exporter` API.
+Metrics (team observability): `claudectl supervisor metrics 0.0.0.0:9464` serves a Prometheus `/metrics` endpoint (`claudectl_tasks_by_state`, `claudectl_fleet_cost_usd_total`, `claudectl_retries_total`, `claudectl_verifier_pass_rate`) that Grafana or Datadog scrape with no claudectl-specific glue. Each scrape reads the coord DB fresh (WAL), so it runs safely alongside the reconciler. A ready dashboard and the full recipe live in [docs/team-observability.md](docs/team-observability.md).
 
 ## Hive Mind & Relay
 

--- a/docs/grafana/claudectl-fleet.json
+++ b/docs/grafana/claudectl-fleet.json
@@ -1,0 +1,153 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source scraping the claudectl exporter",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+  ],
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "tags": ["claudectl", "fleet", "supervisor"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "title": "claudectl — Fleet Overview",
+  "uid": null,
+  "version": 1,
+  "schemaVersion": 39,
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Running tasks",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 8 }, { "color": "red", "value": 16 } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "refId": "A", "expr": "sum(claudectl_tasks_by_state{state=\"RUNNING\"})", "legendFormat": "running" }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Pending backlog",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 10 }, { "color": "red", "value": 25 } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "refId": "A", "expr": "sum(claudectl_tasks_by_state{state=\"PENDING\"})", "legendFormat": "pending" }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Fleet spend (total)",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD", "color": { "mode": "fixed", "fixedColor": "blue" } }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum(claudectl_fleet_cost_usd_total)", "legendFormat": "total" }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Burn rate ($/hr)",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 10 }, { "color": "red", "value": 20 } ] }
+        },
+        "overrides": []
+      },
+      "targets": [
+        { "refId": "A", "expr": "sum(increase(claudectl_fleet_cost_usd_total[1h]))", "legendFormat": "$/hr" }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Tasks by state",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 20, "stacking": { "mode": "normal", "group": "A" } } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull"] } },
+      "targets": [
+        { "refId": "A", "expr": "claudectl_tasks_by_state", "legendFormat": "{{state}}" }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Verifier pass rate",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "spanNulls": true },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "yellow", "value": 0.6 }, { "color": "green", "value": 0.85 } ] }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "min"] } },
+      "targets": [
+        { "refId": "A", "expr": "claudectl_verifier_pass_rate", "legendFormat": "{{kind}}" }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Retries by cause (per 5m)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 60, "stacking": { "mode": "normal", "group": "A" } } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] } },
+      "targets": [
+        { "refId": "A", "expr": "increase(claudectl_retries_total[5m])", "legendFormat": "{{cause}}" }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Cumulative fleet spend",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD", "custom": { "drawStyle": "line", "fillOpacity": 15 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "targets": [
+        { "refId": "A", "expr": "sum(claudectl_fleet_cost_usd_total)", "legendFormat": "total spend" }
+      ]
+    }
+  ]
+}

--- a/docs/team-observability.md
+++ b/docs/team-observability.md
@@ -1,0 +1,136 @@
+# Team observability — fleet metrics in Grafana
+
+claudectl is a local tool, but the supervisor already tracks everything a team
+lead wants to see across a fleet of agents: how many tasks are running, how much
+they've spent, how often they retry, and whether verifiers are passing. This
+page turns that into a dashboard.
+
+The bridge is a Prometheus exporter built into the binary. No agent, no
+sidecar, no claudectl-specific glue in your monitoring stack — just a
+`/metrics` endpoint that Grafana, Datadog, or any Prometheus-compatible system
+scrapes.
+
+```
+ ┌────────────┐  reconciles   ┌──────────────┐  scrape /metrics  ┌──────────┐
+ │ supervisor │──────────────▶│  coord.db    │◀──────────────────│Prometheus│
+ │  (tick)    │   writes      │  (SQLite/WAL)│   claudectl        └────┬─────┘
+ └────────────┘               └──────────────┘   supervisor metrics    │
+                                                                    ┌───▼────┐
+                                                                    │Grafana │
+                                                                    └────────┘
+```
+
+## 1. Run the exporter
+
+```bash
+claudectl supervisor metrics 0.0.0.0:9464
+```
+
+- Binds `127.0.0.1:9464` by default; pass `0.0.0.0:9464` to expose it on the LAN
+  for a shared Prometheus.
+- Each scrape opens the coord DB fresh (WAL), so this is safe to run **alongside**
+  the reconciler — they don't contend for the connection.
+- Blocks until Ctrl-C. For a long-lived deployment, run it under systemd (see
+  [Running as a service](#running-as-a-service)).
+
+Verify it directly:
+
+```bash
+curl -s http://localhost:9464/metrics
+```
+
+## 2. Point Prometheus at it
+
+Add a scrape job to `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: claudectl
+    scrape_interval: 15s
+    static_configs:
+      - targets: ["localhost:9464"]   # or the host running the exporter
+        labels:
+          fleet: primary
+```
+
+The `fleet` label is optional but recommended — it lets one Prometheus/Grafana
+serve several teams or machines. The bundled dashboard is fleet-agnostic and
+aggregates across whatever it scrapes.
+
+## 3. Import the Grafana dashboard
+
+The repo ships a ready dashboard at
+[`docs/grafana/claudectl-fleet.json`](grafana/claudectl-fleet.json).
+
+1. Grafana → **Dashboards → New → Import**.
+2. Upload `claudectl-fleet.json` (or paste its contents).
+3. Pick your Prometheus data source when prompted.
+
+You get five panels: tasks by state, fleet cost, retries by cause, verifier
+pass rate, and a running/blocked headline.
+
+## What the metrics mean
+
+| Metric | Type | Labels | Reading |
+|---|---|---|---|
+| `claudectl_tasks_by_state` | gauge | `state` | How many tasks sit in each lifecycle state (`RUNNING`, `PENDING`, `VERIFYING`, `DONE`, `FAILED`, …). Watch `FAILED` and a growing `PENDING` backlog. |
+| `claudectl_fleet_cost_usd_total` | counter | — | Cumulative USD across every attempt and verifier. Graph `increase(...[1h])` for burn rate. |
+| `claudectl_retries_total` | counter | `cause` | Transitions into `RETRYING`/`RESUMING`, bucketed by cause (`verify_fail`, `timeout`, …). A rising `verify_fail` rate means work is landing but not passing checks. |
+| `claudectl_verifier_pass_rate` | gauge | `kind` | Pass fraction (0–1) per verifier kind (`run`, `brain`, `agent`). A dip is the earliest signal that a class of tasks has started regressing. |
+
+## Alerting starters
+
+Two rules cover most of what a lead cares about:
+
+```yaml
+groups:
+  - name: claudectl
+    rules:
+      - alert: ClaudectlBurnRateHigh
+        expr: increase(claudectl_fleet_cost_usd_total[1h]) > 20
+        for: 10m
+        annotations:
+          summary: "Fleet spend > $20/hr"
+
+      - alert: ClaudectlVerifierRegressed
+        expr: claudectl_verifier_pass_rate < 0.6
+        for: 15m
+        annotations:
+          summary: "Verifier {{ $labels.kind }} passing < 60%"
+```
+
+Tune the thresholds to your fleet — start loose, tighten once you know your
+baseline.
+
+## Running as a service
+
+A minimal systemd unit so the exporter survives reboots:
+
+```ini
+# /etc/systemd/system/claudectl-metrics.service
+[Unit]
+Description=claudectl fleet metrics exporter
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/claudectl supervisor metrics 0.0.0.0:9464
+Restart=on-failure
+User=%i
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl enable --now claudectl-metrics
+```
+
+## Notes
+
+- The exporter only reads. It never mutates coord state, so running it can't
+  affect task execution.
+- `/metrics` is the only route; everything else returns 404. There's no auth —
+  bind to `127.0.0.1` and scrape locally, or put it behind your existing
+  network controls before exposing it.
+- Metrics come from the coord DB, so they reflect supervisor-managed tasks. Ad
+  hoc sessions that never became supervisor tasks won't appear here.

--- a/src/coord/exporter.rs
+++ b/src/coord/exporter.rs
@@ -1,7 +1,3 @@
-// Allow dead_code: `serve` is the public entry point the headless daemon
-// calls in PR8 once the `--exporter` flag lands; the rendering helpers
-// are exercised by the test suite.
-#![allow(dead_code)]
 //! Prometheus / OpenMetrics exporter (#349, RFC §10).
 //!
 //! Hand-rolled HTTP listener so we don't pull a web framework just to

--- a/src/coord/supervisor_cli.rs
+++ b/src/coord/supervisor_cli.rs
@@ -87,6 +87,16 @@ pub enum SupervisorCommand {
     /// Clear the drain marker so the reconciler resumes new
     /// assignments.
     Undrain,
+    /// Serve fleet metrics in Prometheus text format on `<bind>` (default
+    /// `127.0.0.1:9464`). Point Grafana / Datadog at `http://<bind>/metrics`.
+    /// Blocks until Ctrl-C; each scrape reads the coord DB fresh (WAL), so it's
+    /// safe to run alongside the reconciler. This is the bridge from a solo
+    /// tool to team observability — see `docs/team-observability.md`.
+    Metrics {
+        /// Address to bind, e.g. `0.0.0.0:9464` to expose on the LAN.
+        #[arg(default_value = "127.0.0.1:9464")]
+        bind: String,
+    },
 }
 
 pub fn dispatch(cmd: &SupervisorCommand) -> io::Result<()> {
@@ -119,6 +129,7 @@ pub fn dispatch(cmd: &SupervisorCommand) -> io::Result<()> {
         SupervisorCommand::Pr { task_id } => post_pr_summary(task_id),
         SupervisorCommand::Drain => set_drain(true),
         SupervisorCommand::Undrain => set_drain(false),
+        SupervisorCommand::Metrics { bind } => serve_metrics(bind),
     }
 }
 
@@ -260,6 +271,26 @@ fn post_pr_summary(task_id: &str) -> io::Result<()> {
         Err(reason) => println!("skipped: {reason}"),
     }
     Ok(())
+}
+
+/// Serve the Prometheus exporter until the process is interrupted. Verifies the
+/// coord DB opens first so a misconfigured environment fails loudly here rather
+/// than returning empty scrapes. The `ExporterHandle` is held in a named
+/// binding for the life of the loop; dropping it would stop the listener.
+fn serve_metrics(bind: &str) -> io::Result<()> {
+    // Fail fast if coord isn't initialized — otherwise every scrape would 500.
+    store::open().map_err(|e| {
+        io::Error::other(format!(
+            "coord DB not reachable ({e}); run `claudectl init --upgrade` first"
+        ))
+    })?;
+
+    let _handle = super::exporter::serve(bind).map_err(io::Error::other)?;
+    println!("serving fleet metrics at http://{bind}/metrics");
+    println!("point Grafana / Datadog here (see docs/team-observability.md); Ctrl-C to stop.");
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(3600));
+    }
 }
 
 pub fn drain_marker_path() -> PathBuf {


### PR DESCRIPTION
## Why

From the DX/teams analysis: claudectl's supervisor already tracks everything a team lead wants — tasks by state, fleet cost, retries, verifier pass rate — and a Prometheus exporter existed in `coord/exporter.rs`. But **nothing ever called `exporter::serve`**, so there was no way to actually scrape it. The metrics were real; the endpoint was unreachable. This PR wires the last mile from solo tool to team observability.

## What

**1. A command that actually serves the metrics.**
```
claudectl supervisor metrics [bind]     # default 127.0.0.1:9464
```
- Serves `/metrics` in Prometheus text format; everything else 404s.
- Each scrape opens the coord DB fresh (WAL), so it runs safely **alongside** the reconciler — no connection contention.
- Fails fast if coord isn't initialized (instead of returning empty scrapes).
- Blocks until Ctrl-C; docs include a systemd unit for long-lived deployment.

**2. `docs/team-observability.md`** — the full recipe: run the exporter, Prometheus scrape config (with a `fleet` label for multi-team setups), alerting starters (burn-rate + verifier regression), systemd unit, and a metric reference table.

**3. `docs/grafana/claudectl-fleet.json`** — a ready 8-panel dashboard (running/pending headline, fleet spend, burn rate, tasks by state, verifier pass rate with thresholds, retries by cause), importable with a datasource prompt.

Also drops the now-obsolete `#![allow(dead_code)]` on the exporter (serve is live — no dead code remains) and updates the README line that called the binding flag "on the follow-up roadmap."

## Verified end-to-end

```
$ claudectl supervisor metrics 127.0.0.1:19464 &
$ curl -s http://127.0.0.1:19464/metrics
# HELP claudectl_tasks_by_state Tasks bucketed by current state.
# TYPE claudectl_tasks_by_state gauge
# HELP claudectl_fleet_cost_usd_total Cumulative USD spend across attempts and verifiers.
...
$ curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:19464/foo   →  404
```

## Testing

- Exporter snapshot/format tests still green; full suite: 801 lib + 78 integration, clippy `-D warnings` + fmt clean.
- Dashboard JSON validated as well-formed.

## Note

No auth on `/metrics` (matches the exporter's design) — docs say to bind `127.0.0.1` or put it behind existing network controls before exposing. This is the teams-observability slice from the DX analysis; policy-as-code (a lead-owned checked-in guardrail file) is the natural next teams increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)