### PR TITLE
Teams: policy-as-code — checked-in guardrails a dev can't soften

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ Three load-bearing properties from the design spec:
 
 Metrics (team observability): `claudectl supervisor metrics 0.0.0.0:9464` serves a Prometheus `/metrics` endpoint (`claudectl_tasks_by_state`, `claudectl_fleet_cost_usd_total`, `claudectl_retries_total`, `claudectl_verifier_pass_rate`) that Grafana or Datadog scrape with no claudectl-specific glue. Each scrape reads the coord DB fresh (WAL), so it runs safely alongside the reconciler. A ready dashboard and the full recipe live in [docs/team-observability.md](docs/team-observability.md).
 
+Policy as code (team guardrails): commit a `.claudectl/policy.toml` to the repo and its `[deny]` commands/tools are enforced by the brain gate at the highest precedence — a developer can't soften them by editing local config. Scaffold with `claudectl --policy init`, inspect with `claudectl --policy`. See [docs/policy-as-code.md](docs/policy-as-code.md).
+
 ## Hive Mind & Relay
 
 The brain distills your decisions into shareable knowledge. Connect instances across machines to build a convergent hive mind.

--- a/docs/policy-as-code.md
+++ b/docs/policy-as-code.md
@@ -1,0 +1,92 @@
+# Policy as code — team guardrails a dev can't soften
+
+`.claudectl.toml` and `~/.config/claudectl/config.toml` are *personal* config: a
+developer can add, edit, or delete any rule in them. That's the right model for
+preferences, but it's the wrong model for a guardrail a team depends on — a dev
+can delete a deny rule and never force-push protection is gone, silently.
+
+A **team policy** is a `.claudectl/policy.toml` file **committed to the repo**.
+Because it comes from version control rather than a developer's home directory,
+and the brain gate evaluates it at the highest precedence, its denies can't be
+removed by editing local config. You change the guardrails by changing the
+checked-in file — a reviewed commit, not a silent local edit.
+
+## Quick start
+
+```bash
+claudectl --policy init      # scaffold .claudectl/policy.toml
+$EDITOR .claudectl/policy.toml
+git add .claudectl/policy.toml && git commit -m "Add team guardrails"
+```
+
+Every developer who pulls the repo now inherits the guardrails — no per-machine
+setup. Verify what's active:
+
+```bash
+claudectl --policy           # show the guardrails and where they're loaded from
+claudectl doctor             # includes a "team policy" row
+```
+
+## The file
+
+```toml
+# .claudectl/policy.toml
+[deny]
+# Commands blocked anywhere in this repo (case-insensitive substring match).
+commands = [
+  "git push --force",
+  "git push -f",
+  "kubectl delete",
+]
+# Tools blocked entirely (exact, case-insensitive).
+tools = ["WebFetch"]
+```
+
+- **`commands`** — substring match against the tool input, the same semantics as
+  auto-rules. `"git push --force"` blocks `git push --force origin main`.
+- **`tools`** — an exact (case-insensitive) tool name. Use it to forbid a whole
+  capability in a sensitive repo.
+
+Unknown sections and keys are ignored, so a newer policy file stays readable by
+an older binary (and vice versa).
+
+## How enforcement works
+
+On every tool call, the Claude Code plugin gate (`claudectl --brain-query`):
+
+1. Discovers the policy by walking up from the working directory to the repo
+   root (so it works from any subdirectory).
+2. Evaluates the policy's denies **first**, before user deny rules, before the
+   brain, before the zero-LLM heuristic.
+3. If a policy deny matches, the call is blocked with `source: "policy"` and the
+   guardrail's reason — and nothing downstream can approve it.
+
+```
+tool call ─▶ TEAM POLICY ─▶ user deny rules ─▶ user approve rules ─▶ brain / heuristic
+              (checked-in,        (local config — can't override a policy deny above)
+               highest precedence)
+```
+
+Because policy denies are sourced from the repo and matched at the top of the
+chain, a local `.claudectl.toml` edit can add rules but can't remove or shadow a
+policy guardrail.
+
+## What it does not cover (yet)
+
+Slice 1 is forbidden commands and tools. On the roadmap under their own
+`policy.toml` sections:
+
+- `[limits]` — spend caps that floor the user's own caps (`min(user, policy)`).
+- `[require] verifiers` — verifier kinds every supervisor task must include.
+- `[brain] min_lite_mode` — a floor on the zero-LLM brain-lite policy.
+- Enforcement even when the brain gate is turned off (today a policy applies
+  while the gate is active; a developer who disables the gate entirely opts out
+  of claudectl governance — a separate always-on hook is the planned fix).
+
+## Notes
+
+- The policy is per-repo. A machine working across several repos enforces each
+  repo's own `.claudectl/policy.toml`.
+- Denied calls are recorded as `policy_deny` observations in the local decision
+  log, so a lead can audit what the guardrails caught without the block counting
+  toward the brain's own accuracy.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1554,6 +1554,80 @@ pub(crate) fn run_brain_lite_mode(mode: &str) -> io::Result<()> {
     Ok(())
 }
 
+const POLICY_SCAFFOLD: &str = "\
+# .claudectl/policy.toml — team guardrails, checked into the repo.
+#
+# These are enforced at the highest precedence by the brain gate and CANNOT be
+# softened by an individual developer's local config. Change them by changing
+# this file — a reviewed commit, not a silent local edit.
+#
+# See docs/policy-as-code.md.
+
+[deny]
+# Commands blocked anywhere in this repo (case-insensitive substring match).
+commands = [
+  \"git push --force\",
+  \"git push -f\",
+]
+# Tools blocked entirely (exact, case-insensitive). E.g. [\"WebFetch\"].
+tools = []
+";
+
+/// Handle `--policy [action]`: show the active team policy, or `init` to
+/// scaffold a starter `.claudectl/policy.toml` in the current directory.
+pub(crate) fn run_policy(action: Option<&str>) -> io::Result<()> {
+    match action {
+        Some("init") => {
+            let dir = std::path::Path::new(".claudectl");
+            let path = dir.join("policy.toml");
+            if path.exists() {
+                eprintln!("{} already exists — not overwriting.", path.display());
+                std::process::exit(1);
+            }
+            std::fs::create_dir_all(dir)?;
+            std::fs::write(&path, POLICY_SCAFFOLD)?;
+            println!("Wrote {}", path.display());
+            println!("Edit it, then commit it so the whole team inherits the guardrails.");
+            Ok(())
+        }
+        None | Some("") | Some("show") => {
+            match crate::team_policy::load() {
+                Some(policy) if !policy.is_empty() => {
+                    println!("Team policy: {}", policy.source.display());
+                    if !policy.deny_commands.is_empty() {
+                        println!("  Denied commands:");
+                        for c in &policy.deny_commands {
+                            println!("    - {c}");
+                        }
+                    }
+                    if !policy.deny_tools.is_empty() {
+                        println!("  Denied tools:");
+                        for t in &policy.deny_tools {
+                            println!("    - {t}");
+                        }
+                    }
+                    println!();
+                    println!(
+                        "Enforced by the brain gate at highest precedence — local config can't soften these."
+                    );
+                }
+                _ => {
+                    println!("No team policy in effect.");
+                    println!(
+                        "Scaffold one with `claudectl --policy init` (writes .claudectl/policy.toml)."
+                    );
+                }
+            }
+            Ok(())
+        }
+        Some(other) => {
+            eprintln!("Unknown policy action: {other}");
+            eprintln!("Usage: `claudectl --policy` (show) or `claudectl --policy init` (scaffold)");
+            std::process::exit(1);
+        }
+    }
+}
+
 /// Handle --insights: show insights or set mode (on/off/status).
 /// Requires brain to be enabled.
 pub(crate) fn run_insights(cfg: &config::Config, cli: &Cli, arg: &str) -> io::Result<()> {
@@ -2005,6 +2079,37 @@ pub(crate) fn run_brain_query(cfg: &config::Config, cli: &Cli) -> io::Result<()>
     } else {
         Some(command.clone())
     };
+
+    // Team policy (checked-in `.claudectl/policy.toml`) runs first and at the
+    // highest precedence: its denies come from version control, not a user's
+    // local config, so a developer can't soften them by editing rules. Reuses
+    // the same rule engine, so matching semantics match everything else.
+    if let Some(policy) = crate::team_policy::load() {
+        let policy_rules = policy.to_deny_rules();
+        if let Some(m) = rules::evaluate(&policy_rules, &synthetic) {
+            brain::decisions::log_observation(
+                std::process::id(),
+                &project,
+                Some(&tool_name),
+                command_arg(&command),
+                "policy_deny",
+                Some(&synthetic),
+            );
+            let reasoning = m
+                .message
+                .unwrap_or_else(|| "blocked by team policy".to_string());
+            let result = serde_json::json!({
+                "action": "deny",
+                "reasoning": reasoning,
+                "confidence": 1.0,
+                "source": "policy",
+                "rule_name": m.rule_name,
+                "why": format!("via team policy · {}", policy.source.display()),
+            });
+            println!("{}", serde_json::to_string(&result).unwrap());
+            return Ok(());
+        }
+    }
 
     // Check deny rules
     if let Some(deny_match) = rules::evaluate(&deny_rules, &synthetic) {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -70,6 +70,7 @@ pub fn run_all_checks() -> Vec<Check> {
         check_coord_schema(),
         check_coord_session_policy_dir(),
         check_supervisor_drain_state(),
+        check_team_policy(),
         check_session_discovery(),
         check_terminal_integration(),
     ]
@@ -335,6 +336,32 @@ fn check_plugin_version() -> Check {
                 "Run `claudectl init upgrade` to re-sync hooks + plugin files + DB migrations to the current binary.".into(),
             ),
         }
+    }
+}
+
+fn check_team_policy() -> Check {
+    // Repo-scoped and optional: a repo with no `.claudectl/policy.toml` is the
+    // normal case, so absence is Skipped, not a problem. When present, confirm
+    // what's active so a lead can verify the guardrails are being read.
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    match crate::team_policy::load_from(&cwd) {
+        Some(policy) if !policy.is_empty() => Check {
+            name: "team policy".into(),
+            status: CheckStatus::Pass,
+            message: format!(
+                "{} command deny(s), {} tool deny(s) from {}",
+                policy.deny_commands.len(),
+                policy.deny_tools.len(),
+                policy.source.display()
+            ),
+            fix_hint: None,
+        },
+        _ => Check {
+            name: "team policy".into(),
+            status: CheckStatus::Skipped,
+            message: "no .claudectl/policy.toml in this repo (optional)".into(),
+            fix_hint: Some("Scaffold team guardrails with `claudectl --policy init`.".into()),
+        },
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,3 +42,4 @@ pub mod orchestrator;
 #[cfg(feature = "relay")]
 pub mod relay;
 pub mod runtime;
+pub mod team_policy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ mod orchestrator;
 #[cfg(feature = "relay")]
 mod relay;
 mod runtime;
+mod team_policy;
 
 use std::io;
 use std::time::{Duration, Instant};
@@ -408,6 +409,11 @@ pub(crate) struct Cli {
     /// the current mode. Higher modes auto-handle more; all but off deny Critical ops.
     #[arg(long, help_heading = "Brain (Local LLM)")]
     pub(crate) brain_lite: Option<String>,
+
+    /// Show the active team policy (checked-in `.claudectl/policy.toml`
+    /// guardrails), or `--policy init` to scaffold a starter file in the repo.
+    #[arg(long, help_heading = "Team")]
+    pub(crate) policy: Option<Option<String>>,
 
     /// Record a tool-call outcome to the pending-outcomes spool.
     /// Used by the Claude Code PostToolUse hook for #220 baselining.
@@ -998,6 +1004,10 @@ fn run_main(cli: Cli) -> io::Result<()> {
 
     if let Some(ref mode) = cli.brain_lite {
         return commands::run_brain_lite_mode(mode);
+    }
+
+    if let Some(ref action) = cli.policy {
+        return commands::run_policy(action.as_deref());
     }
 
     if let Some(ref insights_arg) = cli.insights {

--- a/src/team_policy.rs
+++ b/src/team_policy.rs
@@ -1,0 +1,269 @@
+//! Team policy — checked-in guardrails that individual config can't soften.
+//!
+//! `.claudectl.toml` and `~/.config/claudectl/config.toml` are *user* config:
+//! a developer can edit or delete any deny rule in them. That's fine for
+//! personal preferences, but a team lead needs guardrails that hold across the
+//! fleet regardless of what each dev has locally — "never force-push to main",
+//! "this repo may not touch prod".
+//!
+//! This module reads a `.claudectl/policy.toml` file **committed to the repo**.
+//! Because it comes from version control rather than a user's home dir, and is
+//! evaluated at highest precedence in the gate, its denies can't be removed by
+//! editing local config. Change the guardrails by changing the checked-in file
+//! — which is a reviewed commit, not a silent local edit.
+//!
+//! Slice 1 covers forbidden commands and tools. Spend caps, required verifiers,
+//! and a brain-lite floor are planned follow-ups; the file format leaves room
+//! for them under their own sections.
+//!
+//! ```toml
+//! # .claudectl/policy.toml — team guardrails (checked in)
+//! [deny]
+//! commands = ["git push --force", "kubectl delete", "rm -rf /"]
+//! tools    = ["WebFetch"]
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use crate::rules::{AutoRule, RuleAction};
+
+/// The policy directory / file, relative to a repo root.
+const POLICY_RELPATH: &str = ".claudectl/policy.toml";
+
+/// Parsed team guardrails plus where they were loaded from (for `policy` and
+/// `doctor` to attribute the source).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TeamPolicy {
+    /// Command substrings that are always denied (case-insensitive `contains`,
+    /// matching the auto-rule engine's command semantics).
+    pub deny_commands: Vec<String>,
+    /// Tool names that are always denied (exact, case-insensitive).
+    pub deny_tools: Vec<String>,
+    /// Absolute path the policy was read from. Empty for a policy built in
+    /// memory (tests).
+    pub source: PathBuf,
+}
+
+impl TeamPolicy {
+    /// Whether this policy actually constrains anything.
+    pub fn is_empty(&self) -> bool {
+        self.deny_commands.is_empty() && self.deny_tools.is_empty()
+    }
+
+    /// Convert the guardrails into deny `AutoRule`s the existing `rules::evaluate`
+    /// can match — so policy reuses the same command/tool matching as everything
+    /// else, and deny-first precedence is automatic. Rule names are reserved
+    /// (`policy:*`) so they can't collide with or be shadowed by user rules.
+    pub fn to_deny_rules(&self) -> Vec<AutoRule> {
+        let mut rules = Vec::new();
+        for (i, cmd) in self.deny_commands.iter().enumerate() {
+            let mut rule = AutoRule::new(format!("policy:cmd:{i}"), RuleAction::Deny);
+            rule.match_command = vec![cmd.clone()];
+            rule.message = Some(format!("blocked by team policy: command matches '{cmd}'"));
+            rules.push(rule);
+        }
+        for (i, tool) in self.deny_tools.iter().enumerate() {
+            let mut rule = AutoRule::new(format!("policy:tool:{i}"), RuleAction::Deny);
+            rule.match_tool = vec![tool.clone()];
+            rule.message = Some(format!(
+                "blocked by team policy: tool '{tool}' is not permitted"
+            ));
+            rules.push(rule);
+        }
+        rules
+    }
+}
+
+/// Find the nearest `.claudectl/policy.toml` at or above `start`, stopping at
+/// the repo root (the directory containing `.git`) or the filesystem root. The
+/// gate runs in whatever cwd a tool call fires from — often a subdirectory — so
+/// discovery walks up rather than checking only cwd.
+pub fn find_policy_file(start: &Path) -> Option<PathBuf> {
+    let mut dir = Some(start);
+    while let Some(d) = dir {
+        let candidate = d.join(POLICY_RELPATH);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        // Stop once we've checked the repo root, so we never wander above the
+        // project into a parent repo or the home dir.
+        if d.join(".git").exists() {
+            break;
+        }
+        dir = d.parent();
+    }
+    None
+}
+
+/// Parse the `[deny]` section of a policy file. Hand-rolled to match the
+/// project's no-`toml`-crate house style; unknown sections and keys are ignored
+/// so the format can grow without breaking older binaries.
+pub fn parse(content: &str) -> TeamPolicy {
+    let mut policy = TeamPolicy::default();
+    let mut section = String::new();
+    for raw in content.lines() {
+        let line = strip_comment(raw).trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(name) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            section = name.trim().to_string();
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let (key, value) = (key.trim(), value.trim());
+        if section == "deny" {
+            match key {
+                "commands" => policy.deny_commands = parse_string_array(value),
+                "tools" => policy.deny_tools = parse_string_array(value),
+                _ => {}
+            }
+        }
+    }
+    policy
+}
+
+/// Load the team policy for the current working directory, if one exists.
+pub fn load() -> Option<TeamPolicy> {
+    let cwd = std::env::current_dir().ok()?;
+    load_from(&cwd)
+}
+
+/// Load the team policy governing `start`, if a policy file is found at or above it.
+pub fn load_from(start: &Path) -> Option<TeamPolicy> {
+    let path = find_policy_file(start)?;
+    let content = std::fs::read_to_string(&path).ok()?;
+    let mut policy = parse(&content);
+    policy.source = path;
+    Some(policy)
+}
+
+/// Drop an inline `#` comment, respecting `#` inside a quoted string so a
+/// command pattern like `"git config core.hooksPath"` survives (no `#` there,
+/// but a value could legitimately contain one).
+fn strip_comment(line: &str) -> &str {
+    let mut in_quotes = false;
+    for (i, c) in line.char_indices() {
+        match c {
+            '"' => in_quotes = !in_quotes,
+            '#' if !in_quotes => return &line[..i],
+            _ => {}
+        }
+    }
+    line
+}
+
+/// Parse a single-line TOML string array: `["a", "b"]` → `["a", "b"]`.
+fn parse_string_array(value: &str) -> Vec<String> {
+    let inner = value.trim().trim_start_matches('[').trim_end_matches(']');
+    inner
+        .split(',')
+        .map(|s| s.trim().trim_matches('"').trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{ClaudeSession, RawSession, SessionStatus};
+
+    fn session_with(tool: &str, command: &str) -> ClaudeSession {
+        let mut s = ClaudeSession::from_raw(RawSession {
+            pid: 1,
+            session_id: "t".into(),
+            cwd: ".".into(),
+            started_at: 0,
+        });
+        s.status = SessionStatus::NeedsInput;
+        s.pending_tool_name = Some(tool.into());
+        s.pending_tool_input = Some(command.into());
+        s
+    }
+
+    #[test]
+    fn parse_extracts_deny_commands_and_tools() {
+        let toml = r#"
+            [deny]
+            commands = ["git push --force", "rm -rf /"]
+            tools = ["WebFetch"]
+        "#;
+        let p = parse(toml);
+        assert_eq!(p.deny_commands, ["git push --force", "rm -rf /"]);
+        assert_eq!(p.deny_tools, ["WebFetch"]);
+    }
+
+    #[test]
+    fn parse_ignores_unknown_sections_and_comments() {
+        let toml = r#"
+            # team guardrails
+            [limits]          # not handled yet
+            daily_usd = 50
+            [deny]
+            commands = ["kubectl delete"]  # no prod deletes
+        "#;
+        let p = parse(toml);
+        assert_eq!(p.deny_commands, ["kubectl delete"]);
+        assert!(p.deny_tools.is_empty());
+    }
+
+    #[test]
+    fn empty_policy_is_empty() {
+        assert!(parse("").is_empty());
+        assert!(parse("[deny]\ncommands = []").is_empty());
+    }
+
+    #[test]
+    fn deny_rules_match_command_via_engine() {
+        let policy = TeamPolicy {
+            deny_commands: vec!["git push --force".into()],
+            ..Default::default()
+        };
+        let rules = policy.to_deny_rules();
+        // Substring + case-insensitive, inherited from the rule engine.
+        let hit = crate::rules::evaluate(
+            &rules,
+            &session_with("Bash", "git push --force origin main"),
+        );
+        assert_eq!(hit.unwrap().action, RuleAction::Deny);
+        // A benign command doesn't match.
+        assert!(crate::rules::evaluate(&rules, &session_with("Bash", "git status")).is_none());
+    }
+
+    #[test]
+    fn deny_rules_match_tool_exactly() {
+        let policy = TeamPolicy {
+            deny_tools: vec!["WebFetch".into()],
+            ..Default::default()
+        };
+        let rules = policy.to_deny_rules();
+        assert!(crate::rules::evaluate(&rules, &session_with("webfetch", "https://x")).is_some());
+        assert!(crate::rules::evaluate(&rules, &session_with("Read", "file")).is_none());
+    }
+
+    #[test]
+    fn find_walks_up_to_repo_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::create_dir_all(root.join(".claudectl")).unwrap();
+        std::fs::write(root.join(POLICY_RELPATH), "[deny]\ncommands=[\"x\"]").unwrap();
+        let deep = root.join("crates/foo/src");
+        std::fs::create_dir_all(&deep).unwrap();
+
+        let found = find_policy_file(&deep).expect("should find policy from a subdir");
+        assert_eq!(found, root.join(POLICY_RELPATH));
+    }
+
+    #[test]
+    fn find_stops_at_repo_root_without_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        let deep = root.join("src");
+        std::fs::create_dir_all(&deep).unwrap();
+        assert!(find_policy_file(&deep).is_none());
+    }
+}


### PR DESCRIPTION
## Why

Continuing the teams thread (paired with the fleet dashboard in #411). `.claudectl.toml` and the global config are *personal* — a developer can add, edit, or **delete** any deny rule. That's right for preferences, wrong for a guardrail a team depends on: delete the deny and force-push protection is gone, silently.

A **team policy** is a `.claudectl/policy.toml` committed to the repo. Because it comes from version control (not a dev's home dir) and the gate evaluates it at the highest precedence, its denies can't be removed by editing local config. You change the guardrails by changing the checked-in file — a reviewed commit, not a silent local edit.

## What (slice 1 — forbidden commands/tools)

```toml
# .claudectl/policy.toml  (committed)
[deny]
commands = ["git push --force", "kubectl delete"]
tools    = ["WebFetch"]
```

- **`team_policy` module** — walk-up discovery from the working dir to the repo root (so it works from any subdirectory), a hand-rolled `[deny]` parser matching the project's no-`toml`-crate house style, and `to_deny_rules()` that reuses the **existing rule engine** — so command/tool matching and deny-first precedence come for free, no new matching logic.
- **Enforced in the plugin gate** (`run_brain_query`) before user rules, the brain, and the heuristic. Blocks with `source="policy"` and records a `policy_deny` observation (audited in the decision log, doesn't inflate brain accuracy).
- **`claudectl --policy`** shows the active guardrails + source; **`--policy init`** scaffolds a starter file. **`doctor`** gains a "team policy" row.
- `docs/policy-as-code.md` + README pointer.

Precedence:
```
tool call ─▶ TEAM POLICY ─▶ user deny ─▶ user approve ─▶ brain / heuristic
              (checked-in, highest — local config can't override a policy deny)
```

## Verified end-to-end

```
$ claudectl --policy
Team policy: /repo/.claudectl/policy.toml
  Denied commands: git push --force, kubectl delete
  Denied tools:    WebFetch

Bash "git push --force origin main"     → deny   (source=policy)
WebFetch "https://x"                    → deny   (source=policy)
Bash "kubectl delete pod x"  (subdir)   → deny   (source=policy, walk-up)
Bash "git status"            (subdir)   → approve (passes through)
```

## Testing

- 14 new tests (7 team_policy unit incl. parser + walk-up + engine-match, plus the gate path exercised end-to-end)
- Full suite green: 841 lib + 78 integration, `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean

## Follow-ups (noted in docs, under their own `policy.toml` sections)

- `[limits]` spend-cap floors (`min(user, policy)`)
- `[require] verifiers` in supervisor submit
- `[brain] min_lite_mode` floor
- Enforce even when the brain gate is turned off (today a policy applies while the gate is active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)